### PR TITLE
Break out VPI defines needed in UHDM.

### DIFF
--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -1559,6 +1559,9 @@ proc generate_code { models } {
     # BaseClass.h
     file_copy_if_change "[project_path]/templates/BaseClass.h" "[codegen_base]/headers/BaseClass.h"
 
+    # uhdm_vpi_user
+    file_copy_if_change "[project_path]/templates/uhdm_vpi_user.h" "[codegen_base]/headers/uhdm_vpi_user.h"
+
     # SymbolFactory.h
     file_copy_if_change "[project_path]/templates/SymbolFactory.h" "[codegen_base]/headers/SymbolFactory.h"
 
@@ -1673,7 +1676,7 @@ $RESTORE($class)
     # ExprEval
     file_copy_if_change "[project_path]/templates/ExprEval.h" "[codegen_base]/headers/ExprEval.h"
     file_copy_if_change "[project_path]/templates/ExprEval.cpp" "[codegen_base]/src/ExprEval.cpp"
-   
+
 }
 
 proc debug_models { models } {

--- a/templates/class_header.h
+++ b/templates/class_header.h
@@ -26,6 +26,9 @@
 #ifndef UHDM_<UPPER_CLASSNAME>_H
 #define UHDM_<UPPER_CLASSNAME>_H
 
+#include "../include/sv_vpi_user.h"
+#include "uhdm_vpi_user.h"
+
 #include "SymbolFactory.h"
 #include "BaseClass.h"
 #include "containers.h"

--- a/templates/uhdm.h
+++ b/templates/uhdm.h
@@ -29,42 +29,10 @@
 #include <vector>
 #include <map>
 
-// Missing defines from vpi_user.h, sv_vpi_user.h
-#define vpiDesign            3000
-#define vpiInterfaceTypespec 3001
-#define vpiNets              3002
-#define vpiSimpleExpr        3003
-#define vpiParameters        3004
-#define vpiSequenceExpr      3005
-#define vpiSoftDisable       3006
-#define vpiIsModPort         3007
-// These define where orinally aliased in sv_vpi_user.h
-// Aliasing makes it hard to distinguish in automatically generated code, assigning unique values.
-#define vpiVarBit            3008
-#define vpiLogicVar          3009
-#define vpiArrayVar          3010
-
-#define vpiWaits             3011
-#define vpiDisables          3012
-#define vpiStructMember      3013
-// Used to mark imported parameters
-#define  vpiImported         3014
-#define  vpiColumnNo         3015
-#define  vpiEndLineNo        3016
-#define  vpiEndColumnNo      3017
-// Tags used to model unsupported nodes
-#define vpiUnsupportedStmt   4000
-#define vpiUnsupportedExpr   4001
-#define vpiUnsupportedTypespec 4002
-
-// Objects not in the Standard
-#define vpiHierPath         5000 // Represents a hierarchical path
-#define vpiReordered        5001 // Boolean for operations (pattern assign, concat) that has been reordered
-#define vpiElaborated       5002 // Boolean indicating UHDM has been elaborated/uniquified
-
 #include "../include/sv_vpi_user.h"
 #include "../include/vhpi_user.h"
 
+#include "headers/uhdm_vpi_user.h"
 #include "headers/uhdm_types.h"
 #include "headers/vpi_uhdm.h"
 #include "headers/containers.h"

--- a/templates/uhdm_vpi_user.h
+++ b/templates/uhdm_vpi_user.h
@@ -1,0 +1,56 @@
+/*
+
+ Copyright 2019-2021 Alain Dargelas
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+#ifndef UHDM_VPI_USER_H
+#define UHDM_VPI_USER_H
+
+// Missing defines from vpi_user.h, sv_vpi_user.h
+#define vpiDesign            3000
+#define vpiInterfaceTypespec 3001
+#define vpiNets              3002
+#define vpiSimpleExpr        3003
+#define vpiParameters        3004
+#define vpiSequenceExpr      3005
+#define vpiSoftDisable       3006
+#define vpiIsModPort         3007
+
+// These define where orinally aliased in sv_vpi_user.h
+// Aliasing makes it hard to distinguish in automatically generated code, assigning unique values.
+#define vpiVarBit            3008
+#define vpiLogicVar          3009
+#define vpiArrayVar          3010
+
+#define vpiWaits             3011
+#define vpiDisables          3012
+#define vpiStructMember      3013
+
+// Used to mark imported parameters
+#define  vpiImported         3014
+#define  vpiColumnNo         3015
+#define  vpiEndLineNo        3016
+#define  vpiEndColumnNo      3017
+
+// Tags used to model unsupported nodes
+#define vpiUnsupportedStmt   4000
+#define vpiUnsupportedExpr   4001
+#define vpiUnsupportedTypespec 4002
+
+// Objects not in the Standard
+#define vpiHierPath         5000 // Represents a hierarchical path
+#define vpiReordered        5001 // Boolean for operations (pattern assign, concat) that has been reordered
+#define vpiElaborated       5002 // Boolean indicating UHDM has been elaborated/uniquified
+
+#endif  // UHDM_VPI_USER_H


### PR DESCRIPTION
Move the defines from uhdm.h into separate uhdm_vpi_user.h

This is in preparation to make headers full self-contained.

Issues #59

Signed-off-by: Henner Zeller <h.zeller@acm.org>