### PR TITLE
Some errors have trailing newlines

### DIFF
--- a/templates/group_header.cpp
+++ b/templates/group_header.cpp
@@ -35,7 +35,7 @@ bool <GROUPNAME>GroupCompliant(any* item) {
   BaseClass* the_item = (BaseClass*) item;
   UHDM_OBJECT_TYPE uhdmtype = the_item->UhdmType();
   if (<CHECKTYPE>) {
-    item->GetSerializer()->GetErrorHandler()("Internal Error: adding wrong object type (" + UhdmName(uhdmtype) + ") in a <GROUPNAME> group!\n");
+    item->GetSerializer()->GetErrorHandler()("Internal Error: adding wrong object type (" + UhdmName(uhdmtype) + ") in a <GROUPNAME> group!");
     return false;
   }
   return true;


### PR DESCRIPTION
Generated code can generate errors with trailing newlines. This creates a mess in error reports when the message is concatenated within some some larger message. Newlines are an output format thing, shouldn't be part of the message content itself.