### PR TITLE
Don't clobber source directory with test outputs.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,7 @@ jobs:
         echo 'PREFIX=$PWD/install' >> $GITHUB_ENV
         echo 'CMAKE_GENERATOR=Ninja' >> $GITHUB_ENV
         echo 'NO_TCMALLOC=On' >> $GITHUB_ENV
+        echo 'TEST_TMPDIR=C:\temp' >> $GITHUB_ENV
 
     - name: Show shell configuration
       run: |
@@ -130,6 +131,7 @@ jobs:
         set MAKE_DIR=C:\make\bin
         set TCL_DIR=%PROGRAMFILES%\Git\mingw64\bin
         set PATH=%MAKE_DIR%;%TCL_DIR%;%PATH%
+        set TEST_TMPDIR=C:\temp
 
         set
         where cmake && cmake --version

--- a/tests/full_elab.cpp
+++ b/tests/full_elab.cpp
@@ -36,7 +36,7 @@
 #include "headers/vpi_visitor.h"
 #include "headers/ElaboratorListener.h"
 
-#include "tests/test-util.h"
+#include "test-util.h"
 
 using namespace UHDM;
 

--- a/tests/full_elab.cpp
+++ b/tests/full_elab.cpp
@@ -36,6 +36,8 @@
 #include "headers/vpi_visitor.h"
 #include "headers/ElaboratorListener.h"
 
+#include "tests/test-util.h"
+
 using namespace UHDM;
 
 
@@ -92,7 +94,7 @@ std::vector<vpiHandle> build_designs (Serializer& s) {
     n->VpiName("o1");
     vn->push_back(n);
     m2->Nets(vn);
-  
+
     // M2 continuous assignment
     VectorOfcont_assign* assigns = s.MakeCont_assignVec();
     cont_assign* cassign = s.MakeCont_assign();
@@ -105,8 +107,8 @@ std::vector<vpiHandle> build_designs (Serializer& s) {
     cassign->Rhs(rhs);
     m2->Cont_assigns(assigns);
   }
-  
- 
+
+
   //-------------------------------------------
   // Instance tree (Elaborated tree)
   // Top level module
@@ -119,7 +121,7 @@ std::vector<vpiHandle> build_designs (Serializer& s) {
     m3->Modules(v1);
     m3->VpiParent(d);
   }
-  
+
   //-------------------------------------------
   // Sub Instance
   module* m4 = s.MakeModule();
@@ -154,15 +156,15 @@ std::vector<vpiHandle> build_designs (Serializer& s) {
     p2->Low_conn(low_conn);
     vn->push_back(n);
     m4->Nets(vn);
-    
+
   }
-  
+
   // Create parent-child relation in between the 2 modules in the instance tree
   v1->push_back(m4);
   m4->VpiParent(m3);
 
   //-------------------------------------------
-  // Create both non-elaborated and elaborated lists 
+  // Create both non-elaborated and elaborated lists
   VectorOfmodule* allModules = s.MakeModuleVec();
   d->AllModules(allModules);
   allModules->push_back(m1);
@@ -171,7 +173,7 @@ std::vector<vpiHandle> build_designs (Serializer& s) {
   VectorOfmodule* topModules = s.MakeModuleVec();
   d->TopModules(topModules);
   topModules->push_back(m3); // Only m3 goes there as it is the top level module
-  
+
   vpiHandle dh = s.MakeUhdmHandle(uhdmdesign, d);
   designs.push_back(dh);
 
@@ -182,7 +184,7 @@ void dumpStats(Serializer& serializer) {
   std::cout << "Stats:\n";
   std::map<std::string, unsigned long> stats = serializer.ObjectStats();
   for (auto stat : stats) {
-    if (stat.second) 
+    if (stat.second)
       std::cout << stat.first << " " << stat.second << "\n";
   }
   std::cout << "\n";
@@ -197,7 +199,7 @@ int main (int argc, char** argv) {
   orig += "DUMP Design content (Pre elab):\n";
   orig += visit_designs(designs);
   std::cout << orig;
-  
+
   std::cout << std::endl;
   bool elaborated = false;
   for(auto design : designs) {
@@ -210,11 +212,10 @@ int main (int argc, char** argv) {
     listen_designs(designs,listener);
     std::cout << std::endl;
   }
-  serializer.Save("elab_test.uhdm");
+  serializer.Save(uhdm_test::getTmpDir() + "/elab_test.uhdm");
   orig = "DUMP Design content (Post elab):\n";
   orig += visit_designs(designs);
   std::cout << orig;
-  
+
   return 0;
 }
-

--- a/tests/test-dump.cpp
+++ b/tests/test-dump.cpp
@@ -25,7 +25,7 @@
 #include "headers/vpi_visitor.h"
 #include "headers/ElaboratorListener.h"
 
-#include "tests/test-util.h"
+#include "test-util.h"
 
 using namespace UHDM;
 

--- a/tests/test-dump.cpp
+++ b/tests/test-dump.cpp
@@ -25,6 +25,8 @@
 #include "headers/vpi_visitor.h"
 #include "headers/ElaboratorListener.h"
 
+#include "tests/test-util.h"
+
 using namespace UHDM;
 
 static int usage(const char *progname) {
@@ -49,7 +51,7 @@ int main (int argc, char** argv) {
   }
 
   if (uhdmFile.empty()) {
-    uhdmFile = "surelog.uhdm";   // used by default in test.
+    uhdmFile = uhdm_test::getTmpDir() + "/surelog.uhdm";   // used by default in test.
   }
 
   struct stat buffer;

--- a/tests/test-util.h
+++ b/tests/test-util.h
@@ -14,8 +14,11 @@ inline std::string getTmpDir();
 inline std::string uhdm_test::getTmpDir() {
   const char *tmpdir = getenv("TEST_TMPDIR");
   if (tmpdir && tmpdir[0]) return tmpdir;
-  tmpdir = getenv("TMPDIR");
+  tmpdir = getenv("TMPDIR");  // typical Unix env var
+  if (tmpdir && tmpdir[0]) return tmpdir;
+  tmpdir = getenv("TEMP");  // typical Windows env var
   if (tmpdir && tmpdir[0]) return tmpdir;
   return "/tmp";
 }
+
 #endif // UHDM_TEST_UTIL

--- a/tests/test-util.h
+++ b/tests/test-util.h
@@ -1,0 +1,21 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+// Some basic functionality for writing tests in absense of
+// googletest.
+#ifndef UHDM_TEST_UTIL
+#define UHDM_TEST_UTIL
+
+#include <stdlib.h>
+#include <string>
+
+namespace uhdm_test {
+inline std::string getTmpDir();
+}  // namespace uhdm_test
+
+inline std::string uhdm_test::getTmpDir() {
+  const char *tmpdir = getenv("TEST_TMPDIR");
+  if (tmpdir && tmpdir[0]) return tmpdir;
+  tmpdir = getenv("TMPDIR");
+  if (tmpdir && tmpdir[0]) return tmpdir;
+  return "/tmp";
+}
+#endif // UHDM_TEST_UTIL

--- a/tests/test1.cpp
+++ b/tests/test1.cpp
@@ -3,7 +3,7 @@
 #include "headers/uhdm.h"
 #include "headers/vpi_visitor.h"
 
-#include "tests/test-util.h"
+#include "test-util.h"
 
 #include <iostream>
 

--- a/tests/test1.cpp
+++ b/tests/test1.cpp
@@ -3,6 +3,8 @@
 #include "headers/uhdm.h"
 #include "headers/vpi_visitor.h"
 
+#include "tests/test-util.h"
+
 #include <iostream>
 
 using namespace UHDM;
@@ -33,7 +35,7 @@ std::vector<vpiHandle> build_designs (Serializer& s) {
   logic_var* lvar = s.MakeLogic_var();
   vars->push_back(lvar);
   lvar->VpiFullName("top::M1::v1");
-  
+
   // Module
   module* m2 = s.MakeModule();
   m2->VpiDefName("M2");
@@ -132,11 +134,12 @@ int main (int argc, char** argv) {
   orig += "VISITOR:\n";
   orig += visit_designs(designs);
   std::cout << orig;
+  const std::string filename = uhdm_test::getTmpDir() + "/surelog.uhdm";
   std::cout << "\nSave design" << std::endl;
-  serializer.Save("surelog.uhdm");
+  serializer.Save(filename);
 
   std::cout << "Restore design" << std::endl;
-  const std::vector<vpiHandle>& restoredDesigns = serializer.Restore("surelog.uhdm");
+  const std::vector<vpiHandle>& restoredDesigns = serializer.Restore(filename);
   std::string restored;
   restored += "VISITOR:\n";
   restored += visit_designs(restoredDesigns);

--- a/tests/test2.cpp
+++ b/tests/test2.cpp
@@ -5,11 +5,13 @@
 #include "headers/uhdm.h"
 #include "headers/vpi_visitor.h"
 
+#include "tests/test-util.h"
+
 using namespace UHDM;
 
 
 int main (int argc, char** argv) {
-  std::string fileName = "surelog.uhdm";
+  std::string fileName = uhdm_test::getTmpDir() + "/surelog.uhdm";
   if (argc > 1) {
     fileName = argv[1];
   }

--- a/tests/test2.cpp
+++ b/tests/test2.cpp
@@ -5,7 +5,7 @@
 #include "headers/uhdm.h"
 #include "headers/vpi_visitor.h"
 
-#include "tests/test-util.h"
+#include "test-util.h"
 
 using namespace UHDM;
 

--- a/tests/test3.cpp
+++ b/tests/test3.cpp
@@ -5,7 +5,7 @@
 #include "headers/uhdm.h"
 #include "headers/vpi_visitor.h"
 
-#include "tests/test-util.h"
+#include "test-util.h"
 
 using namespace UHDM;
 

--- a/tests/test3.cpp
+++ b/tests/test3.cpp
@@ -5,6 +5,8 @@
 #include "headers/uhdm.h"
 #include "headers/vpi_visitor.h"
 
+#include "tests/test-util.h"
+
 using namespace UHDM;
 
 #include "vpi_visitor.h"
@@ -37,7 +39,7 @@ std::vector<vpiHandle> build_designs (Serializer& s) {
   init->Stmt(begin_block);
   VectorOfany* statements = s.MakeAnyVec();
   ref_obj* lhs_rf = s.MakeRef_obj();
-  lhs_rf->VpiName("out");          
+  lhs_rf->VpiName("out");
   assignment* assign1 = s.MakeAssignment();
   assign1->Lhs(lhs_rf);
   constant* c1 = s.MakeConstant();
@@ -51,7 +53,7 @@ std::vector<vpiHandle> build_designs (Serializer& s) {
   c2->VpiValue("STRING:a string");
   assign2->Rhs(c2);
   statements->push_back(assign2);
-  
+
   delay_control* dc = s.MakeDelay_control();
   dc->VpiDelay("#100");
 
@@ -65,7 +67,7 @@ std::vector<vpiHandle> build_designs (Serializer& s) {
   assign3->Rhs(c3);
   dc->Stmt(assign3);
   statements->push_back(dc);
-  
+
   begin_block->Stmts(statements);
   m2->Process(processes);
 
@@ -103,10 +105,11 @@ int main (int argc, char** argv) {
 
   std::cout << orig;
   std::cout << "\nSave design" << std::endl;
-  serializer.Save("surelog3.uhdm");
+  const std::string filename = uhdm_test::getTmpDir() + "/surelog3.uhdm";
+  serializer.Save(filename);
 
   std::cout << "Restore design" << std::endl;
-  std::vector<vpiHandle> restoredDesigns = serializer.Restore("surelog3.uhdm");
+  std::vector<vpiHandle> restoredDesigns = serializer.Restore(filename);
 
   std::string restored = visit_designs(restoredDesigns);
   std::cout << restored;

--- a/tests/test4.cpp
+++ b/tests/test4.cpp
@@ -5,7 +5,7 @@
 #include "headers/uhdm.h"
 #include "headers/vpi_visitor.h"
 
-#include "tests/test-util.h"
+#include "test-util.h"
 
 using namespace UHDM;
 

--- a/tests/test4.cpp
+++ b/tests/test4.cpp
@@ -5,10 +5,13 @@
 #include "headers/uhdm.h"
 #include "headers/vpi_visitor.h"
 
+#include "tests/test-util.h"
+
 using namespace UHDM;
 
+// TODO: this test assumes that test1 and test3 have run before
 int main (int argc, char** argv) {
-  std::string fileName = "surelog.uhdm";
+  std::string fileName = uhdm_test::getTmpDir() + "/surelog.uhdm";
   if (argc > 1) {
     fileName = argv[1];
   }
@@ -19,7 +22,7 @@ int main (int argc, char** argv) {
   std::cout << restored1;
 
   Serializer serializer2;
-  fileName = "surelog3.uhdm";
+  fileName = uhdm_test::getTmpDir() + "/surelog3.uhdm";
   std::cout << "Restore design from: " << fileName << std::endl;
   std::vector<vpiHandle> restoredDesigns2 = serializer2.Restore(fileName);
   std::string restored2 = visit_designs(restoredDesigns2);

--- a/tests/testErrorHandler.cpp
+++ b/tests/testErrorHandler.cpp
@@ -5,7 +5,7 @@
 #include "headers/uhdm.h"
 #include "headers/vpi_visitor.h"
 
-#include "tests/test-util.h"
+#include "test-util.h"
 
 using namespace UHDM;
 

--- a/tests/testErrorHandler.cpp
+++ b/tests/testErrorHandler.cpp
@@ -5,6 +5,8 @@
 #include "headers/uhdm.h"
 #include "headers/vpi_visitor.h"
 
+#include "tests/test-util.h"
+
 using namespace UHDM;
 
 #include "vpi_visitor.h"
@@ -37,7 +39,7 @@ std::vector<vpiHandle> build_designs (Serializer& s) {
   init->Stmt(begin_block);
   VectorOfany* statements = s.MakeAnyVec();
   ref_obj* lhs_rf = s.MakeRef_obj();
-  lhs_rf->VpiName("out");          
+  lhs_rf->VpiName("out");
   assignment* assign1 = s.MakeAssignment();
   assign1->Lhs(lhs_rf);
   constant* c1 = s.MakeConstant();
@@ -51,7 +53,7 @@ std::vector<vpiHandle> build_designs (Serializer& s) {
   c2->VpiValue("STRING:a string");
   assign2->Rhs(c2);
   statements->push_back(assign2);
-  
+
   delay_control* dc = s.MakeDelay_control();
   dc->VpiDelay("#100");
 
@@ -109,11 +111,12 @@ int main (int argc, char** argv) {
   std::string orig = visit_designs(build_designs(serializer));
 
   std::cout << orig;
+  const std::string filename = uhdm_test::getTmpDir() + "/surelog3.uhdm";
   std::cout << "\nSave design" << std::endl;
-  serializer.Save("surelog3.uhdm");
+  serializer.Save(filename);
 
   std::cout << "Restore design" << std::endl;
-  std::vector<vpiHandle> restoredDesigns = serializer.Restore("surelog3.uhdm");
+  std::vector<vpiHandle> restoredDesigns = serializer.Restore(filename);
 
   std::string restored = visit_designs(restoredDesigns);
   std::cout << restored;

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -6,7 +6,7 @@
 #include "headers/vpi_visitor.h"
 #include "headers/ElaboratorListener.h"
 
-#include "tests/test-util.h"
+#include "test-util.h"
 
 using namespace UHDM;
 

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -6,6 +6,8 @@
 #include "headers/vpi_visitor.h"
 #include "headers/ElaboratorListener.h"
 
+#include "tests/test-util.h"
+
 using namespace UHDM;
 
 std::vector<vpiHandle> build_designs (Serializer& s) {
@@ -90,7 +92,7 @@ std::vector<vpiHandle> build_designs (Serializer& s) {
   method_func_call* fcall2 = s.MakeMethod_func_call();
   f3->Stmt(fcall);
   fcall2->VpiName("f1"); // parent class function
-  
+
   VectorOfmodule* topModules = s.MakeModuleVec();
   d->TopModules(topModules);
   topModules->push_back(m1);
@@ -108,11 +110,12 @@ int main (int argc, char** argv) {
   orig += "VISITOR:\n";
   orig += visit_designs(designs);
   std::cout << orig;
+  const std::string filename = uhdm_test::getTmpDir() + "/test_classes.uhdm";
   std::cout << "\nSave design" << std::endl;
-  serializer.Save("test_classes.uhdm");
+  serializer.Save(filename);
 
   std::cout << "Restore design" << std::endl;
-  const std::vector<vpiHandle>& restoredDesigns = serializer.Restore("test_classes.uhdm");
+  const std::vector<vpiHandle>& restoredDesigns = serializer.Restore(filename);
   std::string restored;
   restored += "VISITOR:\n";
   restored += visit_designs(restoredDesigns);
@@ -123,6 +126,6 @@ int main (int argc, char** argv) {
   listen_designs(restoredDesigns,listener);
   std::cout << "Elaborated restored design:\n";
   std::cout << visit_designs(restoredDesigns);
-  
+
   return (orig != restored);
 }

--- a/tests/test_listener.cpp
+++ b/tests/test_listener.cpp
@@ -6,7 +6,7 @@
 #include "headers/uhdm.h"
 #include "headers/vpi_listener.h"
 
-#include "tests/test-util.h"
+#include "test-util.h"
 
 using namespace UHDM;
 

--- a/tests/test_listener.cpp
+++ b/tests/test_listener.cpp
@@ -6,6 +6,8 @@
 #include "headers/uhdm.h"
 #include "headers/vpi_listener.h"
 
+#include "tests/test-util.h"
+
 using namespace UHDM;
 
 class MyVpiListener : public VpiListener {
@@ -43,7 +45,7 @@ private:
 };
 
 int main (int argc, char** argv) {
-  std::string fileName = "surelog.uhdm";
+  std::string fileName = uhdm_test::getTmpDir() + "/surelog.uhdm";
   if (argc > 1) {
     fileName = argv[1];
   }

--- a/tests/test_process.cpp
+++ b/tests/test_process.cpp
@@ -3,6 +3,8 @@
 #include "headers/uhdm.h"
 #include "headers/vpi_visitor.h"
 
+#include "tests/test-util.h"
+
 using namespace UHDM;
 
 #include "vpi_visitor.h"
@@ -91,14 +93,14 @@ int main (int argc, char** argv) {
   std::string orig = visit_designs(build_designs(serializer));
 
   std::cout << orig;
+  const std::string filename = uhdm_test::getTmpDir() + "/surelog_process.uhdm";
   std::cout << "\nSave design" << std::endl;
-  serializer.Save("surelog_process.uhdm");
+  serializer.Save(filename);
 
   std::cout << "Restore design" << std::endl;
-  std::vector<vpiHandle> restoredDesigns = serializer.Restore("surelog_process.uhdm");
+  std::vector<vpiHandle> restoredDesigns = serializer.Restore(filename);
 
   std::string restored = visit_designs(restoredDesigns);
   std::cout << restored;
   return (orig != restored);
 }
-

--- a/tests/test_process.cpp
+++ b/tests/test_process.cpp
@@ -3,7 +3,7 @@
 #include "headers/uhdm.h"
 #include "headers/vpi_visitor.h"
 
-#include "tests/test-util.h"
+#include "test-util.h"
 
 using namespace UHDM;
 

--- a/tests/test_tf_call.cpp
+++ b/tests/test_tf_call.cpp
@@ -3,6 +3,8 @@
 #include "headers/uhdm.h"
 #include "headers/vpi_visitor.h"
 
+#include "tests/test-util.h"
+
 using namespace UHDM;
 
 #include "vpi_visitor.h"
@@ -75,11 +77,12 @@ int main (int argc, char** argv) {
   std::string orig = visit_designs(build_designs(serializer));
 
   std::cout << orig;
+  const std::string filename = uhdm_test::getTmpDir() + "/surelog_tf_call.uhdm";
   std::cout << "\nSave design" << std::endl;
-  serializer.Save("surelog_tf_call.uhdm");
+  serializer.Save(filename);
 
   std::cout << "Restore design" << std::endl;
-  std::vector<vpiHandle> restoredDesigns = serializer.Restore("surelog_tf_call.uhdm");
+  std::vector<vpiHandle> restoredDesigns = serializer.Restore(filename);
 
   std::string restored = visit_designs(restoredDesigns);
   std::cout << restored;

--- a/tests/test_tf_call.cpp
+++ b/tests/test_tf_call.cpp
@@ -3,7 +3,7 @@
 #include "headers/uhdm.h"
 #include "headers/vpi_visitor.h"
 
-#include "tests/test-util.h"
+#include "test-util.h"
 
 using namespace UHDM;
 


### PR DESCRIPTION
Tests should only access directories explicitly made available
for temporary files by the test harness. Add a simple function
that is checking for common environment variables TEST_TMPDIR,
TMPDIR and then fallback to /tmp.

Signed-off-by: Henner Zeller <h.zeller@acm.org>