### PR TITLE
Install all uhdm related headers in flat $PREFIX/include/uhdm/*.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MY_CXX_WARNING_FLAGS}")
 
+# Directory where code is generated into.
+set(GENDIR ${CMAKE_CURRENT_BINARY_DIR}/generated)
+
 if(MSVC)
   set(CMAKE_CXX_FLAGS_DEBUG
       "${CMAKE_CXX_FLAGS_DEBUG} ${TCMALLOC_COMPILE_OPTIONS} /W3 /bigobj ${MY_CXX_WARNING_FLAGS}"
@@ -69,8 +72,8 @@ else()
   # TODO: Reduce complexity/branches etc. whatever makes the optimizer freak
   # out. The code-generation is pretty linear right now.
   set_property(SOURCE
-    ${CMAKE_CURRENT_BINARY_DIR}/src/Serializer_save.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/Serializer_restore.cpp
+    ${GENDIR}/src/Serializer_save.cpp
+    ${GENDIR}/src/Serializer_restore.cpp
     PROPERTY COMPILE_FLAGS -O0
  )
 
@@ -82,13 +85,13 @@ file(GLOB yaml_SRC ${PROJECT_SOURCE_DIR}/model/*.yaml)
 file(GLOB templates_SRC ${PROJECT_SOURCE_DIR}/templates/*.h
      ${PROJECT_SOURCE_DIR}/templates/*.cpp)
 
-set(model-GENERATED_UHDM ${CMAKE_CURRENT_BINARY_DIR}/src/UHDM.capnp)
+set(model-GENERATED_UHDM ${GENDIR}/src/UHDM.capnp)
 set_source_files_properties(${model-GENERATED_UHDM} PROPERTIES GENERATED TRUE)
 add_custom_command(
   OUTPUT ${model-GENERATED_UHDM}
   COMMAND tclsh ${PROJECT_SOURCE_DIR}/model_gen/model_gen.tcl
           ${PROJECT_SOURCE_DIR}/model/models.lst ${CMAKE_CURRENT_BINARY_DIR}
-          ${CMAKE_CURRENT_BINARY_DIR}
+          ${GENDIR}
   WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
   DEPENDS ${PROJECT_SOURCE_DIR}/model_gen/model_gen.tcl
           ${PROJECT_SOURCE_DIR}/model_gen/generate_elaborator.tcl
@@ -98,8 +101,8 @@ add_custom_command(
           ${yaml_SRC}
           ${templates_SRC})
 
-set(model-GENERATED_SRC ${CMAKE_CURRENT_BINARY_DIR}/src/UHDM.capnp.h
-                        ${CMAKE_CURRENT_BINARY_DIR}/src/UHDM.capnp.c++)
+set(model-GENERATED_SRC ${GENDIR}/src/UHDM.capnp.h
+                        ${GENDIR}/src/UHDM.capnp.c++)
 foreach(header_file ${model-GENERATED_SRC})
   set_source_files_properties(${header_file} PROPERTIES GENERATED TRUE)
 endforeach(header_file ${model-GENERATED_SRC})
@@ -113,53 +116,53 @@ add_custom_command(
 add_custom_target(GenerateCode DEPENDS ${model-GENERATED_SRC})
 
 set(uhdm-GENERATED_SRC
-    ${CMAKE_CURRENT_BINARY_DIR}/src/ExprEval.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/Serializer_restore.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/Serializer_save.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/SymbolFactory.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/UHDM.capnp.c++
-    ${CMAKE_CURRENT_BINARY_DIR}/src/actual_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/assertion.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/clone_tree.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/constraint_item_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/enum_struct_packed_net_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/enum_struct_union_packed_array_typespec_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/enum_struct_union_packed_var_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/expr_constr_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/expr_dist.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/expr_interf_expr_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/expr_range_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/expr_ref_obj_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/expr_sequence_inst_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/expr_sequence_inst_named_event_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/expr_tchk_term_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/expr_typespec_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/instance_item.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/interf_prog_mod_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/method_func_task_call_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/named_event_sequence_expr_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/nets_vars_ref_obj_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/operand_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/parameters.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/pattern.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/pattern_expr_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/property_expr_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/property_expr_named_event_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/property_inst_spec_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/ref_obj_interf_net_var_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/sequence_expr_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/sequence_expr_multiclock_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/simple_expr_use_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/stmt.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/sys_func_task_call_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/task_func_named_begin_fork_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/tf_call_args.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/variable_drivers_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/variable_loads_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/variables_operation_group.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/vpi_listener.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/vpi_user.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/src/vpi_visitor.cpp
+    ${GENDIR}/src/ExprEval.cpp
+    ${GENDIR}/src/Serializer_restore.cpp
+    ${GENDIR}/src/Serializer_save.cpp
+    ${GENDIR}/src/SymbolFactory.cpp
+    ${GENDIR}/src/UHDM.capnp.c++
+    ${GENDIR}/src/actual_group.cpp
+    ${GENDIR}/src/assertion.cpp
+    ${GENDIR}/src/clone_tree.cpp
+    ${GENDIR}/src/constraint_item_group.cpp
+    ${GENDIR}/src/enum_struct_packed_net_group.cpp
+    ${GENDIR}/src/enum_struct_union_packed_array_typespec_group.cpp
+    ${GENDIR}/src/enum_struct_union_packed_var_group.cpp
+    ${GENDIR}/src/expr_constr_group.cpp
+    ${GENDIR}/src/expr_dist.cpp
+    ${GENDIR}/src/expr_interf_expr_group.cpp
+    ${GENDIR}/src/expr_range_group.cpp
+    ${GENDIR}/src/expr_ref_obj_group.cpp
+    ${GENDIR}/src/expr_sequence_inst_group.cpp
+    ${GENDIR}/src/expr_sequence_inst_named_event_group.cpp
+    ${GENDIR}/src/expr_tchk_term_group.cpp
+    ${GENDIR}/src/expr_typespec_group.cpp
+    ${GENDIR}/src/instance_item.cpp
+    ${GENDIR}/src/interf_prog_mod_group.cpp
+    ${GENDIR}/src/method_func_task_call_group.cpp
+    ${GENDIR}/src/named_event_sequence_expr_group.cpp
+    ${GENDIR}/src/nets_vars_ref_obj_group.cpp
+    ${GENDIR}/src/operand_group.cpp
+    ${GENDIR}/src/parameters.cpp
+    ${GENDIR}/src/pattern.cpp
+    ${GENDIR}/src/pattern_expr_group.cpp
+    ${GENDIR}/src/property_expr_group.cpp
+    ${GENDIR}/src/property_expr_named_event_group.cpp
+    ${GENDIR}/src/property_inst_spec_group.cpp
+    ${GENDIR}/src/ref_obj_interf_net_var_group.cpp
+    ${GENDIR}/src/sequence_expr_group.cpp
+    ${GENDIR}/src/sequence_expr_multiclock_group.cpp
+    ${GENDIR}/src/simple_expr_use_group.cpp
+    ${GENDIR}/src/stmt.cpp
+    ${GENDIR}/src/sys_func_task_call_group.cpp
+    ${GENDIR}/src/task_func_named_begin_fork_group.cpp
+    ${GENDIR}/src/tf_call_args.cpp
+    ${GENDIR}/src/variable_drivers_group.cpp
+    ${GENDIR}/src/variable_loads_group.cpp
+    ${GENDIR}/src/variables_operation_group.cpp
+    ${GENDIR}/src/vpi_listener.cpp
+    ${GENDIR}/src/vpi_user.cpp
+    ${GENDIR}/src/vpi_visitor.cpp
 )
 
 foreach(src_file ${uhdm-GENERATED_SRC})
@@ -167,15 +170,15 @@ foreach(src_file ${uhdm-GENERATED_SRC})
 endforeach(src_file ${uhdm-GENERATED_SRC})
 
 add_library(uhdm STATIC ${uhdm-GENERATED_SRC})
-set_target_properties(uhdm PROPERTIES PUBLIC_HEADER ${CMAKE_CURRENT_BINARY_DIR}/headers/uhdm.h)
-target_include_directories(uhdm PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/headers>
-  $<INSTALL_INTERFACE:include/uhdm/include>
-  $<INSTALL_INTERFACE:include/uhdm>
-  $<INSTALL_INTERFACE:include/uhdm/headers>)
+set_target_properties(uhdm PROPERTIES PUBLIC_HEADER ${GENDIR}/uhdm/uhdm.h)
+
+# Our uhdm headers come with angle brackets (indicating system headers),
+# make sure that the compiler looks here first before finding an existing UHDM
+# installation. Hence we use SYSTEM
+target_include_directories(uhdm SYSTEM PUBLIC
+  $<BUILD_INTERFACE:${GENDIR}>
+  $<INSTALL_INTERFACE:include>)
 target_include_directories(uhdm PRIVATE
-  ${PROJECT_SOURCE_DIR}/src
   ${PROJECT_SOURCE_DIR}/third_party/capnproto/c++/src
   ${PROJECT_SOURCE_DIR}/third_party/UHDM/src)
 target_compile_definitions(uhdm
@@ -256,9 +259,8 @@ set_property(TARGET test_inst PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_
 target_compile_definitions(test_inst
   PUBLIC PLI_DLLISPEC=
   PUBLIC PLI_DLLESPEC=)
-target_include_directories(test_inst PRIVATE
-  ${CMAKE_INSTALL_PREFIX}/include/uhdm
-  ${CMAKE_INSTALL_PREFIX}/include/uhdm/include)
+target_include_directories(test_inst SYSTEM PRIVATE
+  ${CMAKE_INSTALL_PREFIX}/include)
 target_link_libraries(test_inst PRIVATE
   ${CMAKE_INSTALL_PREFIX}/lib/uhdm/${CMAKE_STATIC_LIBRARY_PREFIX}uhdm${CMAKE_STATIC_LIBRARY_SUFFIX}
   ${CMAKE_INSTALL_PREFIX}/lib/uhdm/${CMAKE_STATIC_LIBRARY_PREFIX}capnp${CMAKE_STATIC_LIBRARY_SUFFIX}
@@ -274,7 +276,7 @@ install(
   TARGETS uhdm capnp kj uhdm-dump uhdm-hier
   ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/uhdm
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/include/uhdm)
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/include/uhdm/include)
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/headers/
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/include/uhdm/headers/)
+install(DIRECTORY ${GENDIR}/uhdm/
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/include/uhdm/)
+install(FILES ${GENDIR}/src/UHDM.capnp
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/uhdm)

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,9 @@ install: build
 	cmake --install build --config Release
 
 uninstall:
-	rm -rf $(PREFIX)/lib/uhdm
-	rm -rf $(PREFIX)/include/uhdm
+	$(RM) $(PREFIX)/bin/uhdm-dump $(PREFIX)/bin/uhdm-dump
+	$(RM) -r $(PREFIX)/lib/uhdm
+	$(RM) -r $(PREFIX)/include/uhdm
 
 build:
 	mkdir -p build

--- a/model_gen/generate_elaborator.tcl
+++ b/model_gen/generate_elaborator.tcl
@@ -74,10 +74,10 @@ proc generate_elaborator { models } {
     ref->VpiName(parent->VpiName());
     if (parent->UhdmType() == uhdmref_obj) {
       ref->VpiFullName(((ref_obj*)VpiParent())->VpiFullName());
-    } 
+    }
     ref->VpiParent((any*) parent);
     ref->Actual_group(elaborator->bindAny(ref->VpiName()));
-    if (!ref->Actual_group()) 
+    if (!ref->Actual_group())
       if (parent->UhdmType() == uhdmref_obj) {
         ref->Actual_group((any*) ((ref_obj*)VpiParent())->Actual_group());
       }
@@ -352,7 +352,7 @@ proc generate_elaborator { models } {
           }
 "
                             }
-                            
+
                         }
                     }
                 }
@@ -381,13 +381,13 @@ proc generate_elaborator { models } {
     regsub {<MODULE_ELABORATOR_LISTENER>} $listener_content $module_vpi_listener listener_content
     regsub {<CLASS_ELABORATOR_LISTENER>} $listener_content $class_vpi_listener listener_content
 
-    set_content_if_change "[codegen_base]/headers/ElaboratorListener.h" $listener_content
+    set_content_if_change "[gen_header_dir]/ElaboratorListener.h" $listener_content
 
     set fid [open "[project_path]/templates/clone_tree.h"]
     set clone_content [read $fid]
     close $fid
 
-    set_content_if_change "[codegen_base]/headers/clone_tree.h" $clone_content
+    set_content_if_change "[gen_header_dir]/clone_tree.h" $clone_content
 
     set fid [open "[project_path]/templates/clone_tree.cpp"]
     set clone_content [read $fid]

--- a/templates/BaseClass.h
+++ b/templates/BaseClass.h
@@ -27,7 +27,7 @@
 #ifndef UHDM_BASE_CLASS_H
 #define UHDM_BASE_CLASS_H
 #include <set>
-#include "uhdm_types.h"
+#include <uhdm/uhdm_types.h>
 
 namespace UHDM {
   class Serializer;

--- a/templates/ElaboratorListener.h
+++ b/templates/ElaboratorListener.h
@@ -28,13 +28,13 @@
 #include <stack>
 #include <iostream>
 
-#include "headers/VpiListener.h"
-#include "headers/clone_tree.h"
+#include <uhdm/VpiListener.h>
+#include <uhdm/clone_tree.h>
 
 // Since there is a lot of implementation happening inside this
 // header, we need to include this.
 // TODO: move implementation in ElaboratorListener.cpp
-#include "headers/Serializer.h"
+#include <uhdm/Serializer.h>
 
 namespace UHDM {
 

--- a/templates/ExprEval.cpp
+++ b/templates/ExprEval.cpp
@@ -22,8 +22,8 @@
  * Created on July 3, 2021, 8:03 PM
  */
 
-#include "ExprEval.h"
-#include "uhdm.h"
+#include <uhdm/ExprEval.h>
+#include <uhdm/uhdm.h>
 
 using namespace UHDM;
 

--- a/templates/ExprEval.h
+++ b/templates/ExprEval.h
@@ -24,7 +24,7 @@
  * Created on July 3, 2021, 8:03 PM
  */
 
-#include "typespec.h"
+#include <uhdm/typespec.h>
 
 namespace UHDM {
 

--- a/templates/Serializer.h
+++ b/templates/Serializer.h
@@ -33,7 +33,7 @@
 
 #include <iostream>
 #include <functional>
-#include "uhdm.h"
+#include <uhdm/uhdm.h>
 
 namespace UHDM {
 

--- a/templates/Serializer_restore.cpp
+++ b/templates/Serializer_restore.cpp
@@ -22,7 +22,7 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
-#include "headers/Serializer.h"
+#include <uhdm/Serializer.h>
 
 #include <fcntl.h>
 #include <limits.h>
@@ -48,9 +48,9 @@
 #include <capnp/serialize-packed.h>
 
 #include "UHDM.capnp.h"
-#include "headers/containers.h"
-#include "headers/uhdm.h"
-#include "headers/uhdm_types.h"
+#include <uhdm/containers.h>
+#include <uhdm/uhdm.h>
+#include <uhdm/uhdm_types.h>
 
 namespace UHDM {
 const std::vector<vpiHandle> Serializer::Restore(const std::string& file) {

--- a/templates/Serializer_save.cpp
+++ b/templates/Serializer_save.cpp
@@ -22,7 +22,7 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
-#include "headers/Serializer.h"
+#include <uhdm/Serializer.h>
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -49,9 +49,9 @@
 #include <capnp/serialize-packed.h>
 
 #include "UHDM.capnp.h"
-#include "headers/containers.h"
-#include "headers/uhdm.h"
-#include "headers/uhdm_types.h"
+#include <uhdm/containers.h>
+#include <uhdm/uhdm.h>
+#include <uhdm/uhdm_types.h>
 
 namespace UHDM {
 void Serializer::SetId(const BaseClass* p, unsigned long id) {

--- a/templates/SymbolFactory.cpp
+++ b/templates/SymbolFactory.cpp
@@ -22,7 +22,7 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
-#include "SymbolFactory.h"
+#include <uhdm/SymbolFactory.h>
 
 namespace UHDM {
 

--- a/templates/SymbolFactory.h
+++ b/templates/SymbolFactory.h
@@ -31,7 +31,7 @@
 #include <vector>
 #include <unordered_map>
 
-#include "uhdm_types.h"
+#include <uhdm/uhdm_types.h>
 
 namespace UHDM {
 class Serializer;

--- a/templates/UHDM.capnp
+++ b/templates/UHDM.capnp
@@ -1,8 +1,8 @@
 @0xfff7299129556877;
 
 struct ObjIndexType {
-   index @0 : UInt64;
-   type  @1 : UInt32;
+  index @0 : UInt64;
+  type  @1 : UInt32;
 }
 
 struct UhdmRoot {
@@ -13,4 +13,3 @@ struct UhdmRoot {
 
 
 <CAPNP_SCHEMA>
-

--- a/templates/VpiListener.h
+++ b/templates/VpiListener.h
@@ -27,8 +27,8 @@
 #ifndef UHDM_VPILISTENER_CLASS_H
 #define UHDM_VPILISTENER_CLASS_H
 
-#include "headers/uhdm_forward_decl.h"
-#include "include/vpi_user.h"
+#include <uhdm/uhdm_forward_decl.h>
+#include <uhdm/vpi_user.h>
 
 namespace UHDM {
 class VpiListener {

--- a/templates/class_header.h
+++ b/templates/class_header.h
@@ -26,14 +26,14 @@
 #ifndef UHDM_<UPPER_CLASSNAME>_H
 #define UHDM_<UPPER_CLASSNAME>_H
 
-#include "../include/sv_vpi_user.h"
-#include "uhdm_vpi_user.h"
+#include <uhdm/sv_vpi_user.h>
+#include <uhdm/uhdm_vpi_user.h>
 
-#include "SymbolFactory.h"
-#include "BaseClass.h"
-#include "containers.h"
+#include <uhdm/SymbolFactory.h>
+#include <uhdm/BaseClass.h>
+#include <uhdm/containers.h>
 
-#include "<EXTENDS>.h"
+#include <uhdm/<EXTENDS>.h>
 
 <GROUP_HEADER_DEPENDENCY>
 

--- a/templates/clone_tree.cpp
+++ b/templates/clone_tree.cpp
@@ -22,10 +22,10 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
-#include "clone_tree.h"
+#include <uhdm/clone_tree.h>
 
-#include "ElaboratorListener.h"
-#include "uhdm.h"
+#include <uhdm/ElaboratorListener.h>
+#include <uhdm/uhdm.h>
 
 using namespace UHDM;
 

--- a/templates/clone_tree.h
+++ b/templates/clone_tree.h
@@ -28,7 +28,7 @@
 #include <string>
 #include <vector>
 
-#include "../include/sv_vpi_user.h"
+#include <uhdm/sv_vpi_user.h>
 
 namespace UHDM {
 class BaseClass;

--- a/templates/containers.h
+++ b/templates/containers.h
@@ -25,7 +25,7 @@
 
 #include <vector>
 #include <unordered_map>
-#include "uhdm_types.h"
+#include <uhdm/uhdm_types.h>
 
 #ifndef UHDM_CONTAINERS_H
 #define UHDM_CONTAINERS_H

--- a/templates/group_header.cpp
+++ b/templates/group_header.cpp
@@ -22,10 +22,10 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
-#include "<GROUPNAME>.h"
+#include <uhdm/<GROUPNAME>.h>
 
 #include <iostream>
-#include "headers/uhdm.h"
+#include <uhdm/uhdm.h>
 
 namespace UHDM {
 bool <GROUPNAME>GroupCompliant(any* item) {

--- a/templates/group_header.h
+++ b/templates/group_header.h
@@ -26,7 +26,7 @@
 #ifndef UHDM_<UPPER_GROUPNAME>_H
 #define UHDM_<UPPER_GROUPNAME>_H
 
-#include "headers/uhdm_forward_decl.h"
+#include <uhdm/uhdm_forward_decl.h>
 
 namespace UHDM {
 

--- a/templates/uhdm.h
+++ b/templates/uhdm.h
@@ -30,16 +30,16 @@
 #include <set>
 #include <map>
 
-#include "../include/sv_vpi_user.h"
-#include "../include/vhpi_user.h"
+#include <uhdm/sv_vpi_user.h>
+#include <uhdm/vhpi_user.h>
 
-#include "headers/uhdm_vpi_user.h"
-#include "headers/uhdm_types.h"
-#include "headers/vpi_uhdm.h"
-#include "headers/containers.h"
+#include <uhdm/uhdm_vpi_user.h>
+#include <uhdm/uhdm_types.h>
+#include <uhdm/vpi_uhdm.h>
+#include <uhdm/containers.h>
 
 <INCLUDE_FILES>
 
-#include "headers/Serializer.h"
+#include <uhdm/Serializer.h>
 
 #endif

--- a/templates/uhdm_types.h
+++ b/templates/uhdm_types.h
@@ -27,7 +27,7 @@
 #define UHDM_TYPES_H
 
 #include <string>
-#include "../include/vpi_user.h"
+#include <uhdm/vpi_user.h>
 
 namespace UHDM {
 class BaseClass;

--- a/templates/vpi_listener.cpp
+++ b/templates/vpi_listener.cpp
@@ -22,7 +22,7 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
-#include "headers/vpi_listener.h"
+#include <uhdm/vpi_listener.h>
 
 #include <string.h>
 
@@ -31,14 +31,14 @@
 #include <string>
 #include <vector>
 
-#include "include/sv_vpi_user.h"
-#include "include/vhpi_user.h"
+#include <uhdm/sv_vpi_user.h>
+#include <uhdm/vhpi_user.h>
 
-#include "headers/Serializer.h"
-#include "headers/containers.h"
-#include "headers/uhdm.h"
-#include "headers/uhdm_types.h"
-#include "headers/vpi_uhdm.h"
+#include <uhdm/Serializer.h>
+#include <uhdm/containers.h>
+#include <uhdm/uhdm.h>
+#include <uhdm/uhdm_types.h>
+#include <uhdm/vpi_uhdm.h>
 
 
 using namespace UHDM;

--- a/templates/vpi_listener.h
+++ b/templates/vpi_listener.h
@@ -25,9 +25,9 @@
 
 #include <string>
 #include <vector>
-#include "headers/BaseClass.h"
-#include "../include/sv_vpi_user.h"
-#include "headers/VpiListener.h"
+#include <uhdm/BaseClass.h>
+#include <uhdm/sv_vpi_user.h>
+#include <uhdm/VpiListener.h>
 
 #ifndef UHDM_VPI_LISTENER_H
 #define UHDM_VPI_LISTENER_H

--- a/templates/vpi_uhdm.h
+++ b/templates/vpi_uhdm.h
@@ -30,7 +30,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "uhdm_types.h"
+#include <uhdm/uhdm_types.h>
 
 namespace UHDM {
   class Serializer;

--- a/templates/vpi_user.cpp
+++ b/templates/vpi_user.cpp
@@ -22,8 +22,8 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
-#include "include/sv_vpi_user.h"
-#include "include/vhpi_user.h"
+#include <uhdm/sv_vpi_user.h>
+#include <uhdm/vhpi_user.h>
 
 #include <string.h>
 #if defined(_MSC_VER)
@@ -38,11 +38,11 @@
 #include <string>
 #include <vector>
 
-#include "headers/Serializer.h"
-#include "headers/containers.h"
-#include "headers/uhdm.h"
-#include "headers/uhdm_types.h"
-#include "headers/vpi_uhdm.h"
+#include <uhdm/Serializer.h>
+#include <uhdm/containers.h>
+#include <uhdm/uhdm.h>
+#include <uhdm/uhdm_types.h>
+#include <uhdm/vpi_uhdm.h>
 
 <HEADERS>
 

--- a/templates/vpi_visitor.cpp
+++ b/templates/vpi_visitor.cpp
@@ -22,7 +22,7 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
-#include "vpi_visitor.h"
+#include <uhdm/vpi_visitor.h>
 
 #include <string.h>
 
@@ -60,13 +60,13 @@ static bool showIDs = false;
 
 #else
 
-#include "include/sv_vpi_user.h"
-#include "include/vhpi_user.h"
-#include "headers/uhdm_types.h"
-#include "headers/containers.h"
-#include "headers/vpi_uhdm.h"
-#include "headers/uhdm.h"
-#include "headers/Serializer.h"
+#include <uhdm/sv_vpi_user.h>
+#include <uhdm/vhpi_user.h>
+#include <uhdm/uhdm_types.h>
+#include <uhdm/containers.h>
+#include <uhdm/vpi_uhdm.h>
+#include <uhdm/uhdm.h>
+#include <uhdm/Serializer.h>
 
 #endif
 

--- a/templates/vpi_visitor.h
+++ b/templates/vpi_visitor.h
@@ -27,10 +27,10 @@
 #include <vector>
 #include <set>
 
-#include "../include/sv_vpi_user.h"
+#include <uhdm/sv_vpi_user.h>
 
-#include "headers/BaseClass.h"
-#include "headers/uhdm_forward_decl.h"
+#include <uhdm/BaseClass.h>
+#include <uhdm/uhdm_forward_decl.h>
 
 #ifndef UHDM_VPI_VISITOR_H
 #define UHDM_VPI_VISITOR_H

--- a/tests/full_elab.cpp
+++ b/tests/full_elab.cpp
@@ -31,10 +31,10 @@
 #include <map>
 #include <stack>
 
-#include "headers/uhdm.h"
-#include "headers/vpi_listener.h"
-#include "headers/vpi_visitor.h"
-#include "headers/ElaboratorListener.h"
+#include <uhdm/uhdm.h>
+#include <uhdm/vpi_listener.h>
+#include <uhdm/vpi_visitor.h>
+#include <uhdm/ElaboratorListener.h>
 
 #include "test-util.h"
 

--- a/tests/listener_elab.cpp
+++ b/tests/listener_elab.cpp
@@ -32,11 +32,11 @@
 #include <stack>
 
 // Verifies that the forward declaration header compiles
-#include "headers/uhdm_forward_decl.h"
+#include <uhdm/uhdm_forward_decl.h>
 
-#include "headers/uhdm.h"
-#include "headers/vpi_listener.h"
-#include "headers/vpi_visitor.h"
+#include <uhdm/uhdm.h>
+#include <uhdm/vpi_listener.h>
+#include <uhdm/vpi_visitor.h>
 
 using namespace UHDM;
 

--- a/tests/test-dump.cpp
+++ b/tests/test-dump.cpp
@@ -20,10 +20,10 @@
   #include <unistd.h>
 #endif
 
-#include "headers/uhdm.h"
-#include "headers/vpi_listener.h"
-#include "headers/vpi_visitor.h"
-#include "headers/ElaboratorListener.h"
+#include <uhdm/uhdm.h>
+#include <uhdm/vpi_listener.h>
+#include <uhdm/vpi_visitor.h>
+#include <uhdm/ElaboratorListener.h>
 
 #include "test-util.h"
 

--- a/tests/test1.cpp
+++ b/tests/test1.cpp
@@ -1,7 +1,7 @@
 // -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
 
-#include "headers/uhdm.h"
-#include "headers/vpi_visitor.h"
+#include <uhdm/uhdm.h>
+#include <uhdm/vpi_visitor.h>
 
 #include "test-util.h"
 

--- a/tests/test2.cpp
+++ b/tests/test2.cpp
@@ -2,8 +2,8 @@
 
 #include <iostream>
 
-#include "headers/uhdm.h"
-#include "headers/vpi_visitor.h"
+#include <uhdm/uhdm.h>
+#include <uhdm/vpi_visitor.h>
 
 #include "test-util.h"
 

--- a/tests/test3.cpp
+++ b/tests/test3.cpp
@@ -2,14 +2,14 @@
 
 #include <iostream>
 
-#include "headers/uhdm.h"
-#include "headers/vpi_visitor.h"
+#include <uhdm/uhdm.h>
+#include <uhdm/vpi_visitor.h>
 
 #include "test-util.h"
 
 using namespace UHDM;
 
-#include "vpi_visitor.h"
+#include <uhdm/vpi_visitor.h>
 
 std::vector<vpiHandle> build_designs (Serializer& s) {
   std::vector<vpiHandle> designs;

--- a/tests/test4.cpp
+++ b/tests/test4.cpp
@@ -2,8 +2,8 @@
 
 #include <iostream>
 
-#include "headers/uhdm.h"
-#include "headers/vpi_visitor.h"
+#include <uhdm/uhdm.h>
+#include <uhdm/vpi_visitor.h>
 
 #include "test-util.h"
 

--- a/tests/testErrorHandler.cpp
+++ b/tests/testErrorHandler.cpp
@@ -2,14 +2,14 @@
 
 #include <iostream>
 
-#include "headers/uhdm.h"
-#include "headers/vpi_visitor.h"
+#include <uhdm/uhdm.h>
+#include <uhdm/vpi_visitor.h>
 
 #include "test-util.h"
 
 using namespace UHDM;
 
-#include "vpi_visitor.h"
+#include <uhdm/vpi_visitor.h>
 
 std::vector<vpiHandle> build_designs (Serializer& s) {
   std::vector<vpiHandle> designs;

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -1,10 +1,10 @@
 // -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
 #include <iostream>
 
-#include "headers/uhdm.h"
-#include "headers/vpi_listener.h"
-#include "headers/vpi_visitor.h"
-#include "headers/ElaboratorListener.h"
+#include <uhdm/uhdm.h>
+#include <uhdm/vpi_listener.h>
+#include <uhdm/vpi_visitor.h>
+#include <uhdm/ElaboratorListener.h>
 
 #include "test-util.h"
 

--- a/tests/test_garbage_collect.cpp
+++ b/tests/test_garbage_collect.cpp
@@ -1,7 +1,7 @@
 // -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
 
-#include "headers/uhdm.h"
-#include "headers/vpi_visitor.h"
+#include <uhdm/uhdm.h>
+#include <uhdm/vpi_visitor.h>
 
 #include "test-util.h"
 

--- a/tests/test_helper.h
+++ b/tests/test_helper.h
@@ -5,8 +5,8 @@
 #include <string>
 #include <vector>
 
-#include "headers/uhdm_types.h"
-#include "include/sv_vpi_user.h"
+#include <uhdm/uhdm_types.h>
+#include <uhdm/sv_vpi_user.h>
 
 std::string print_designs (const std::vector<vpiHandle>& designs) {
   std::string result;

--- a/tests/test_listener.cpp
+++ b/tests/test_listener.cpp
@@ -3,8 +3,8 @@
 #include <iostream>
 #include <stack>
 
-#include "headers/uhdm.h"
-#include "headers/vpi_listener.h"
+#include <uhdm/uhdm.h>
+#include <uhdm/vpi_listener.h>
 
 #include "test-util.h"
 

--- a/tests/test_process.cpp
+++ b/tests/test_process.cpp
@@ -1,13 +1,13 @@
 #include <iostream>
 
-#include "headers/uhdm.h"
-#include "headers/vpi_visitor.h"
+#include <uhdm/uhdm.h>
+#include <uhdm/vpi_visitor.h>
 
 #include "test-util.h"
 
 using namespace UHDM;
 
-#include "vpi_visitor.h"
+#include <uhdm/vpi_visitor.h>
 
 // This builds a simple design:
 // module m1;

--- a/tests/test_tf_call.cpp
+++ b/tests/test_tf_call.cpp
@@ -1,13 +1,13 @@
 #include <iostream>
 
-#include "headers/uhdm.h"
-#include "headers/vpi_visitor.h"
+#include <uhdm/uhdm.h>
+#include <uhdm/vpi_visitor.h>
 
 #include "test-util.h"
 
 using namespace UHDM;
 
-#include "vpi_visitor.h"
+#include <uhdm/vpi_visitor.h>
 
 std::vector<vpiHandle> build_designs (Serializer& s) {
   std::vector<vpiHandle> designs;

--- a/tests/vpi_get_test.cpp
+++ b/tests/vpi_get_test.cpp
@@ -2,11 +2,11 @@
 
 #include <iostream>
 
-#include "headers/uhdm.h"
-#include "headers/constant.h"
-#include "headers/vpi_uhdm.h"     // struct uhdm_handle
-#include "include/vhpi_user.h"    // vpi_user functions.
-#include "headers/uhdm_types.h"   // for uhdmconstant
+#include <uhdm/uhdm.h>
+#include <uhdm/constant.h>
+#include <uhdm/vpi_uhdm.h>     // struct uhdm_handle
+#include <uhdm/vhpi_user.h>    // vpi_user functions.
+#include <uhdm/uhdm_types.h>   // for uhdmconstant
 
 #include <stdlib.h>
 

--- a/tests/vpi_value_conversion_test.cpp
+++ b/tests/vpi_value_conversion_test.cpp
@@ -3,8 +3,8 @@
 #include <iostream>
 #include <memory>
 
-#include "headers/vpi_uhdm.h"     // struct uhdm_handle
-#include "include/vhpi_user.h"    // vpi_user functions.
+#include <uhdm/vpi_uhdm.h>     // struct uhdm_handle
+#include <uhdm/vhpi_user.h>    // vpi_user functions.
 
 
 #include <stdlib.h>

--- a/util/uhdm-dump.cpp
+++ b/util/uhdm-dump.cpp
@@ -34,10 +34,10 @@
 #  include <unistd.h>
 #endif
 
-#include "headers/uhdm.h"
-#include "headers/vpi_listener.h"
-#include "headers/vpi_visitor.h"
-#include "headers/ElaboratorListener.h"
+#include <uhdm/uhdm.h>
+#include <uhdm/vpi_listener.h>
+#include <uhdm/vpi_visitor.h>
+#include <uhdm/ElaboratorListener.h>
 
 using namespace UHDM;
 

--- a/util/uhdm-hier.cpp
+++ b/util/uhdm-hier.cpp
@@ -33,8 +33,8 @@
 #include <unistd.h>
 #endif
 
-#include "headers/uhdm.h"
-#include "headers/vpi_listener.h"
+#include <uhdm/uhdm.h>
+#include <uhdm/vpi_listener.h>
 
 using namespace UHDM;
 


### PR DESCRIPTION
**DON'T MERGE INTO SURELOG YET**



This removes the arbitrary distinction between relatively
meaningless names header/ and include/

Adapt all code that used the previous paths in their includes
to point to the new location.

Install location is presumed to be a 'system location', i.e. the distributed includes are used in angled brackets,
such as `#include <uhdm/uhdm.h>`

This likely cause one-time disruption for current users that directly included things from `uhdm/headers/foo.h` as these are now in `uhdm/foo.h`; currently the user-base is small enough to be a limited disruption.

While at it, install also the UHDM.capnp in `$PREFIX/lib/uhdm`
for other tools using different languages to pick up just the
schema.

Fixes #484

Signed-off-by: Henner Zeller <h.zeller@acm.org>