### PR TITLE
Prepare installation of headers in single location.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,8 +161,7 @@ endforeach(src_file ${uhdm-GENERATED_SRC})
 add_library(uhdm STATIC ${uhdm-GENERATED_SRC})
 set_target_properties(uhdm PROPERTIES PUBLIC_HEADER ${CMAKE_CURRENT_BINARY_DIR}/headers/uhdm.h)
 target_include_directories(uhdm PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>  # finding include/
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>  # finding headers/
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/headers>
   $<INSTALL_INTERFACE:include/uhdm/include>
   $<INSTALL_INTERFACE:include/uhdm>
@@ -267,7 +266,7 @@ install(
   TARGETS uhdm capnp kj uhdm-dump uhdm-hier
   ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/uhdm
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/include/uhdm)
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/
         DESTINATION ${CMAKE_INSTALL_PREFIX}/include/uhdm/include)
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/headers/
         DESTINATION ${CMAKE_INSTALL_PREFIX}/include/uhdm/headers/)

--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -59,6 +59,7 @@ proc exec_path {} {
 
 file mkdir [codegen_base]/src
 file mkdir [codegen_base]/headers
+file mkdir [codegen_base]/include
 
 source [exec_path]/file_utils.tcl
 source [exec_path]/pdict.tcl
@@ -1596,6 +1597,11 @@ proc generate_code { models } {
 
     # uhdm_vpi_user
     file_copy_if_change "[project_path]/templates/uhdm_vpi_user.h" "[codegen_base]/headers/uhdm_vpi_user.h"
+
+    # All the files from the include dir
+    file_copy_if_change "[project_path]/include/sv_vpi_user.h" "[codegen_base]/include/sv_vpi_user.h"
+    file_copy_if_change "[project_path]/include/vhpi_user.h" "[codegen_base]/include/vhpi_user.h"
+    file_copy_if_change "[project_path]/include/vpi_user.h" "[codegen_base]/include/vpi_user.h"
 
     # SymbolFactory.h
     file_copy_if_change "[project_path]/templates/SymbolFactory.h" "[codegen_base]/headers/SymbolFactory.h"


### PR DESCRIPTION
**DON'T MERGE INTO SURELOG YET** (that actually also requires fixing #483)

Right now, we still in stall in $PREFIX/include/uhdm/include
and $PREFIX/include/uhdm/headers, but this is the
preparation to do that all from the build/ directory.

Issues #484

Signed-off-by: Henner Zeller <h.zeller@acm.org>