### PR TITLE
Disable garbage collect test for now.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,7 @@ if (UHDM_BUILD_TESTS)
     tests/vpi_value_conversion_test.cpp
     tests/testErrorHandler.cpp
     tests/test_classes.cpp
-    tests/test_garbage_collect.cpp
+    #tests/test_garbage_collect.cpp  # disabled. Has use-after-delete issue.
   )
 endif()
 


### PR DESCRIPTION
There is some use-after-delete or similar issue going
on; since this is only used in the context of #480,
disable for now.

Signed-off-by: Henner Zeller <h.zeller@acm.org>