### PR TITLE
Move invocation of capnproto tool out of model_gen.tcl to build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,22 +76,16 @@ else()
 
 endif()
 
-# model_gen generated
-set(model-GENERATED_SRC ${CMAKE_CURRENT_BINARY_DIR}/src/UHDM.capnp.h
-                        ${CMAKE_CURRENT_BINARY_DIR}/src/UHDM.capnp.c++)
-
 # All the files the generator depends on.
 file(GLOB yaml_SRC ${PROJECT_SOURCE_DIR}/model/*.yaml)
 
 file(GLOB templates_SRC ${PROJECT_SOURCE_DIR}/templates/*.h
      ${PROJECT_SOURCE_DIR}/templates/*.cpp)
 
-foreach(header_file ${model-GENERATED_SRC})
-  set_source_files_properties(${header_file} PROPERTIES GENERATED TRUE)
-endforeach(header_file ${model-GENERATED_SRC})
-add_custom_target(GenerateCode DEPENDS ${model-GENERATED_SRC})
+set(model-GENERATED_UHDM ${CMAKE_CURRENT_BINARY_DIR}/src/UHDM.capnp)
+set_source_files_properties(${model-GENERATED_UHDM} PROPERTIES GENERATED TRUE)
 add_custom_command(
-  OUTPUT ${model-GENERATED_SRC}
+  OUTPUT ${model-GENERATED_UHDM}
   COMMAND tclsh ${PROJECT_SOURCE_DIR}/model_gen/model_gen.tcl
           ${PROJECT_SOURCE_DIR}/model/models.lst ${CMAKE_CURRENT_BINARY_DIR}
           ${CMAKE_CURRENT_BINARY_DIR}
@@ -103,6 +97,20 @@ add_custom_command(
           ${PROJECT_SOURCE_DIR}/templates/UHDM.capnp
           ${yaml_SRC}
           ${templates_SRC})
+
+set(model-GENERATED_SRC ${CMAKE_CURRENT_BINARY_DIR}/src/UHDM.capnp.h
+                        ${CMAKE_CURRENT_BINARY_DIR}/src/UHDM.capnp.c++)
+foreach(header_file ${model-GENERATED_SRC})
+  set_source_files_properties(${header_file} PROPERTIES GENERATED TRUE)
+endforeach(header_file ${model-GENERATED_SRC})
+
+set(CAPNP_DIR ${CMAKE_CURRENT_BINARY_DIR}/third_party/capnproto/c++/src/capnp)
+
+add_custom_command(
+  OUTPUT ${model-GENERATED_SRC}
+  COMMAND ${CAPNP_DIR}/capnp compile -o${CAPNP_DIR}/capnpc-c++ ${model-GENERATED_UHDM}
+  DEPENDS capnpc capnpc_cpp ${model-GENERATED_UHDM})
+add_custom_target(GenerateCode DEPENDS ${model-GENERATED_SRC})
 
 set(uhdm-GENERATED_SRC
     ${CMAKE_CURRENT_BINARY_DIR}/src/ExprEval.cpp

--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -1573,24 +1573,7 @@ proc generate_code { models } {
     set_content_if_change "[codegen_base]/src/vpi_user.cpp" $vpi_user
 
     # UHDM.capnp
-    if {[write_capnp $capnp_schema_all $capnp_root_schema]
-        || ![file exists "[codegen_base]/src/UHDM.capnp.h"]} {
-        log "Generating Capnp schema..."
-        file delete -force [codegen_base]/src/UHDM.capnp.*
-        set capnp_path [find_file $working_dir "capnpc-c++$exeext"]
-        puts "capnp_path = $capnp_path"
-        set capnp_path [file dirname $capnp_path]
-
-        if { ($tcl_platform(platform) == "windows") && (![info exists ::env(MSYSTEM)]) } {
-            exec -ignorestderr cmd /c "set PATH=$capnp_path;%PATH%; && cd /d [codegen_base]/src && $capnp_path/capnp.exe compile -oc++ UHDM.capnp"
-        } else {
-            if { $tcl_platform(platform) == "windows" } {
-                exec -ignorestderr sh -c "export PATH=\$(cygpath -u -a $capnp_path):\$PATH; $capnp_path/capnp compile -oc++:. [codegen_base]/src/UHDM.capnp"
-            } else {
-                exec -ignorestderr sh -c "export PATH=$capnp_path:\$PATH; $capnp_path/capnp compile -oc++:. [codegen_base]/src/UHDM.capnp"
-            }
-        }
-    }
+    write_capnp $capnp_schema_all $capnp_root_schema
 
     # BaseClass.h
     file_copy_if_change "[project_path]/templates/BaseClass.h" "[codegen_base]/headers/BaseClass.h"


### PR DESCRIPTION
Invoking the capnproto tool is fragile in the tcl-script as it has
to do all the platform specific things that are otherwise nicer
solved in cmake.

Signed-off-by: Henner Zeller <h.zeller@acm.org>