### PR TITLE
Issue #817 Use Python as build scripting tool

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
       with:
         msystem: MSYS
         update: true
-        install: make cmake ninja gcc
+        install: make cmake ninja gcc python
       env:
         MSYS2_PATH_TYPE: inherit
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
+# Environment cache folders & files
+__pycache__
+.vs
+.vscode
+*.user
+
+# Build directories
 build
+out
+CMakeBuilds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,12 +18,16 @@ option(
   "Building with clang++ and libc++(in Linux). To enable with: -DWITH_LIBCXX=On"
   On)
 option(UHDM_BUILD_TESTS "Enable testing." ON)
+option(WITH_PYTHON_GENERATOR "Use Python generator instead of TCL." OFF)
 
 project(UHDM)
 
 # NOTE: Policy changes has to happen before adding any subprojects
 cmake_policy(SET CMP0091 NEW)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+message(STATUS "Python3_EXECUTABLE = ${Python3_EXECUTABLE}")
 
 set(BUILD_TESTING OFF CACHE BOOL "Don't build capnproto tests")
 add_subdirectory(third_party/capnproto EXCLUDE_FROM_ALL)
@@ -47,7 +51,7 @@ if(MSVC)
       "${CMAKE_CXX_FLAGS_DEBUG} ${TCMALLOC_COMPILE_OPTIONS} /W3 /bigobj ${MY_CXX_WARNING_FLAGS}"
   )
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
-      "${CMAKE_CXX_FLAGS_RELEASE} ${TCMALLOC_COMPILE_OPTIONS} /W3 /bigobj ${MY_CXX_WARNING_FLAGS}"
+      "${CMAKE_CXX_FLAGS_RELEASE} ${TCMALLOC_COMPILE_OPTIONS} /Zi /W3 /bigobj ${MY_CXX_WARNING_FLAGS}"
   )
   set(CMAKE_CXX_FLAGS_RELEASE
       "${CMAKE_CXX_FLAGS_RELEASE} ${TCMALLOC_COMPILE_OPTIONS} /W3 /bigobj ${MY_CXX_WARNING_FLAGS}"
@@ -62,7 +66,9 @@ else()
   set(CMAKE_CXX_FLAGS_DEBUG
       "${CMAKE_CXX_FLAGS_DEBUG} ${TCMALLOC_COMPILE_OPTIONS} -Wall -O0 -g ${MSYS_COMPILE_OPTIONS} ${MY_CXX_WARNING_FLAGS}"
   )
-
+  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
+      "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${TCMALLOC_COMPILE_OPTIONS} -Wall -O3 -g ${MSYS_COMPILE_OPTIONS} ${MY_CXX_WARNING_FLAGS}"
+  )
   set(CMAKE_CXX_FLAGS_RELEASE
       "${CMAKE_CXX_FLAGS_RELEASE} ${TCMALLOC_COMPILE_OPTIONS} -Wall -O3 -DNDEBUG ${MSYS_COMPILE_OPTIONS} ${MY_CXX_WARNING_FLAGS}"
   )
@@ -81,25 +87,38 @@ endif()
 
 # All the files the generator depends on.
 file(GLOB yaml_SRC ${PROJECT_SOURCE_DIR}/model/*.yaml)
-
 file(GLOB templates_SRC ${PROJECT_SOURCE_DIR}/templates/*.h
      ${PROJECT_SOURCE_DIR}/templates/*.cpp)
 
 set(model-GENERATED_UHDM ${GENDIR}/src/UHDM.capnp)
 set_source_files_properties(${model-GENERATED_UHDM} PROPERTIES GENERATED TRUE)
-add_custom_command(
-  OUTPUT ${model-GENERATED_UHDM}
-  COMMAND tclsh ${PROJECT_SOURCE_DIR}/model_gen/model_gen.tcl
-          ${PROJECT_SOURCE_DIR}/model/models.lst ${CMAKE_CURRENT_BINARY_DIR}
-          ${GENDIR}
-  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-  DEPENDS ${PROJECT_SOURCE_DIR}/model_gen/model_gen.tcl
-          ${PROJECT_SOURCE_DIR}/model_gen/generate_elaborator.tcl
-          ${PROJECT_SOURCE_DIR}/model_gen/parse_model.tcl
-          ${PROJECT_SOURCE_DIR}/model/models.lst
-          ${PROJECT_SOURCE_DIR}/templates/UHDM.capnp
-          ${yaml_SRC}
-          ${templates_SRC})
+
+if (WITH_PYTHON_GENERATOR)
+  file(GLOB py_SRC ${PROJECT_SOURCE_DIR}/scripts/*.py)
+  add_custom_command(
+    OUTPUT ${model-GENERATED_UHDM}
+    COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/generate.py --source-dirpath=${UHDM_SOURCE_DIR} -output-dirpath=${GENDIR}
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    DEPENDS ${PROJECT_SOURCE_DIR}/model/models.lst
+            ${PROJECT_SOURCE_DIR}/templates/UHDM.capnp
+            ${py_SRC}
+            ${yaml_SRC}
+            ${templates_SRC})
+else()
+  add_custom_command(
+    OUTPUT ${model-GENERATED_UHDM}
+    COMMAND tclsh ${PROJECT_SOURCE_DIR}/model_gen/model_gen.tcl
+            ${PROJECT_SOURCE_DIR}/model/models.lst ${CMAKE_CURRENT_BINARY_DIR}
+            ${GENDIR}
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    DEPENDS ${PROJECT_SOURCE_DIR}/model_gen/model_gen.tcl
+            ${PROJECT_SOURCE_DIR}/model_gen/generate_elaborator.tcl
+            ${PROJECT_SOURCE_DIR}/model_gen/parse_model.tcl
+            ${PROJECT_SOURCE_DIR}/model/models.lst
+            ${PROJECT_SOURCE_DIR}/templates/UHDM.capnp
+            ${yaml_SRC}
+            ${templates_SRC})
+endif()
 
 set(model-GENERATED_SRC ${GENDIR}/src/UHDM.capnp.h
                         ${GENDIR}/src/UHDM.capnp.c++)

--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -138,7 +138,7 @@ proc printMethods { classname type vpi card {real_type ""} } {
     while (parent) {
       const BaseClass* actual_parent = parent->VpiParent();
       if (parent->UhdmType() == uhdmdesign) break;
-      if (parent->UhdmType() == uhdmpackage || parent->UhdmType() == uhdmclass_defn) column = true;
+      if ((parent->UhdmType() == uhdmpackage) || (parent->UhdmType() == uhdmclass_defn)) column = true;
       const std::string\\& name = (!parent->VpiName().empty()) ? parent->VpiName() : parent->VpiDefName();
       UHDM_OBJECT_TYPE parent_type = (parent != nullptr) ? parent->UhdmType() : uhdmunsupported_stmt;
       UHDM_OBJECT_TYPE actual_parent_type = (actual_parent != nullptr) ? actual_parent->UhdmType() : uhdmunsupported_stmt;
@@ -171,7 +171,7 @@ proc printMethods { classname type vpi card {real_type ""} } {
       unsigned int index = names.size() -1;
       while(1) {
         fullName += names\[index\];
-        if (index > 0) fullName += (column) ? \"::\" : \".\";
+        if (index > 0) fullName += column ? \"::\" : \".\";
         if (index == 0) break;
         index--;
       }
@@ -274,7 +274,7 @@ proc printIterateBody { name classname vpi card } {
     set vpi_iterate_body ""
     if {$card == "any"} {
         append vpi_iterate_body "
-  if (handle->type == uhdm${classname} \\&\\& type == $vpi) {
+  if ((handle->type == uhdm${classname}) \\&\\& (type == $vpi)) {
     if ((($classname*)(object))->[string toupper ${name} 0 0]())
       return NewHandle(uhdm${name}, (($classname*)(object))->[string toupper ${name} 0 0]());
     else return 0;
@@ -379,7 +379,7 @@ proc printGetHandleBody { classname type vpi object card } {
             set casted_object2 "(($classname*)(object))"
         }
         append vpi_get_handle_body "
-  if (handle->type == uhdm${classname} \\&\\& type == $vpi) {
+  if ((handle->type == uhdm${classname}) \\&\\& (type == $vpi)) {
      if ($casted_object1->[string toupper ${object} 0 0]()))
        return NewHandle($casted_object1->[string toupper ${object} 0 0]())->UhdmType(), $casted_object2->[string toupper ${object} 0 0]());
      else return 0;
@@ -393,7 +393,7 @@ proc printGetStrVisitor {classname type vpi card} {
     set vpi_get_str_body ""
     if {($card == 1) && ($type == "string") && ($vpi != "vpiFile")} {
         append vpi_get_str_body "    if (const char* s = vpi_get_str($vpi, obj_h))
-      stream_indent(out, indent) << \"|$vpi:\" << s << \"\\n\";
+      stream_indent(out, indent) << \"|$vpi:\" << s << std::endl;
 "
     }
     return $vpi_get_str_body
@@ -420,7 +420,7 @@ proc printGetVisitor {classname type vpi card} {
 "
     } elseif {($card == 1) && ($type != "string") && ($vpi != "vpiLineNo") && ($vpi != "vpiColumnNo")  && ($vpi != "vpiEndLineNo") && ($vpi != "vpiEndColumnNo") && ($vpi != "vpiType")} {
         append vpi_get_body "    if (const int n = vpi_get($vpi, obj_h))
-      stream_indent(out, indent) << \"|$vpi:\" << n << \"\\n\";
+      stream_indent(out, indent) << \"|$vpi:\" << n << std::endl;
 "
     }
     return $vpi_get_body
@@ -436,7 +436,7 @@ proc printGetStrBody {classname type vpi card} {
     if {$card == 1 && ($type == "string")} {
         if {$vpi == "vpiFullName"} {
             append vpi_get_str_body "
-  if (handle->type == uhdm${classname} \\&\\& property == $vpi) {
+  if ((handle->type == uhdm${classname}) \\&\\& (property == $vpi)) {
     const $classname* const o = (const $classname*)(obj);
     return (o->[string toupper ${vpi} 0 0]().empty() || o->[string toupper ${vpi} 0 0]() == o->VpiName())
         ? 0
@@ -444,7 +444,7 @@ proc printGetStrBody {classname type vpi card} {
   }"
         } else {
             append vpi_get_str_body "
-  if (handle->type == uhdm${classname} \\&\\& property == $vpi) {
+  if ((handle->type == uhdm${classname}) \\&\\& (property == $vpi)) {
     const $classname* const o = (const $classname*)(obj);
     return (PLI_BYTE8*) (o->[string toupper ${vpi} 0 0]().empty() ? 0 : o->[string toupper ${vpi} 0 0]().c_str());
   }"
@@ -549,15 +549,15 @@ proc printVpiVisitor {classname vpi card} {
     global VISITOR_RELATIONS
 
     set vpi_visitor ""
-    if ![info exist VISITOR_RELATIONS($classname)] {
-        set vpi_visitor "    vpiHandle itr;
-"
-    } else {
-        if ![regexp "vpiHandle itr;" $VISITOR_RELATIONS($classname)] {
-            set vpi_visitor "    vpiHandle itr;
-"
-        }
-    }
+#    if ![info exist VISITOR_RELATIONS($classname)] {
+#        set vpi_visitor "    vpiHandle itr;
+#"
+#    } else {
+#        if ![regexp "vpiHandle itr;" $VISITOR_RELATIONS($classname)] {
+#            set vpi_visitor "    vpiHandle itr;
+#"
+#        }
+#    }
 
     if {($vpi == "vpiParent") && ($classname !="part_select")} {
         return
@@ -577,7 +577,7 @@ proc printVpiVisitor {classname vpi card} {
         # Prevent loop in Standard VPI
         if {($vpi != "vpiModule") && ($vpi != "vpiInterface")} {
             append vpi_visitor "    itr = vpi_handle($vpi,obj_h);
-    visit_object(itr, subobject_indent, \"$vpi\", visited, out $shallowVisit);
+    visit_object(itr, subobject_indent, \"$vpi\", visited, out$shallowVisit);
     release_handle(itr);
 "
         }
@@ -590,7 +590,7 @@ proc printVpiVisitor {classname vpi card} {
         if {$vpi != "vpiUse"} {
             append vpi_visitor "    itr = vpi_iterate($vpi,obj_h);
     while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, \"$vpi\", visited, out $shallowVisit);
+      visit_object(obj, subobject_indent, \"$vpi\", visited, out$shallowVisit);
       release_handle(obj);
     }
     release_handle(itr);
@@ -1246,8 +1246,8 @@ proc generate_code { models } {
             regsub -all {<DISABLE_OBJECT_FACTORY>} $template "#if 0 // This class cannot be instantiated" template
             regsub -all {<END_DISABLE_OBJECT_FACTORY>} $template "#endif" template
         } else {
-            regsub -all {<FINAL_CLASS>} $template "final" template
-            regsub -all {<FINAL_DESTRUCTOR>} $template "final" template
+            regsub -all {<FINAL_CLASS>} $template " final" template
+            regsub -all {<FINAL_DESTRUCTOR>} $template " final" template
             regsub -all {<VIRTUAL>} $template "virtual " template
             regsub -all {<OVERRIDE_OR_FINAL>}  $template "final" template
             regsub -all {<DISABLE_OBJECT_FACTORY>} $template "" template
@@ -1291,7 +1291,7 @@ proc generate_code { models } {
 
         if {$modeltype == "class_def"} {
             # DeepClone() not implemented for class_def; just declare to narrow the covariant return type.
-            append methods($classname) "\n  ${classname}* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener, BaseClass* parent) const override = 0;\n"
+            append methods($classname) "\n  virtual ${classname}* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener, BaseClass* parent) const override = 0;\n"
         } else {
             # Builtin properties do not need to be specified in each models
             # Builtins: "vpiParent, Parent type, vpiFile, Id" method and field
@@ -1305,9 +1305,9 @@ proc generate_code { models } {
             append methods($classname) [printMethods $classname "unsigned int" uhdmId 1]
             append members($classname) [printMembers "unsigned int" uhdmId 1]
             if [regexp {_call} ${classname}] {
-                append methods($classname) "\n  tf_call* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener, BaseClass* parent) const override;\n"
+                append methods($classname) "\n  virtual tf_call* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener, BaseClass* parent) const override;\n"
             } else {
-                append methods($classname) "\n  ${classname}* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener, BaseClass* parent) const override;\n"
+                append methods($classname) "\n  virtual ${classname}* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener, BaseClass* parent) const override;\n"
             }
             append vpi_handle_body($classname) [printGetHandleBody $classname BaseClass vpiParent vpiParent 1]
             lappend capnp_schema($classname) [list vpiParent UInt64]
@@ -1506,7 +1506,7 @@ proc generate_code { models } {
 
         if {($type_specified == 0) && ($modeltype == "obj_def")} {
             set vpiclasstype [makeVpiName $classname]
-            append methods($classname) "\n  unsigned int VpiType() const final { return $vpiclasstype; }\n"
+            append methods($classname) "\n  virtual unsigned int VpiType() const final { return $vpiclasstype; }\n"
             lappend vpi_get_body_inst($classname) [list $classname "unsigned int" vpiType 1]
 
         }

--- a/scripts/ElaboratorListener_h.py
+++ b/scripts/ElaboratorListener_h.py
@@ -1,0 +1,203 @@
+import config
+import file_utils
+
+
+def _generate_module_listeners(models):
+    listeners = []
+    classname = 'module'
+    while classname:
+        model = models[classname]
+
+        for key, value in model.allitems():
+            if key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
+                name = value.get('name')
+                type = value.get('type')
+                card = value.get('card')
+
+                cast = 'any' if key == 'group_ref' else type
+                Cast = cast[:1].upper() + cast[1:]
+                method = name[:1].upper() + name[1:]
+
+                if (card == 'any') and not method.endswith('s'):
+                    method += 's'
+
+                if card == '1':
+                    listeners.append(f'if (auto obj = defMod->{method}()) {{')
+                    listeners.append( '  auto* stmt = obj->DeepClone(serializer_, this, defMod);')
+                    listeners.append( '  stmt->VpiParent(inst);')
+                    listeners.append(f'  inst->{method}(stmt);')
+                    listeners.append( '}')
+
+                elif method in ['Task_funcs']:
+                    listeners.append(f'if (auto vec = defMod->{method}()) {{')
+                    listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
+                    listeners.append(f'  inst->{method}(clone_vec);')
+                    listeners.append( '  for (auto obj : *vec) {')
+                    listeners.append( '    enterTask_func(obj, defMod, nullptr, nullptr);')
+                    listeners.append( '    auto* tf = obj->DeepClone(serializer_, this, inst);')
+                    listeners.append( '    ComponentMap& funcMap = std::get<2>(instStack_.at(instStack_.size()-2).second);')
+                    listeners.append( '    funcMap.insert(std::make_pair(tf->VpiName(), tf));')
+                    listeners.append( '    leaveTask_func(obj, defMod, nullptr, nullptr);')
+                    listeners.append( '    tf->VpiParent(inst);')
+                    listeners.append( '    clone_vec->push_back(tf);')
+                    listeners.append( '  }')
+                    listeners.append( '}')
+
+                elif method in ['Cont_assigns', 'Gen_scope_arrays']:
+                    # We want to deep clone existing instance cont assign to perform binding
+                    listeners.append(f'if (auto vec = inst->{method}()) {{')
+                    listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
+                    listeners.append(f'  inst->{method}(clone_vec);')
+                    listeners.append( '  for (auto obj : *vec) {')
+                    listeners.append( '    auto* stmt = obj->DeepClone(serializer_, this, inst);')
+                    listeners.append( '    stmt->VpiParent(inst);')
+                    listeners.append( '    clone_vec->push_back(stmt);')
+                    listeners.append( '  }')
+                    listeners.append( '}')
+                    # We also want to clone the module cont assign
+                    listeners.append(f'if (auto vec = defMod->{method}()) {{')
+                    listeners.append(f'  if (inst->{method}() == nullptr) {{')
+                    listeners.append(f'    auto clone_vec = serializer_->Make{Cast}Vec();')
+                    listeners.append(f'    inst->{method}(clone_vec);')
+                    listeners.append( '  }')
+                    listeners.append(f'  auto clone_vec = inst->{method}();')
+                    listeners.append( '  for (auto obj : *vec) {')
+                    listeners.append( '    auto* stmt = obj->DeepClone(serializer_, this, inst);')
+                    listeners.append( '    stmt->VpiParent(inst);')
+                    listeners.append( '    clone_vec->push_back(stmt);')
+                    listeners.append( '  }')
+                    listeners.append( '}')
+
+                elif method in ['Typespecs']:
+                    # We don't want to override the elaborated instance ports by the module def ports, same for nets, params and param_assigns
+                    listeners.append(f'if (auto vec = defMod->{method}()) {{')
+                    listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
+                    listeners.append(f'  inst->{method}(clone_vec);')
+                    listeners.append( '  for (auto obj : *vec) {')
+                    listeners.append( '    if (uniquifyTypespec()) {')
+                    listeners.append( '      auto* stmt = obj->DeepClone(serializer_, this, inst);')
+                    listeners.append( '      stmt->VpiParent(inst);')
+                    listeners.append( '      clone_vec->push_back(stmt);')
+                    listeners.append( '    } else {')
+                    listeners.append( '      auto* stmt = obj;')
+                    listeners.append( '      clone_vec->push_back(stmt);')
+                    listeners.append( '    }')
+                    listeners.append( '  }')
+                    listeners.append( '}')
+
+                elif method not in ['Ports', 'Nets', 'Parameters', 'Param_assigns']:
+                    # We don't want to override the elaborated instance ports by the module def ports, same for nets, params and param_assigns
+                    listeners.append(f'if (auto vec = defMod->{method}()) {{')
+                    listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
+                    listeners.append(f'  inst->{method}(clone_vec);')
+                    listeners.append( '  for (auto obj : *vec) {')
+                    listeners.append( '    auto* stmt = obj->DeepClone(serializer_, this, inst);')
+                    listeners.append( '    stmt->VpiParent(inst);')
+                    listeners.append( '    clone_vec->push_back(stmt);')
+                    listeners.append( '  }')
+                    listeners.append( '}')
+
+                elif method in ['Ports']:
+                    listeners.append(f'if (auto vec = inst->{method}()) {{')
+                    listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
+                    listeners.append(f'  inst->{method}(clone_vec);')
+                    listeners.append( '  for (auto obj : *vec) {')
+                    listeners.append( '    auto* stmt = obj->DeepClone(serializer_, this, inst);')
+                    listeners.append( '    stmt->VpiParent(inst);')
+                    listeners.append( '    clone_vec->push_back(stmt);')
+                    listeners.append( '  }')
+                    listeners.append( '}')
+
+        classname = models[classname]['extends']
+
+    return listeners
+
+
+def _generate_class_listeners(models):
+    listeners = []
+
+    for model in models.values():
+        modeltype = model.get('type')
+        if modeltype != 'obj_def':
+            continue
+
+        classname = model.get('name')
+        if classname != 'class_defn':
+            continue
+
+        while classname:
+            model = models[classname]
+
+            for key, value in model.allitems():
+                if key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
+                    name = value.get('name')
+                    type = value.get('type')
+                    card = value.get('card')
+
+                    cast = 'any' if key == 'group_ref' else type
+                    Cast = cast[:1].upper() + cast[1:]
+                    method = name[:1].upper() + name[1:]
+
+                    if (card == 'any') and not method.endswith('s'):
+                        method += 's'
+
+                    if card == '1':
+                        listeners.append(f'if (auto obj = cl->{method}()) {{')
+                        listeners.append( '  auto* stmt = obj->DeepClone(serializer_, this, cl);')
+                        listeners.append( '  stmt->VpiParent(cl);')
+                        listeners.append(f'  cl->{method}(stmt);')
+                        listeners.append( '}')
+
+                    elif method == 'Deriveds':
+                        # Don't deep clone
+                        listeners.append(f'if (auto vec = cl->{method}()) {{')
+                        listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
+                        listeners.append(f'  cl->{method}(clone_vec);')
+                        listeners.append( '  for (auto obj : *vec) {')
+                        listeners.append( '    auto* stmt = obj;')
+                        listeners.append( '    clone_vec->push_back(stmt);')
+                        listeners.append( '  }')
+                        listeners.append( '}')
+
+                    else:
+                        listeners.append(f'if (auto vec = cl->{method}()) {{')
+                        listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
+                        listeners.append(f'  cl->{method}(clone_vec);')
+                        listeners.append( '  for (auto obj : *vec) {')
+                        listeners.append( '    auto* stmt = obj->DeepClone(serializer_, this, cl);')
+                        listeners.append( '    stmt->VpiParent(cl);')
+                        listeners.append( '    clone_vec->push_back(stmt);')
+                        listeners.append( '  }')
+                        listeners.append( '}')
+
+            classname = models[classname]['extends']
+
+    return listeners
+
+
+def generate(models):
+    module_listeners = _generate_module_listeners(models)
+    class_listeners = _generate_class_listeners(models)
+
+    with open(config.get_template_filepath('ElaboratorListener.h'), 'r+t') as strm:
+        file_content = strm.read()
+
+    file_content = file_content.replace('<MODULE_ELABORATOR_LISTENER>', (' ' * 10) + ('\n' + (' ' * 10)).join(module_listeners))
+    file_content = file_content.replace('<CLASS_ELABORATOR_LISTENER>', (' ' * 4) + ('\n' + (' ' * 4)).join(class_listeners))
+    file_utils.set_content_if_changed(config.get_output_header_filepath('ElaboratorListener.h'), file_content)
+
+    return True
+
+
+def _main():
+    import loader
+
+    config.configure()
+
+    models = loader.load_models()
+    return generate(models)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if _main() else 1)

--- a/scripts/VpiListenerTracer_h.py
+++ b/scripts/VpiListenerTracer_h.py
@@ -1,0 +1,27 @@
+import config
+import file_utils
+import VpiListener_h
+
+def generate(models):
+    methods = VpiListener_h.get_methods(models, ' TRACE_ENTER; ', ' TRACE_LEAVE; ')
+
+    with open(config.get_template_filepath('VpiListenerTracer.h'), 'r+t') as strm:
+        file_content = strm.read()
+
+    file_content = file_content.replace('<VPI_LISTENER_TRACER_METHODS>', '\n'.join(methods))
+    file_utils.set_content_if_changed(config.get_output_header_filepath('VpiListenerTracer.h'), file_content)
+    return True
+
+
+def _main():
+    import loader
+
+    config.configure()
+
+    models = loader.load_models()
+    return generate(models)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if _main() else 1)

--- a/scripts/VpiListener_h.py
+++ b/scripts/VpiListener_h.py
@@ -1,0 +1,41 @@
+import config
+import file_utils
+
+
+def get_methods(models, enter, leave):
+    methods = []
+    for model in models.values():
+        if model['type'] != 'group_def':
+            classname = model['name']
+            Classname_ = classname[:1].upper() + classname[1:]
+
+            methods.append(f'    virtual void enter{Classname_}(const {classname}* object, const BaseClass* parent, vpiHandle handle, vpiHandle parentHandle) {{{enter}}}')
+            methods.append(f'    virtual void leave{Classname_}(const {classname}* object, const BaseClass* parent, vpiHandle handle, vpiHandle parentHandle) {{{leave}}}')
+            methods.append('')
+
+    return methods
+
+
+def generate(models):
+    methods = get_methods(models, '', '')
+
+    with open(config.get_template_filepath('VpiListener.h'), 'r+t') as strm:
+        file_content = strm.read()
+
+    file_content = file_content.replace('<VPI_LISTENER_METHODS>', '\n'.join(methods))
+    file_utils.set_content_if_changed(config.get_output_header_filepath('VpiListener.h'), file_content)
+    return True
+
+
+def _main():
+    import loader
+
+    config.configure()
+
+    models = loader.load_models()
+    return generate(models)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if _main() else 1)

--- a/scripts/capnp.py
+++ b/scripts/capnp.py
@@ -1,0 +1,124 @@
+import ctypes
+import os
+import platform
+import subprocess
+import sys
+
+import config
+import file_utils
+
+
+def _get_schema(type, vpi, card):
+    mapping = {
+      'string': 'UInt64',
+      'unsigned int': 'UInt64',
+      'int': 'Int64',
+      'any': 'Int64',
+      'bool': 'Bool',
+      'value': 'UInt64',
+      'delay': 'UInt64',
+    }
+
+    type = mapping.get(type, type)
+    if card == '1':
+        return (vpi, type)
+    elif card == 'any':
+        return (vpi, f'List({type})')
+    else:
+        return (None, None)
+
+
+def generate(models):
+    capnp_schema = {}
+    capnp_schema_all = []
+    capnpRootSchemaIndex = 2
+    capnp_root_schema = []
+
+    for model in models.values():
+        modeltype = model['type']
+        if modeltype == 'group_def':
+            continue
+
+        classname = model['name']
+        capnp_schema[classname] = []
+
+        Classname_ = classname[:1].upper() + classname[1:]
+        Classname = Classname_.replace('_', '')
+
+        if modeltype != 'class_def':
+            capnp_schema[classname].append(('vpiParent', 'UInt64'))
+            capnp_schema[classname].append(('uhdmParentType', 'UInt64'))
+            capnp_schema[classname].append(('vpiFile', 'UInt64'))
+            capnp_schema[classname].append(('vpiLineNo', 'UInt32'))
+            capnp_schema[classname].append(('vpiColumnNo', 'UInt16'))
+            capnp_schema[classname].append(('vpiEndLineNo', 'UInt32'))
+            capnp_schema[classname].append(('vpiEndColumnNo', 'UInt16'))
+            capnp_schema[classname].append(('uhdmId', 'UInt64'))
+
+            capnp_root_schema.append(f'  factory{Classname} @{capnpRootSchemaIndex} :List({Classname});')
+            capnpRootSchemaIndex += 1
+
+        for key, value in model.allitems():
+            if key == 'property':
+                if value.get('name') != 'type':
+                    vpi = value.get('vpi')
+                    type = value.get('type')
+                    card = value.get('card')
+                    capnp_schema[classname].append(_get_schema(type, vpi, card))
+
+            elif key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
+                name = value.get('name')
+                type = value.get('type')
+                card = value.get('card')
+
+                if (card == 'any') and not name.endswith('s'):
+                    name += 's'
+
+                name = name.replace('_', '')
+
+                obj_key = 'ObjIndexType' if key in ['class_ref', 'group_ref'] else 'UInt64'
+                capnp_schema[classname].append(_get_schema(obj_key, name, card))
+
+        if modeltype != 'class_def':
+            capnpIndex = 0
+            capnp_schema_all.append(f'struct {Classname} {{')
+            for name, type in capnp_schema[classname]:
+                if name and type:
+                    capnp_schema_all.append(f'  {name} @{capnpIndex} :{type};')
+                    capnpIndex += 1
+
+            # process baseclass recursively
+            baseclass = model['extends']
+            while baseclass:
+                for name, type in capnp_schema[baseclass]:
+                    if name and type:
+                        capnp_schema_all.append(f'  {name} @{capnpIndex} :{type};')
+                        capnpIndex += 1
+
+                baseclass = models[baseclass]['extends']
+
+            capnp_schema_all.append('}')
+            capnp_schema_all.append('')
+
+    with open(config.get_template_filepath('UHDM.capnp'), 'r+t') as strm:
+        file_content = strm.read()
+
+    file_content = file_content.replace('<CAPNP_SCHEMA>', '\n'.join(capnp_schema_all))
+    file_content = file_content.replace('<CAPNP_ROOT_SCHEMA>', '\n'.join(capnp_root_schema))
+    file_utils.set_content_if_changed(config.get_output_source_filepath('UHDM.capnp'), file_content)
+
+    return True
+
+
+def _main():
+    import loader
+
+    config.configure()
+
+    models = loader.load_models()
+    return generate(models)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if _main() else 1)

--- a/scripts/class_hierarchy.py
+++ b/scripts/class_hierarchy.py
@@ -1,0 +1,41 @@
+import config
+import file_utils
+from collections import defaultdict
+from collections import OrderedDict
+from io import StringIO
+
+
+def generate(models):
+    relationships = defaultdict(set)
+    for model in models.values():
+        if model['type'] not in [ 'group_def' ]:
+            thisclass = model['name']
+            baseclass = model.get('extends') or 'BaseClass'
+            relationships[baseclass].add(thisclass)
+
+    file_content = StringIO()
+    stack = [ ('BaseClass', 0) ]
+    while stack:
+        thisclass, indent = stack.pop()
+
+        file_content.write(' ' * indent)
+        file_content.write(thisclass)
+        file_content.write('\n')
+        stack.extend([ (subclass, indent + 2) for subclass in sorted(relationships.get(thisclass, set()), reverse=True) ])
+
+    file_utils.set_content_if_changed(config.get_output_header_filepath('class_hierarchy.txt'), file_content.getvalue())
+    return True
+
+
+def _main():
+    import loader
+
+    config.configure()
+
+    models = loader.load_models()
+    return generate(models)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if _main() else 1)

--- a/scripts/classes_h.py
+++ b/scripts/classes_h.py
@@ -1,0 +1,258 @@
+import os
+from collections import OrderedDict
+
+import config
+import file_utils
+
+
+def _print_group_headers(type, real_type):
+    return [ f'#include "{real_type}.h"' ] if type == 'any' else []
+
+
+def _print_methods(classname, type, vpi, card, real_type=''):
+    content = []
+    if type in ['string', 'value', 'delay']:
+        type = 'std::string'
+    if vpi == 'uhdmType':
+        type = 'UHDM_OBJECT_TYPE'
+
+    final = ''
+    virtual = ''
+    if vpi in ['vpiParent', 'uhdmParentType', 'uhdmType', 'vpiLineNo', 'vpiColumnNo', 'vpiEndLineNo', 'vpiEndColumnNo', 'vpiFile', 'vpiName', 'vpiDefName', 'uhdmId']:
+        final = ' final'
+        virtual = 'virtual '
+
+    check = ''
+    group_headers = []
+    if type == 'any':
+        check = f'if (!{real_type}GroupCompliant(data)) return false; '
+
+    Vpi_ = vpi[:1].upper() + vpi[1:]
+
+    if card == '1':
+        pointer = ''
+        const = ''
+        if type not in ['unsigned int', 'int', 'bool', 'std::string']:
+            pointer = '*'
+            const = 'const '
+
+        if type == 'std::string':
+            content.append(f'  {virtual}bool {Vpi_}(const {type}{pointer}& data){final};')
+            content.append(f'  {virtual}const {type}{pointer}& {Vpi_}() const{final};')
+        else:
+            content.append(f'  {virtual}{const}{type}{pointer} {Vpi_}() const{final} {{ return {vpi}_; }}')
+            if vpi == 'vpiParent':
+                content.append(f'  virtual bool {Vpi_}({type}{pointer} data) final {{ {check}{vpi}_ = data; if (data) uhdmParentType_ = data->UhdmType(); return true; }}')
+            else:
+                content.append(f'  {virtual}bool {Vpi_}({type}{pointer} data){final} {{ {check}{vpi}_ = data; return true; }}')
+    elif card == 'any':
+        content.append(f'  VectorOf{type}* {Vpi_}() const {{ return {vpi}_; }}')
+        content.append(f'  bool {Vpi_}(VectorOf{type}* data) {{ {check}{vpi}_ = data; return true; }}')
+
+    return content
+
+
+def _print_members(type, vpi, card):
+    content = []
+
+    if type in ['string', 'value', 'delay']:
+        type = 'std::string'
+
+    if card == '1':
+        pointer = ''
+        default_assignment = '0'
+        if type not in ['unsigned int', 'int', 'bool', 'std::string']:
+            pointer = '*'
+            default_assignment = 'nullptr'
+
+        if type == 'std::string':
+            content.append(f'  SymbolFactory::ID {vpi}_ = 0;')
+        else:
+            content.append(f'  {type}{pointer} {vpi}_ = {default_assignment};')
+
+    elif card == 'any':
+        content.append(f'  VectorOf{type}* {vpi}_ = nullptr;')
+
+    return content
+
+
+members = {}
+def _generate_group_checker(model, models, templates):
+    groupname = model.get('name')
+    modeltype = model.get('type')
+
+    files = {
+        'group_header.h': config.get_output_header_filepath(f'{groupname}.h'),
+        'group_header.cpp': config.get_output_source_filepath(f'{groupname}.cpp'),
+    }
+
+    members[groupname] = set()
+    for input, output in files.items():
+        checktype = set()
+        for key, value in model.allitems():
+            if key in ['obj_ref', 'class_ref', 'group_ref'] and value:
+                name = value.get('name')
+                members[groupname].add(name)
+
+                if key == 'group_ref':
+                    if name not in members:
+                        print(f'ERROR: Group {name} unknown while processing group {groupname}')
+                    else:
+                        checktype.update([f'(uhdmtype != uhdm{member})' for member in members[name]])
+                else:
+                    checktype.add(f'(uhdmtype != uhdm{name})')
+
+                if key == 'class_ref':
+                    checktype.update([f'(uhdmtype != uhdm{subclass})' for subclass in models[name]['subclasses']])
+
+        prefix = ' ' * 6
+        checktype = ' &&\n'.join([ prefix + ct for ct in sorted(checktype) ])
+
+        file_content = templates[input]
+        file_content = file_content.replace('<GROUPNAME>', groupname)
+        file_content = file_content.replace('<UPPER_GROUPNAME>', groupname.upper())
+        file_content = file_content.replace('<CHECKTYPE>', checktype)
+        file_utils.set_content_if_changed(output, file_content)
+
+    return True
+
+
+def _generate_one_class(model, models, templates):
+    file_content = templates['class_header.h']
+    classname = model['name']
+    modeltype = model['type']
+    group_headers = set()
+    methods = []
+    members = []
+    forward_declares = set()
+
+    Classname_ = classname[:1].upper() + classname[1:]
+    Classname = Classname_.replace('_', '')
+
+    if modeltype == 'class_def':
+        # DeepClone() not implemented for class_def; just declare to narrow the covariant return type.
+        methods.append(f'  virtual {classname}* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener, BaseClass* parent) const override = 0;')
+    else:
+        # Builtin properties do not need to be specified in each models
+        # Builtins: "vpiParent, Parent type, vpiFile, Id" method and field
+        methods.extend(_print_methods(classname, 'BaseClass', 'vpiParent', '1'))
+        members.extend(_print_members('BaseClass', 'vpiParent', '1'))
+
+        methods.extend(_print_methods(classname, 'unsigned int', 'uhdmParentType', '1'))
+        members.extend(_print_members('unsigned int', 'uhdmParentType', '1'))
+
+        methods.extend(_print_methods(classname, 'string','vpiFile', '1'))
+        members.extend(_print_members('string', 'vpiFile', '1'))
+
+        methods.extend(_print_methods(classname, 'unsigned int', 'uhdmId', '1'))
+        members.extend(_print_members('unsigned int', 'uhdmId', '1'))
+
+        if '_call' in classname:
+            methods.append(f'  virtual tf_call* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener, BaseClass* parent) const override;')
+        else:
+            methods.append(f'  virtual {classname}* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener, BaseClass* parent) const override;')
+
+    type_specified = False
+    for key, value in model.allitems():
+        if key == 'property':
+            name = value.get('name')
+            vpi = value.get('vpi')
+            type = value.get('type')
+            card = value.get('card')
+
+            Vpi = vpi[:1].upper() + vpi[1:]
+
+            if name == 'type':
+                type_specified = True
+                methods.append(f'  {type} {Vpi}() const final {{ return {value.get("vpiname")}; }}')
+            else: # properties are already defined in vpi_user.h, no need to redefine them
+                methods.extend(_print_methods(classname, type, vpi, card))
+                members.extend(_print_members(type, vpi, card))
+
+        elif key == 'extends' and value:
+            file_content = file_content.replace('<EXTENDS>', value)
+
+        elif key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
+            name = value.get('name')
+            vpi = value.get('vpi')
+            type = value.get('type')
+            card = value.get('card')
+
+            if (card == 'any') and not name.endswith('s'):
+                name += 's'
+            real_type = type
+
+            if key == 'group_ref':
+                type = 'any'
+
+            if type != 'any' and card == '1':
+                forward_declares.add(f'class {type};')
+
+            group_headers.update(_print_group_headers(type, real_type))
+            methods.extend(_print_methods(classname, type, name, card, real_type))
+            members.extend(_print_members(type, name, card))
+
+    if not type_specified and (modeltype == 'obj_def'):
+        vpiclasstype = config.make_vpi_name(classname)
+        methods.append(f'  virtual unsigned int VpiType() const final {{ return {vpiclasstype}; }}')
+
+    if modeltype == 'class_def':
+        file_content = file_content.replace('<FINAL_CLASS>', '')
+        file_content = file_content.replace('<FINAL_DESTRUCTOR>', '')
+        file_content = file_content.replace('<VIRTUAL>', 'virtual ')
+        file_content = file_content.replace('<OVERRIDE_OR_FINAL>', 'override')
+        file_content = file_content.replace('<DISABLE_OBJECT_FACTORY>', '#if 0 // This class cannot be instantiated')
+        file_content = file_content.replace('<END_DISABLE_OBJECT_FACTORY>', '#endif')
+    else:
+        file_content = file_content.replace('<FINAL_CLASS>', ' final')
+        file_content = file_content.replace('<FINAL_DESTRUCTOR>', ' final')
+        file_content = file_content.replace('<VIRTUAL>', 'virtual ')
+        file_content = file_content.replace('<OVERRIDE_OR_FINAL>', 'final')
+        file_content = file_content.replace('<DISABLE_OBJECT_FACTORY>', '')
+        file_content = file_content.replace('<END_DISABLE_OBJECT_FACTORY>', '')
+
+    file_content = file_content.replace('<EXTENDS>', 'BaseClass')
+    file_content = file_content.replace('<CLASSNAME>', classname)
+    file_content = file_content.replace('<UPPER_CLASSNAME>', classname.upper())
+    file_content = file_content.replace('<METHODS>', '\n\n'.join(methods))
+    file_content = file_content.replace('<MEMBERS>', '\n\n'.join(members))
+    file_content = file_content.replace('<GROUP_HEADER_DEPENDENCY>', '\n'.join(sorted(group_headers)))
+    file_content = file_content.replace('<TYPE_FORWARD_DECLARE>', '\n'.join(sorted(forward_declares)))
+
+    file_utils.set_content_if_changed(config.get_output_header_filepath(f'{classname}.h'), file_content)
+    return True
+
+
+def generate(models):
+    templates = {}
+    for filename in [ 'class_header.h', 'group_header.h', 'group_header.cpp' ]:
+        template_filepath = config.get_template_filepath(filename)
+        with open(template_filepath, 'r+t') as strm:
+            templates[filename] = strm.read()
+
+    for model in models.values():
+        classname = model['name']
+        modeltype = model['type']
+
+        config.log(f'> Generating {classname}.h')
+
+        if modeltype == 'group_def':
+            _generate_group_checker(model, models, templates)
+        else:
+            _generate_one_class(model, models, templates)
+
+    return True
+
+
+def _main():
+    import loader
+
+    config.configure()
+
+    models = loader.load_models()
+    return generate(models)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if _main() else 1)

--- a/scripts/clone_tree_cpp.py
+++ b/scripts/clone_tree_cpp.py
@@ -1,0 +1,186 @@
+import config
+import file_utils
+
+
+def generate(models):
+    implementations = []
+
+    for model in models.values():
+        modeltype = model.get('type')
+        if modeltype != 'obj_def':
+            continue
+
+        classname = model.get('name')
+        if '_call' in classname or classname in [ 'function', 'task', 'constant', 'tagged_pattern', 'gen_scope_array', 'hier_path' ]:
+            continue  # Use hardcoded implementations
+
+        Classname = classname[0].upper() + classname[1:]
+        vpi_name = config.make_vpi_name(classname)
+
+        implementations.append(f'{classname}* {classname}::DeepClone(Serializer* serializer, ElaboratorListener* elaborator, BaseClass* parent) const {{')
+        if 'Net' in vpi_name:
+            implementations.append(f'  {classname}* clone = dynamic_cast<{classname}*>(elaborator->bindNet(VpiName()));')
+            implementations.append( '  if (clone != nullptr) {')
+            implementations.append(f'    return clone;')
+            implementations.append( '  }')
+            implementations.append(f'  clone = serializer->Make{Classname}();')
+
+        elif 'Parameter' in vpi_name:
+            implementations.append(f'  {classname}* clone = dynamic_cast<{classname}*>(elaborator->bindParam(VpiName()));')
+            implementations.append( '  if (clone == nullptr) {')
+            implementations.append(f'    clone = serializer->Make{Classname}();')
+            implementations.append( '  }')
+
+        else:
+            implementations.append(f'  {classname}* const clone = serializer->Make{Classname}();')
+
+        implementations.append('  const unsigned long id = clone->UhdmId();')
+        implementations.append('  *clone = *this;')
+        implementations.append('  clone->UhdmId(id);')
+
+        if classname in ['part_select', 'bit_select', 'indexed_part_select']:
+            implementations.append('  if (const any* parent = VpiParent()) {')
+            implementations.append('    ref_obj* ref = serializer->MakeRef_obj();')
+            implementations.append('    clone->VpiParent(ref);')
+            implementations.append('    ref->VpiName(parent->VpiName());')
+            implementations.append('    if (parent->UhdmType() == uhdmref_obj) {')
+            implementations.append('      ref->VpiFullName(((ref_obj*) VpiParent())->VpiFullName());')
+            implementations.append('    }')
+            implementations.append('    ref->VpiParent((any*) parent);')
+            implementations.append('    ref->Actual_group(elaborator->bindAny(ref->VpiName()));')
+            implementations.append('    if (!ref->Actual_group())')
+            implementations.append('      if (parent->UhdmType() == uhdmref_obj) {')
+            implementations.append('        ref->Actual_group((any*) ((ref_obj*) VpiParent())->Actual_group());')
+            implementations.append('      }')
+            implementations.append('  }')
+        else:
+            implementations.append('  clone->VpiParent(parent);')
+
+        if 'BitSelect' in vpi_name:
+            implementations.append('  if (any* n = elaborator->bindNet(VpiName())) {')
+            implementations.append('    if (net* nn = dynamic_cast<net*>(n))')
+            implementations.append('      clone->VpiFullName(nn->VpiFullName());')
+            implementations.append('  }')
+
+        baseclass = classname
+        while baseclass:
+            model = models[baseclass]
+            classname = model.get('name')
+
+            for key, value in model.allitems():
+                if key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
+                    name = value.get('name')
+                    vpi = value.get('vpi')
+                    type = value.get('type')
+                    card = value.get('card')
+
+                    cast = 'any' if key == 'group_ref' else type
+                    Cast = cast[:1].upper() + cast[1:]
+                    method = name[:1].upper() + name[1:]
+
+                    if (card == 'any') and not method.endswith('s'):
+                        method += 's'
+
+                    # Unary relations
+                    if card == '1':
+                        if (classname in ['ref_obj', 'ref_var']) and (method == 'Actual_group'):
+                            implementations.append(f'  clone->{method}(elaborator->bindAny(VpiName()));')
+                            implementations.append(f'  if (!clone->{method}()) clone->{method}((any*) this->{method}());')
+
+                        elif method in ['Task', 'Function']:
+                            prefix = ''
+                            if 'method_' in classname:
+                                implementations.append(f'  const ref_obj* ref = dynamic_cast<const ref_obj*> (clone->Prefix());')
+                                implementations.append( '  const class_var* prefix = nullptr;')
+                                implementations.append( '  if (ref) prefix = dynamic_cast<const class_var*> (ref->Actual_group());')
+                                prefix = ', prefix'
+                            implementations.append(f'  if ({method.lower()}* t = dynamic_cast<{method.lower()}*> (elaborator->bindTaskFunc(VpiName(){prefix}))) {{')
+                            implementations.append(f'    clone->{method}(t);')
+                            implementations.append( '  } else {')
+                            implementations.append( '    elaborator->scheduleTaskFuncBinding(clone);')
+                            implementations.append( '  }')
+
+                        elif classname == 'function' and method == 'Return':
+                            implementations.append(f'  if (auto obj = {method}()) clone->{method}((variables*) obj);')
+
+                        elif classname == 'class_typespec' and method == 'Class_defn':
+                            implementations.append(f'  if (auto obj = {method}()) clone->{method}((class_defn*) obj);')
+
+                        elif method == 'Instance':
+                            implementations.append(f'  if (auto obj = {method}()) clone->{method}((instance*) obj);')
+                            implementations.append( '  if (instance* inst = dynamic_cast<instance*>(parent))')
+                            implementations.append( '    clone->Instance(inst);')
+
+                        elif method == 'Module':
+                            implementations.append(f'  if (auto obj = {method}()) clone->{method}((module*) obj);')
+
+                        elif method == 'Typespec':
+                            implementations.append( '  if (elaborator->uniquifyTypespec()) {')
+                            implementations.append(f'    if (auto obj = {method}()) clone->{method}(obj->DeepClone(serializer, elaborator, clone));')
+                            implementations.append( '  } else {')
+                            implementations.append(f'    if (auto obj = {method}()) clone->{method}((typespec*) obj);')
+                            implementations.append( '  }')
+
+                        else:
+                            implementations.append(f'  if (auto obj = {method}()) clone->{method}(obj->DeepClone(serializer, elaborator, clone));')
+
+                    # N-ary relations
+                    elif method == 'Typespecs':
+                        implementations.append(f'  if (auto vec = {method}()) {{')
+                        implementations.append(f'    auto clone_vec = serializer->Make{Cast}Vec();')
+                        implementations.append(f'    clone->{method}(clone_vec);')
+                        implementations.append( '    for (auto obj : *vec) {')
+                        implementations.append( '      if (elaborator->uniquifyTypespec()) {')
+                        implementations.append( '        clone_vec->push_back(obj->DeepClone(serializer, elaborator, clone));')
+                        implementations.append( '      } else {')
+                        implementations.append( '        clone_vec->push_back(obj);')
+                        implementations.append( '      }')
+                        implementations.append( '    }')
+                        implementations.append( '  }')
+
+                    elif classname == 'class_defn' and method == 'Deriveds':
+                        # Don't deep clone
+                        implementations.append(f'  if (auto vec = {method}()) {{')
+                        implementations.append(f'    auto clone_vec = serializer->Make{Cast}Vec();')
+                        implementations.append(f'    clone->{method}(clone_vec);')
+                        implementations.append( '    for (auto obj : *vec) {')
+                        implementations.append( '      clone_vec->push_back(obj);')
+                        implementations.append( '    }')
+                        implementations.append( '  }')
+
+                    else:
+                        implementations.append(f'  if (auto vec = {method}()) {{')
+                        implementations.append(f'    auto clone_vec = serializer->Make{Cast}Vec();')
+                        implementations.append(f'    clone->{method}(clone_vec);')
+                        implementations.append( '    for (auto obj : *vec) {')
+                        implementations.append( '      clone_vec->push_back(obj->DeepClone(serializer, elaborator, clone));')
+                        implementations.append( '    }')
+                        implementations.append( '  }')
+
+            baseclass = models[baseclass]['extends']
+
+        implementations.append('  return clone;')
+        implementations.append('}')
+        implementations.append('')
+
+    with open(config.get_template_filepath('clone_tree.cpp'), 'r+t') as strm:
+        file_content = strm.read()
+
+    file_content = file_content.replace('<CLONE_IMPLEMENTATIONS>', '\n'.join(implementations))
+    file_utils.set_content_if_changed(config.get_output_source_filepath('clone_tree.cpp'), file_content)
+
+    return True
+
+
+def _main():
+    import loader
+
+    config.configure()
+
+    models = loader.load_models()
+    return generate(models)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if _main() else 1)

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -1,0 +1,152 @@
+import os
+from threading import Thread, Lock
+
+_source_dirpath = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+_output_dirpath = _source_dirpath
+
+_include_dirname = 'include'
+_models_dirname = 'model'
+_templates_dirname = 'templates'
+_output_headers_dirname = 'uhdm'
+_output_sources_dirname = 'src'
+_verbose = True
+
+_log_mutex = Lock()
+
+
+def verbosity():
+    global _verbose
+    return _verbose
+
+
+def log(text, end='\n'):
+    global _verbose
+    if _verbose:
+        _log_mutex.acquire()
+        try:
+            print(text, end=end, flush=True)
+        finally:
+            _log_mutex.release()
+
+
+def configure(args=None):
+    global _source_dirpath
+    global _output_dirpath
+
+    if args:
+        if args.source_dirpath:
+            _source_dirpath = args.source_dirpath
+
+        if args.output_dirpath:
+            _output_dirpath = args.output_dirpath
+
+
+    output_headers_dirpath = os.path.join(_output_dirpath, _output_headers_dirname)
+    if not os.path.exists(output_headers_dirpath):
+        os.makedirs(output_headers_dirpath)
+
+    output_sources_dirpath = os.path.join(_output_dirpath, _output_sources_dirname)
+    if not os.path.exists(output_sources_dirpath):
+        os.makedirs(output_sources_dirpath)
+
+    print(f'Configuration update: srcdir={_source_dirpath}, headers={output_headers_dirpath}, sources={output_sources_dirpath}')
+
+
+def get_source_dirpath():
+    global _source_dirpath
+    return _source_dirpath
+
+
+def get_include_dirpath():
+    global _source_dirpath
+    global _include_dirname
+    return os.path.join(_source_dirpath, _include_dirname)
+
+def get_include_filepath(filename):
+    global _source_dirpath
+    global _include_dirname
+    return os.path.join(_source_dirpath, _include_dirname, filename)
+
+
+def get_template_dirpath():
+  global _source_dirpath
+  global _templates_dirname
+  return os.path.join(_source_dirpath, _templates_dirname)
+
+
+def get_template_filepath(filename):
+    global _source_dirpath
+    global _templates_dirname
+    return os.path.join(_source_dirpath, _templates_dirname, filename)
+
+
+def get_output_header_dirpath():
+    global _output_dirpath
+    global _output_headers_dirname
+    return os.path.join(_output_dirpath, _output_headers_dirname)
+
+
+def get_output_source_dirpath():
+    global _output_dirpath
+    global _output_sources_dirname
+    return os.path.join(_output_dirpath, _output_sources_dirname)
+
+
+def get_output_header_filepath(filename):
+    global _output_dirpath
+    global _output_headers_dirname
+    return os.path.join(_output_dirpath, _output_headers_dirname, filename)
+
+
+def get_output_source_filepath(filename):
+    global _output_dirpath
+    global _output_sources_dirname
+    return os.path.join(_output_dirpath, _output_sources_dirname, filename)
+
+
+def get_modellist_filepath():
+    global _source_dirpath
+    global _models_dirname
+    return os.path.join(_source_dirpath, _models_dirname, 'models.lst')
+
+
+def make_vpi_name(classname):
+    vpiclasstype = f'vpi{classname[:1].upper()}{classname[1:]}'
+
+    underscore = False
+    type = vpiclasstype
+    vpiclasstype = ''
+    for ch in type:
+        if ch == '_':
+          underscore = True
+        elif underscore:
+            vpiclasstype += ch.upper()
+            underscore = False
+        else:
+            vpiclasstype += ch
+
+    overrides = {
+      'vpiForkStmt': 'vpiFork',
+      'vpiForStmt': 'vpiFor',
+      'vpiIoDecl': 'vpiIODecl',
+      'vpiClockingIoDecl': 'vpiClockingIODecl',
+      'vpiTfCall': 'vpiSysTfCall',
+      'vpiAtomicStmt': 'vpiStmt',
+      'vpiAssertStmt': 'vpiAssert',
+      'vpiClockedProperty': 'vpiClockedProp',
+      'vpiIfStmt': 'vpiIf',
+      'vpiWhileStmt': 'vpiWhile',
+      'vpiCaseStmt': 'vpiCase',
+      'vpiContinueStmt': 'vpiContinue',
+      'vpiBreakStmt': 'vpiBreak',
+      'vpiReturnStmt': 'vpiReturn',
+      'vpiProcessStmt': 'vpiProcess',
+      'vpiForeverStmt': 'vpiForever',
+      'vpiConstrForeach': 'vpiConstrForEach',
+      'vpiFinalStmt': 'vpiFinal',
+      'vpiWaitStmt': 'vpiWait',
+      'vpiThreadObj': 'vpiThread',
+      'vpiSwitchTran': 'vpiSwitch',
+    }
+
+    return overrides.get(vpiclasstype, vpiclasstype)

--- a/scripts/containers_h.py
+++ b/scripts/containers_h.py
@@ -1,0 +1,51 @@
+import config
+import file_utils
+from collections import OrderedDict
+
+
+def generate(models):
+    types = set()
+    for model in models.values():
+        for key, value in model.allitems():
+            if key == 'property':
+                name = value.get('name')
+                type = value.get('type')
+                card = value.get('card')
+
+                if (name != 'type') and (type != 'any') and (card == 'any'):
+                    types.add(type)
+
+            elif key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
+                card = value.get('card')
+
+                if card == 'any':
+                    type = 'any' if key == 'group_ref' else value.get('type')
+                    types.add(type)
+
+    containers = []
+    for type in sorted(types):
+        containers.append(f'  typedef std::vector<{type}*> VectorOf{type};')
+        containers.append(f'  typedef std::vector<{type}*>::iterator VectorOf{type}Itr;')
+        containers.append('')
+    containers = '\n'.join(containers)
+
+    with open(config.get_template_filepath('containers.h'), 'r+t') as strm:
+        file_content = strm.read()
+
+    file_content = file_content.replace('<CONTAINERS>', containers)
+    file_utils.set_content_if_changed(config.get_output_header_filepath('containers.h'), file_content)
+    return True
+
+
+def _main():
+    import loader
+
+    config.configure()
+
+    models = loader.load_models()
+    return generate(models)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if _main() else 1)

--- a/scripts/file_utils.py
+++ b/scripts/file_utils.py
@@ -1,0 +1,53 @@
+import shutil
+import os
+
+
+def set_content_if_changed(filename, content):
+    if os.path.exists(filename):
+        with open(filename, 'rb') as strm:
+            orig_content = strm.read()
+
+        if orig_content == content:
+            return False
+
+    with open(filename, 'wt') as strm:
+        strm.write(content)
+
+    return True
+
+
+def copy_file_if_changed(src, dst):
+    '''
+    Copy file from source to destination if destination does not exist or
+    its content is different.
+    '''
+    src_content = None
+    if os.path.exists(src):
+        with open(src, 'rb') as strm:
+            src_content = strm.read()
+
+    dst_content = None
+    if os.path.exists(dst):
+        with open(dst, 'rb') as strm:
+            dst_content = strm.read()
+
+    if src_content and (src_content == dst_content):
+        return False
+
+    shutil.copyfile(src, dst)
+    return True
+
+
+def find_file(basedir, filename):
+    for subdir, dirs, filenames in os.walk(basedir):
+        if filename in filenames:
+            return os.path.join(subdir, filename)
+
+    return None
+
+def remove_file_safely(filepath):
+    if os.path.isfile(filepath):
+        os.remove(filepath)
+        return True
+
+    return False

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -1,0 +1,165 @@
+import argparse
+import concurrent.futures
+import os
+
+import config
+import file_utils
+import loader
+
+import capnp
+import class_hierarchy
+import classes_h
+import clone_tree_cpp
+import containers_h
+import ElaboratorListener_h
+import serializer
+import uhdm_forward_decl_h
+import uhdm_h
+import uhdm_types_h
+import vpi_listener
+import vpi_user_cpp
+import vpi_visitor_cpp
+import VpiListener_h
+import VpiListenerTracer_h
+
+
+def _worker(params):
+    key, args = params
+
+    config.log(f' ... {key}')
+
+    if key == 'capnp':
+        return capnp.generate(*args)
+
+    elif key == 'class_hierarchy':
+        return class_hierarchy.generate(*args)
+
+    elif key == 'classes_h':
+        return classes_h.generate(*args)
+
+    elif key == 'clone_tree_cpp':
+        return clone_tree_cpp.generate(*args)
+
+    elif key == 'containers_h':
+        return containers_h.generate(*args)
+
+    elif key == 'Copier':
+        for source, destination in args[0].items():
+          file_utils.copy_file_if_changed(source, destination)
+        return True
+
+    elif key == 'ElaboratorListener_h':
+        return ElaboratorListener_h.generate(*args)
+
+    elif key == 'serializer':
+        return serializer.generate(*args)
+
+    elif key == 'uhdm_forward_decl_h':
+        return uhdm_forward_decl_h.generate(*args)
+
+    elif key == 'uhdm_h':
+        return uhdm_h.generate(*args)
+
+    elif key == 'uhdm_types_h':
+        return uhdm_types_h.generate(*args)
+
+    elif key == 'vpi_listener':
+        return vpi_listener.generate(*args)
+
+    elif key == 'vpi_user_cpp':
+        return vpi_user_cpp.generate(*args)
+
+    elif key == 'vpi_visitor_cpp':
+        return vpi_visitor_cpp.generate(*args)
+
+    elif key == 'VpiListener_h':
+        return VpiListener_h.generate(*args)
+
+    elif key == 'VpiListenerTracer_h':
+        return VpiListenerTracer_h.generate(*args)
+
+    config.log('ERROR: Unknown key "{key}"')
+    return False
+
+
+def _main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-output-dirpath', dest='output_dirpath', type=str, help='Output path')
+    parser.add_argument('--parallel', dest='parallel', action='store_true', default=True)
+    parser.add_argument('--source-dirpath', dest='source_dirpath', type=str, help='Path to UHDM source')
+    args = parser.parse_args()
+    config.configure(args)
+
+    print('Generating UHDM models ...')
+    print('   Loading models ...')
+    models = loader.load_models()
+    print(f'   ... found {len(models)} models.')
+
+    print('   Validating ordering ...')
+    # Check validity
+    index = 0
+    order = {}
+    for name in models.keys():
+        order[name] = index
+        index += 1
+
+    for name, model in models.items():
+        baseclass = model['extends']
+        if baseclass:
+            thisIndex = order[name]
+            baseIndex = order[baseclass]
+            if baseIndex >= thisIndex:
+                raise Exception(f'Model {name} should follow {baseclass} in listing.')
+    print('   ... all good.')
+
+    params = [
+        ('capnp', [models]),
+        ('class_hierarchy', [models]),
+        ('classes_h', [models]),
+        ('clone_tree_cpp', [models]),
+        ('containers_h', [models]),
+        ('ElaboratorListener_h', [models]),
+        ('Copier', [{
+            config.get_template_filepath('BaseClass.h'): config.get_output_header_filepath('BaseClass.h'),
+            config.get_template_filepath('clone_tree.h'): config.get_output_header_filepath('clone_tree.h'),
+            config.get_template_filepath('ExprEval.h'): config.get_output_header_filepath('ExprEval.h'),
+            config.get_template_filepath('ExprEval.cpp'): config.get_output_source_filepath('ExprEval.cpp'),
+            config.get_template_filepath('SymbolFactory.h'): config.get_output_header_filepath('SymbolFactory.h'),
+            config.get_template_filepath('SymbolFactory.cpp'): config.get_output_source_filepath('SymbolFactory.cpp'),
+            config.get_template_filepath('uhdm_vpi_user.h'): config.get_output_header_filepath('uhdm_vpi_user.h'),
+            config.get_template_filepath('vpi_uhdm.h'): config.get_output_header_filepath('vpi_uhdm.h'),
+            config.get_template_filepath('vpi_visitor.h'): config.get_output_header_filepath('vpi_visitor.h'),
+
+            config.get_include_filepath('sv_vpi_user.h'): config.get_output_header_filepath('sv_vpi_user.h'),
+            config.get_include_filepath('vhpi_user.h'): config.get_output_header_filepath('vhpi_user.h'),
+            config.get_include_filepath('vpi_user.h'): config.get_output_header_filepath('vpi_user.h'),
+        }]),
+        ('serializer', [models]),
+        ('uhdm_forward_decl_h', [models]),
+        ('uhdm_h', [models]),
+        ('uhdm_types_h', [models]),
+        ('vpi_listener', [models]),
+        ('vpi_user_cpp', [models]),
+        ('vpi_visitor_cpp', [models]),
+        ('VpiListener_h', [models]),
+        ('VpiListenerTracer_h', [models]),
+    ]
+
+    if args.parallel:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+            results = list(executor.map(_worker, params))
+    else:
+        results = [_worker(args) for args in params]
+
+    result = sum([0 if r else 1 for r in results])
+    if result:
+        print('ERROR: UHDM model generation FAILED!')
+    else:
+        print('UHDM Models generated successfully!.')
+
+    return result
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(_main())

--- a/scripts/loader.py
+++ b/scripts/loader.py
@@ -1,0 +1,105 @@
+import os
+import re
+from collections import OrderedDict
+from multimap import MutableMultiMap
+import pprint
+
+import config
+
+
+def _load_one_model(filepath):
+    lineNo = 0
+    top_def = None
+    cur_def = None
+    with open(filepath, 'r+t') as strm:
+        for line in strm:
+            lineNo += 1
+
+            # Strip out any comment
+            pos = line.find('#')
+            if pos >= 0:
+                line = line[:pos]
+
+            line = line.strip()
+            if not line: # empty line, ignore!
+                continue
+
+            m = re.match('^[-]*\s*(?P<key>\w+)\s*:\s*(?P<value>.+)$', line)
+            if not m:
+              print(f'Failed to parse {filepath}:{lineNo}')
+              continue  # TODO(HS): Should this be an error?
+
+            key = m.group('key').strip()
+            value = m.group('value').strip()
+            if key in [ 'obj_def', 'class_def', 'group_def' ]:
+                top_def = MutableMultiMap([
+                    ('type', key),
+                    ('name', value),
+                    ('extends', None),
+                    ('subclasses', set()),
+                ])
+                cur_def = top_def
+
+            elif key in ['name']:
+                cur_def['vpiname'] = value
+
+            elif key in ['extends']:
+                top_def[key] = value
+
+            elif key in ['property', 'class_ref', 'obj_ref', 'group_ref', 'class']:
+                cur_def = MutableMultiMap([
+                    ('type', key),
+                    ('name', value),
+                ])
+                top_def.append((key, cur_def))
+
+            elif key in ['type', 'card', 'vpi', 'vpi_obj']:
+                cur_def[key] = value
+
+            else:
+                print(f'Found unknown key "{key}" at {filepath}:{lineNo}')
+
+    return top_def
+
+
+def load_models():
+    list_filepath = config.get_modellist_filepath()
+    base_dirpath = os.path.dirname(list_filepath)
+
+    models = OrderedDict()
+    with open(list_filepath, 'r+t') as strm:
+        for model_filename in strm:
+            pos = model_filename.find('#')
+            if pos >= 0:
+                model_filename = model_filename[:pos]
+            model_filename = model_filename.strip()
+
+            if model_filename:
+                model_filepath = os.path.join(base_dirpath, model_filename)
+                model = _load_one_model(model_filepath)
+                models[model['name']] = model
+
+                # if config.verbosity():
+                #     print(f"{'=' * 40} {model_filename} {'=' * 40}")
+                #     pprint.pprint(model)
+                #     print('')
+
+    # Populate the subclass list
+    for name, value in models.items():
+        baseclass = value.get('extends')
+        while baseclass:
+            models[baseclass]['subclasses'].add(name)
+            baseclass = models[baseclass].get('extends')
+
+    return models
+
+
+def _main():
+  config.configure()
+  load_models()
+  return True
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if _main() else 1)

--- a/scripts/multimap.py
+++ b/scripts/multimap.py
@@ -1,0 +1,751 @@
+"""Module for various mapping which allow multiple values per key. As a by
+product of how they are controlled they also maintain order.
+
+The API of these objects tends towards being a drop-in replacement for normal
+mappings. All the dict methods will return only the first occourance of a key.
+Even len(map) will return the number of unique keys, not the number of pairs
+stored. Many dict methods have an "all" prefixed version which does the same
+thing but to all key-value pairs. Thusly, multiple of the same key may be
+returned while using them.
+
+Several list methods are also exposed, such as insert, extend, pop, etc.
+Primary testing can be found in the nitrogen.uri.query module.
+
+The read-only versions arent very well protected. They are only there as
+reminders to the honest programmer who makes mistakes.
+
+I have also stuck with the dict-like naming convention of all lowercase names
+with no word seperators.
+
+Internally the mapping is represented as a list of (key, value) pairs (which
+is what maintains the order) AND a mapping of keys to a list of positions in
+the pair list (for making everything faster). Need to keep in mind that any
+given list in _key_ids may be empty.
+
+I have not implemented something corresponding to the following list methods:
+    - count
+    - index
+    - remove
+
+Ref: https://github.com/mikeboers/MultiMap
+
+"""
+
+
+import collections
+from bisect import bisect
+
+class MultiMap(collections.Mapping):
+    """An ordered mapping which supports multiple values for the same key."""
+    
+    def __init__(self, *args, **kwargs):
+        """Initialize a MultiMap.
+        
+        >>> m = MultiMap({'a': 1, 'b': 2})
+        >>> m
+        MultiMap([('a', 1), ('b', 2)])
+
+        >>> m = MultiMap([('a', 1), ('b', 2)])
+        >>> m
+        MultiMap([('a', 1), ('b', 2)])
+
+        >>> m = MultiMap(a=1, b=2)
+        >>> m
+        MultiMap([('a', 1), ('b', 2)])
+
+        >>> m = MultiMap([('a', 1), ('b', 2), ('c', 3), ('c', 4)])
+        >>> m
+        MultiMap([('a', 1), ('b', 2), ('c', 3), ('c', 4)])
+        
+        """
+        self._pairs = []
+        for arg in args:
+            if isinstance(arg, collections.Mapping):
+                for x in arg.items():
+                    self._pairs.append(self._conform_pair(x))
+            else:
+                for x in arg:
+                    self._pairs.append(self._conform_pair(x))
+        for x in kwargs.items():
+            self._pairs.append(self._conform_pair(x))
+        self._rebuild_key_ids()
+    
+    def _rebuild_key_ids(self):
+        """Rebuild the internal key to index mapping."""
+        self._key_ids = collections.defaultdict(list)
+        for i, x in enumerate(self._pairs):
+            self._key_ids[x[0]].append(i)
+    
+    def _conform_key(self, key):
+        """Force a given key into certain form.
+        
+        For overriding.
+        
+        """
+        return key
+    
+    def _conform_value(self, value):
+        """Force a given value into certain form.
+
+        For overriding.
+
+        """
+        return value
+    
+    def _conform_pair(self, pair):
+        """Force a given key/value pair into a certain form.
+        
+        Override the _conform_key and _conform_value if you want to change
+        the mapping behaviour.
+        
+        """
+        pair = tuple(pair)
+        if len(pair) != 2:
+            raise ValueError('MultiMap element must have length 2')
+        return (self._conform_key(pair[0]), self._conform_value(pair[1]))
+    
+    @classmethod
+    def fromkeys(cls, keys, value=None):
+        return cls([(k, value) for k in keys])
+    
+    def __repr__(self):
+        return '%s(%r)' % (self.__class__.__name__, self._pairs)
+    
+    def __nonzero__(self):
+        """
+        
+        >>> bool(MultiMap([]))
+        False
+        >>> bool(MultiMap(a=1))
+        True
+        
+        """
+        return bool(self._pairs)
+    
+    def __getitem__(self, key):
+        """Get the FIRST value for the given key.
+        
+        >>> m = MultiMap([('a', 1), ('b', 2), ('b', 3), ('c', 4), ('d', 5), ('c', 6)])
+        >>> m['a']
+        1
+        >>> m['b']
+        2
+        >>> m['x']
+        Traceback (most recent call last):
+        ...
+        KeyError: 'x'
+            
+        """
+        key = self._conform_key(key)
+        try:
+            return self._pairs[self._key_ids[key][0]][1]
+        except IndexError:
+            raise KeyError(key)
+    
+    def __contains__(self, key):
+        """Is the given key in this mapping?
+        
+        >>> m = MultiMap(a=1)
+        >>> 'a' in m
+        True
+        >>> 'x' in m
+        False
+        
+        """
+        # Need to explicitly check the value of the id list, as it may be in
+        # there already but be empty.
+        return bool(self._key_ids[self._conform_key(key)])
+    
+    def has_key(self, key):
+        return key in self
+    
+    def __len__(self):
+        """The number of different keys.
+        
+        >>> m = MultiMap([('a', 1), ('b', 2), ('b', 3), ('c', 4), ('d', 5), ('c', 6)])
+        >>> len(m)
+        4
+        
+        """
+        return len(self._key_ids)
+    
+    def alllen(self):
+        """The number of pairs. Includes duplicate keys.
+        
+        >>> m = MultiMap([('a', 1), ('b', 2), ('b', 3), ('c', 4), ('d', 5), ('c', 6)])
+        >>> m.alllen()
+        6
+        
+        """
+        return len(self._pairs)
+    
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+        
+    def getall(self, key):
+        """A list of all the values stored under this key.
+        
+        Returns an empty list if there are no values under this key.
+        
+        >>> m = MultiMap([('a', 1), ('b', 2), ('b', 3), ('c', 4), ('d', 5), ('c', 6)])
+        >>> m.getall('a')
+        [1]
+        >>> m.getall('b')
+        [2, 3]
+        >>> m.getall('x')
+        []
+        
+        """
+        key = self._conform_key(key)
+        return [self._pairs[i][1] for i in self._key_ids[key]]
+    
+    # These are for compatibility with other multi-value mapping libraries.
+    getlist = list = getall
+    
+    def iteritems(self):
+        """Iterator across all the non-duplicate keys and their values.
+        
+        Only yields the first key of duplicates.
+        
+        """
+        keys_yielded = set()
+        for k, v in self._pairs:
+            if k not in keys_yielded:
+                keys_yielded.add(k)
+                yield k, v
+                
+    def __iter__(self):
+        """Iterate across the unique keys in the mapping."""
+        return (x[0] for x in self.iteritems())
+    
+    def keys(self):
+        """A list of the first keys in the mapping, in order.
+        
+        >>> m = MultiMap([('a', 1), ('b', 2), ('b', 3), ('c', 4), ('d', 5), ('c', 6)])
+        >>> m.keys()
+        ['a', 'b', 'c', 'd']
+        
+        """
+        return list(self)
+    
+    def iterkeys(self):
+        """Iterate across the first keys in the mapping."""
+        return iter(self)
+    
+    def iterallkeys(self):
+        """Iterate across ALL of the keys in the mapping, in order."""
+        for x in self._pairs:
+            yield x[0]
+    
+    def allkeys(self):
+        """A list of ALL of the keys in the mapping, in order.
+        
+        >>> m = MultiMap([('a', 1), ('b', 2), ('b', 3), ('c', 4), ('d', 5), ('c', 6)])
+        >>> m.allkeys()
+        ['a', 'b', 'b', 'c', 'd', 'c']
+        
+        """
+        return [x[0] for x in self._pairs]
+    
+    def items(self):
+        """A list of items with the first keys in the mapping.
+        
+        >>> m = MultiMap([('a', 1), ('b', 2), ('b', 3), ('c', 4), ('d', 5), ('c', 6)])
+        >>> m.items()
+        [('a', 1), ('b', 2), ('c', 4), ('d', 5)]
+        
+        """
+        return list(self.iteritems())
+    
+    def itervalues(self):
+        """Iterate across the value for the first keys in the mapping."""
+        return (x[1] for x in self.iteritems())
+    
+    def values(self):
+        """A list of values for the first keys in the mapping.
+        
+        >>> m = MultiMap([('a', 1), ('b', 2), ('b', 3), ('c', 4), ('d', 5), ('c', 6)])
+        >>> m.values()
+        [1, 2, 4, 5]
+        
+        """
+        return list(self.itervalues())
+    
+    def iterallvalues(self):
+        """Iterate across ALL of the values in the mapping."""
+        for x in self._pairs:
+            yield x[1]
+    
+    def allvalues(self):
+        """A list of ALL values in the mapping.
+        
+        >>> m = MultiMap([('a', 1), ('b', 2), ('b', 3), ('c', 4), ('d', 5), ('c', 6)])
+        >>> m.allvalues()
+        [1, 2, 3, 4, 5, 6]
+        
+        """
+        return [x[1] for x in self._pairs]
+    
+    def iterallitems(self):
+        """Iterate across ALL of the pairs in the mapping."""
+        return iter(self._pairs)
+    
+    def allitems(self):
+        """A list of ALL of the pairs in the mapping."""
+        return self._pairs[:]
+
+
+class MutableMultiMap(MultiMap, collections.MutableMapping):
+    """An ordered mapping which supports multiple values for the same key.
+
+    >>> m = MutableMultiMap({'a': 1, 'b': 2})
+    >>> m
+    MutableMultiMap([('a', 1), ('b', 2)])
+
+    >>> m = MutableMultiMap([('a', 1), ('b', 2)])
+    >>> m
+    MutableMultiMap([('a', 1), ('b', 2)])
+
+    >>> m = MutableMultiMap(a=1, b=2)
+    >>> m
+    MutableMultiMap([('a', 1), ('b', 2)])
+    
+    >>> m['a']
+    1
+
+    >>> m['c'] = 3
+    >>> m['c']
+    3
+
+    >>> m.setall('c', [1, 2, 3])
+    >>> m['c']
+    1
+    >>> m.getall('c')
+    [1, 2, 3]
+
+    >>> m.keys()
+    ['a', 'b', 'c']
+    >>> m.allkeys()
+    ['a', 'b', 'c', 'c', 'c']
+    >>> m.allvalues()
+    [1, 2, 1, 2, 3]
+    >>> len(m)
+    3
+    >>> m.alllen()
+    5
+
+    >>> m['c'] = 4
+    >>> m.getall('c')
+    [4]
+
+    >>> m.append((1, 2))
+    >>> m.allitems()
+    [('a', 1), ('b', 2), ('c', 4), (1, 2)]
+
+    >>> m.popitem()
+    (1, 2)
+
+    >>> m.popitem(0)
+    ('a', 1)
+    
+    >>> M = MutableMultiMap([('a', 0), ('b', 1), ('c', 2), ('b', 3), ('c', 4), ('c', 5)])
+    
+    >>> m = M.copy()
+    >>> m.pop('b')
+    1
+    >>> m
+    MutableMultiMap([('a', 0), ('c', 2), ('c', 4), ('c', 5)])
+    
+    >>> m = M.copy()
+    >>> m.popone('b')
+    1
+    >>> m
+    MutableMultiMap([('a', 0), ('c', 2), ('b', 3), ('c', 4), ('c', 5)])
+    
+    >>> m.popall('c')
+    [2, 4, 5]
+    >>> m
+    MutableMultiMap([('a', 0), ('b', 3)])
+    
+    >>> m = M.copy()
+    >>> m.popitem()
+    ('c', 5)
+    >>> m.popitem(0)
+    ('a', 0)
+    
+    """
+    
+    def _remove_pairs(self, ids_to_remove):
+        """Remove the pairs identified by the given indices into _pairs.
+        
+        Removes the pair, and updates the _key_ids mapping to be accurate.
+        Removing the ids from the _key_ids is your own responsibility.
+        
+        Params:
+            ids_to_remove -- The indices to remove. MUST be sorted.
+        
+        """
+        # Remove them.
+        for i in reversed(ids_to_remove):
+            del self._pairs[i]
+        
+        # We use the bisect to tell us how many spots the given index is
+        # shifting up in the list.
+        for ids in self._key_ids.values():
+            for i, id in enumerate(ids):
+                ids[i] -= bisect(ids_to_remove, id)
+    
+    def _insert_pairs(self, ids_and_pairs):
+        """Insert some new pairs, and keep the _key_ids updated.
+        
+        Params:
+            ids_and_pairs -- A list of (index, (key, value)) tuples.
+        
+        """
+        ids_to_insert = [x[0] for x in ids_and_pairs]
+        
+        # We use the bisect to tell us how many spots the given index is
+        # shifting up in the list.
+        for ids in self._key_ids.values():
+            for i, id in enumerate(ids):
+                ids[i] += bisect(ids_to_insert, id)
+        
+        # Do the actual insertion
+        for i, pair in ids_and_pairs:
+            self._pairs.insert(i, pair)
+    
+    def __delitem__(self, key):
+        """Remove all key/value pairs by the given key.
+
+        Raises a KeyError if there are none.
+
+        >>> m = MutableMultiMap([('a', 1), ('b', 2), ('b', 3), ('c', 4), ('d', 5), ('c', 6)])
+        >>> del m['a']
+        >>> m
+        MutableMultiMap([('b', 2), ('b', 3), ('c', 4), ('d', 5), ('c', 6)])
+        >>> m['b']
+        2
+        >>> m.getall('c')
+        [4, 6]
+
+        >>> m = MutableMultiMap([('a', 1), ('b', 2), ('b', 3), ('c', 4), ('d', 5), ('c', 6)])
+        >>> del m['b']
+        >>> m
+        MutableMultiMap([('a', 1), ('c', 4), ('d', 5), ('c', 6)])
+        >>> m['a']
+        1
+        >>> m['c']
+        4
+        >>> m.getall('c')
+        [4, 6]
+
+        >>> m = MutableMultiMap(a=1)
+        >>> del m['x']
+        Traceback (most recent call last):
+        ...
+        KeyError: 'x'
+
+        """
+        key = self._conform_key(key)
+        del_ids = self._key_ids[key]
+        if not del_ids:
+            raise KeyError(key)
+
+        # Remove the ids.
+        del self._key_ids[key]
+
+        self._remove_pairs(del_ids)
+        
+    def __setitem__(self, key, value):
+        """Set a key-value pair.
+        
+        If the key was not already in the mapping, it gets put at the end. If
+        it was already in with a single value, the value gets updated. If
+        there were multiple values, all but the first are removed.
+        
+        >>> m = MutableMultiMap(a=1)
+        >>> m['b'] = 2
+        >>> m
+        MutableMultiMap([('a', 1), ('b', 2)])
+        >>> m['c'] = 3
+        >>> m
+        MutableMultiMap([('a', 1), ('b', 2), ('c', 3)])
+        >>> m['b'] = 4
+        >>> m
+        MutableMultiMap([('a', 1), ('b', 4), ('c', 3)])
+        >>> m['b']
+        4
+        
+        >>> m = MutableMultiMap([('a', 1), ('b', 2), ('c', 3), ('b', 4)])
+        >>> m['b'] = 'new'
+        >>> m.allitems()
+        [('a', 1), ('b', 'new'), ('c', 3)]
+        
+        """
+        self.setall(key, [value])
+    
+    def clear(self):
+        self._pairs = []
+        self._rebuild_key_ids()
+        
+    def setall(self, key, values):
+        """Set more than one value for a given key.
+        
+        Replaces all the existing values for the given key with new values,
+        removes extra values that are already set if we don't suply enough,
+        and appends values to the end if there are not enough existing spots.
+        
+        >>> m = MutableMultiMap(a=1, b=2, c=3)
+        >>> m.sort()
+        >>> m.keys()
+        ['a', 'b', 'c']
+        >>> m.append(('b', 4))
+        >>> m.setall('b', [5, 6, 7])
+        >>> m.allitems()
+        [('a', 1), ('b', 5), ('c', 3), ('b', 6), ('b', 7)]
+        
+        """
+        key = self._conform_key(key)
+        values = [self._conform_value(x) for x in values]
+        ids = self._key_ids[key][:]
+        while ids and values:
+            id    = ids.pop(0)
+            value = values.pop(0)
+            self._pairs[id] = (key, value)
+        if ids:
+            self._key_ids[key] = self._key_ids[key][:-len(ids)]
+            self._remove_pairs(ids)
+        for value in values:
+            self._key_ids[key].append(len(self._pairs))
+            self._pairs.append((key, value))
+    
+    def discard(self, key):
+        """Same as del m[key], but does not throw an error."""
+        try:
+            del self[key]
+        except KeyError:
+            pass
+
+    def sort(self, *args, **kwargs):
+        """Sort the MultiMap.
+        
+        Takes the same arguments as list.sort, and operates on tuples of
+        (key, value) pairs.
+        
+        >>> m = MutableMultiMap()
+        >>> m['c'] = 1
+        >>> m['b'] = 3
+        >>> m['a'] = 2
+        >>> m.sort()
+        >>> m.keys()
+        ['a', 'b', 'c']
+        >>> m.sort(key=lambda x: x[1])
+        >>> m.keys()
+        ['c', 'a', 'b']
+        
+        """
+        self._pairs.sort(*args, **kwargs)
+        self._rebuild_key_ids()
+    
+    def reverse(self):
+        self._pairs.reverse()
+        self._rebuild_key_ids()
+    
+    def insert(self, index, pair):
+        self._insert_pairs([(index, self._conform_pair(pair))])
+        
+    def append(self, pair):
+        key, value = pair = self._conform_pair(pair)
+        self._key_ids[key].append(len(self._pairs))
+        self._pairs.append(pair)
+    
+    def extend(self, pairs):
+        for pair in pairs:
+            self.append(pair)
+    
+    def pop(self, key, *default):
+        """Remove specified key and return the corresponding value.
+        
+        If key is not found, default is returned if given.
+        
+        Removes ALL values for this key, but only returns the first.
+        
+        >>> m = MutableMultiMap([('a', 1), ('b', 2), ('b', 3), ('c', 4)])
+        >>> m.pop('a')
+        1
+        >>> m.pop('b')
+        2
+        >>> m.items()
+        [('c', 4)]
+        >>> m.pop('x')
+        Traceback (most recent call last):
+        ...
+        KeyError: 'x'
+        >>> m.pop('x', 'default')
+        'default'
+        
+        """
+        try:
+            value = self[key]
+        except KeyError:
+            if default:
+                return default[0]
+            raise
+        del self[key]
+        return value
+    
+    def popone(self, key, *default):
+        """Remove first of given key and return corresponding value.
+        
+        If key is not found, default is returned if given.
+        
+        >>> m = MutableMultiMap([('a', 1), ('b', 2), ('b', 3), ('c', 4)])
+        >>> m.popone('b')
+        2
+        >>> m.items()
+        [('a', 1), ('b', 3), ('c', 4)]
+        >>> m.popone('b')
+        3
+        >>> m.popone('b')
+        Traceback (most recent call last):
+        ...
+        KeyError: 'b'
+        >>> m.popone('b', 'default')
+        'default'
+        
+        """
+        try:
+            value = self[key]
+        except KeyError:
+            if default:
+                return default[0]
+            raise
+        
+        # Delete this one.
+        self._remove_pairs([self._key_ids[self._conform_key(key)].pop(0)])
+        
+        return value
+
+    def popall(self, key):
+        """Remove specified key and return all corresponding values.
+        
+        If they key is not found, an empty list is return.
+        
+        >>> m = MutableMultiMap([('a', 1), ('b', 2), ('b', 3), ('c', 4)])
+        >>> m.popall('a')
+        [1]
+        >>> m.popall('b')
+        [2, 3]
+        >>> m.popall('x')
+        []
+        
+        """
+        values = self.getall(key)
+        try:
+            del self[key]
+        except KeyError:
+            pass
+        return values
+
+    def popitem(self, index=-1):
+        """Remove and return an item at index (default last)."""
+        return self._pairs.pop(index)
+
+
+
+    def update(self, mapping):
+        for k in mapping:
+            self[k] = mapping[k]
+    
+    def copy(self):
+        return self.__class__(self._pairs[:])
+
+
+
+class DelayedTraits(object):
+    def __init__(self, supplier=None):
+        self.supplier = supplier
+        self._setup = False
+        self.__pairs = None
+        self.__key_ids = None
+            
+    @property
+    def _pairs(self):
+        if self.__pairs is None:
+            self.__pairs = [(self._conform_key(k), self._conform_value(v)) for
+                k, v in self.supplier()]
+        return self.__pairs
+    
+    @_pairs.setter
+    def _pairs(self, value):
+        self.__pairs = value
+    
+    @property
+    def _key_ids(self):
+        if self.__key_ids is None:
+            self._rebuild_key_ids()
+        return self.__key_ids
+    
+    @_key_ids.setter
+    def _key_ids(self, value):
+        self.__key_ids = value
+
+
+class DelayedMultiMap(DelayedTraits, MultiMap):
+    """
+    >>> def gen():
+    ...     print 'generating'
+    ...     for x in range(5):
+    ...         yield (x, 'x')
+    >>> m = DelayedMultiMap(gen)
+    >>> m[0]
+    generating
+    'x'
+    >>> m[5] = 'new'
+    Traceback (most recent call last):
+    ...
+    TypeError: 'DelayedMultiMap' object does not support item assignment
+
+    """
+    
+    pass
+
+class DelayedMutableMultiMap(DelayedTraits, MutableMultiMap):
+    """
+    >>> def gen():
+    ...     print 'generating'
+    ...     for x in range(5):
+    ...         yield (x, 'x')
+    >>> m = DelayedMutableMultiMap(gen)
+    >>> m[0]
+    generating
+    'x'
+    >>> m[5] = 'new'
+    >>> m
+    DelayedMutableMultiMap([(0, 'x'), (1, 'x'), (2, 'x'), (3, 'x'), (4, 'x'), (5, 'new')])
+    
+    """
+    
+    pass
+
+
+def test_conform_methods():
+    class CaseInsensitive(MutableMultiMap):
+        def _conform_key(self, key):
+            return key.lower()
+    d = CaseInsensitive()
+    d['a'] = 1
+    d['A'] = 2
+    assert len(d) == 1
+    assert d['a'] == 2
+    d['Content-Encoding'] = 'deflate'
+    assert 'content-encoding' in d
+    assert 'blah' not in d
+
+
+if __name__ == '__main__':
+    import nose; nose.run(defaultTest=__name__)
+    import doctest; doctest.testmod()

--- a/scripts/scripts.pyproj
+++ b/scripts/scripts.pyproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>bdbc56d1-89ba-40cd-9724-d828e05d8a7d</ProjectGuid>
+    <ProjectHome>.</ProjectHome>
+    <StartupFile>generate.py</StartupFile>
+    <SearchPath>
+    </SearchPath>
+    <WorkingDirectory>.</WorkingDirectory>
+    <OutputPath>.</OutputPath>
+    <Name>db</Name>
+    <RootNamespace>db</RootNamespace>
+    <LaunchProvider>Standard Python launcher</LaunchProvider>
+    <CommandLineArguments>-output-dirpath E:\Public\UHDM\out\build\debug\generated</CommandLineArguments>
+    <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
+    <IsWindowsApplication>False</IsWindowsApplication>
+    <InterpreterId>Global|PythonCore|3.8</InterpreterId>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="capnp.py" />
+    <Compile Include="classes_h.py" />
+    <Compile Include="class_hierarchy.py" />
+    <Compile Include="clone_tree_cpp.py" />
+    <Compile Include="config.py" />
+    <Compile Include="containers_h.py" />
+    <Compile Include="ElaboratorListener_h.py" />
+    <Compile Include="file_utils.py" />
+    <Compile Include="generate.py" />
+    <Compile Include="loader.py" />
+    <Compile Include="multimap.py" />
+    <Compile Include="serializer.py" />
+    <Compile Include="uhdm_forward_decl_h.py" />
+    <Compile Include="uhdm_h.py" />
+    <Compile Include="uhdm_types_h.py" />
+    <Compile Include="VpiListenerTracer_h.py" />
+    <Compile Include="VpiListener_h.py" />
+    <Compile Include="vpi_listener.py" />
+    <Compile Include="vpi_user_cpp.py" />
+    <Compile Include="vpi_visitor_cpp.py" />
+    <Content Include="collections\**\*.json" />
+    <Content Include="pipelines\*.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <InterpreterReference Include="Global|PythonCore|3.8" />
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+  </PropertyGroup>
+  <!-- Uncomment the CoreCompile target to enable the Build command in
+       Visual Studio and specify your pre- and post-build commands in
+       the BeforeBuild and AfterBuild targets below. -->
+  <!--<Target Name="CoreCompile" />-->
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
+</Project>

--- a/scripts/scripts.sln
+++ b/scripts/scripts.sln
@@ -1,0 +1,23 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29409.12
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "scripts", "scripts.pyproj", "{BDBC56D1-89BA-40CD-9724-D828E05D8A7D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BDBC56D1-89BA-40CD-9724-D828E05D8A7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BDBC56D1-89BA-40CD-9724-D828E05D8A7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AF2101A9-769D-4616-B7B0-1D348158F0EE}
+	EndGlobalSection
+EndGlobal

--- a/scripts/serializer.py
+++ b/scripts/serializer.py
@@ -1,0 +1,359 @@
+import os
+from collections import OrderedDict
+
+import config
+import file_utils
+import uhdm_types_h
+
+
+def _print_methods(classname, type, vpi, card, real_type=''):
+    content = []
+    if card != '1':
+        return content
+
+    if type in ['string', 'value', 'delay']:
+        type = 'std::string'
+
+    if vpi == 'uhdmType':
+        type = 'UHDM_OBJECT_TYPE'
+
+    final = ''
+    virtual = ''
+    if vpi in ['vpiParent', 'uhdmParentType', 'uhdmType', 'vpiLineNo', 'vpiColumnNo', 'vpiEndLineNo', 'vpiEndColumnNo', 'vpiFile', 'vpiName', 'vpiDefName', 'uhdmId']:
+        final = ' final'
+        virtual = 'virtual '
+
+    check = ''
+    if type == 'any':
+        check = f'if (!{real_type}GroupCompliant(data)) return false;'
+
+    pointer = ''
+    const = ''
+    if type not in ['unsigned int', 'int', 'bool', 'std::string']:
+        pointer = '*'
+        const = 'const '
+
+    Vpi_ = vpi[:1].upper() + vpi[1:]
+
+    if type == 'std::string':
+        if vpi == 'vpiFullName':
+            content.append(f'const {type}{pointer}& {classname}::{Vpi_}() const {{')
+            content.append(f'  if ({vpi}_) {{')
+            content.append(f'    return serializer_->symbolMaker.GetSymbol({vpi}_);')
+            content.append( '  } else {')
+            content.append( '    std::vector<std::string> names;')
+            content.append( '    const BaseClass* parent = this;')
+            content.append( '    const BaseClass* child = nullptr;')
+            content.append( '    bool column = false;')
+            content.append( '    while (parent != nullptr) {')
+            content.append( '      const BaseClass* actual_parent = parent->VpiParent();')
+            content.append( '      if (parent->UhdmType() == uhdmdesign) break;')
+            content.append( '      if ((parent->UhdmType() == uhdmpackage) || (parent->UhdmType() == uhdmclass_defn)) column = true;')
+            content.append( '      const std::string& name = parent->VpiName().empty() ? parent->VpiDefName() : parent->VpiName();')
+            content.append( '      UHDM_OBJECT_TYPE parent_type = (parent != nullptr) ? parent->UhdmType() : uhdmunsupported_stmt;')
+            content.append( '      UHDM_OBJECT_TYPE actual_parent_type = (actual_parent != nullptr) ? actual_parent->UhdmType() : uhdmunsupported_stmt;')
+            content.append( '      bool skip_name = (actual_parent_type == uhdmref_obj) || (parent_type == uhdmmethod_func_call) ||')
+            content.append( '                       (parent_type == uhdmmethod_task_call) || (parent_type == uhdmfunc_call) ||')
+            content.append( '                       (parent_type == uhdmtask_call) || (parent_type == uhdmsys_func_call) ||')
+            content.append( '                       (parent_type == uhdmsys_task_call);')
+            content.append( '      if (child != nullptr) {')
+            content.append( '        UHDM_OBJECT_TYPE child_type = child->UhdmType();')
+            content.append( '        if ((child_type == uhdmbit_select) && (parent_type == uhdmport)) {')
+            content.append( '          skip_name = true;')
+            content.append( '        }')
+            content.append( '        if ((child_type == uhdmref_obj) && (parent_type == uhdmbit_select)) {')
+            content.append( '          skip_name = true;')
+            content.append( '        }')
+            content.append( '        if ((child_type == uhdmref_obj) && (parent_type == uhdmindexed_part_select)) {')
+            content.append( '          skip_name = true;')
+            content.append( '        }')
+            content.append( '        if ((child_type == uhdmref_obj) && (parent_type == uhdmhier_path)) {')
+            content.append( '          skip_name = true;')
+            content.append( '        }')
+            content.append( '      }')
+            content.append( '      if ((!name.empty()) && (!skip_name))')
+            content.append( '        names.push_back(name);')
+            content.append( '      child = parent;')
+            content.append( '      parent = parent->VpiParent();')
+            content.append( '    }')
+            content.append( '    std::string fullName;')
+            content.append( '    if (!names.empty()) {')
+            content.append( '      unsigned int index = names.size() - 1;')
+            content.append( '      while(1) {')
+            content.append( '        fullName += names[index];')
+            content.append( '        if (index > 0) fullName += column ? "::" : ".";')
+            content.append( '        if (index == 0) break;')
+            content.append( '        index--;')
+            content.append( '      }')
+            content.append( '    }')
+            content.append( '    if (!fullName.empty()) {')
+            content.append(f'      (({classname}*)this)->VpiFullName(fullName);')
+            content.append( '    }')
+            content.append(f'    return serializer_->symbolMaker.GetSymbol({vpi}_);')
+            content.append( '  }')
+            content.append( '}')
+        else:
+            content.append(f'const {type}{pointer}& {classname}::{Vpi_}() const {{ return serializer_->symbolMaker.GetSymbol({vpi}_); }}')
+        content.append('')
+        content.append(f'bool {classname}::{Vpi_}(const {type}{pointer}& data) {{ {vpi}_ = serializer_->symbolMaker.Make(data); return true; }}')
+        content.append('')
+
+    return content
+
+
+def generate(models):
+    methods = []
+    saves = {}
+    restores = {}
+
+    for model in models.values():
+        modeltype = model['type']
+        if modeltype == 'group_def':
+            continue
+
+        classname = model['name']
+        Classname_ = classname[:1].upper() + classname[1:]
+        Classname = Classname_.replace('_', '')
+
+        saves[classname] = []
+        restores[classname] = []
+
+        if modeltype != 'class_def':
+            methods.extend(_print_methods(classname, 'BaseClass', 'vpiParent', '1'))
+            methods.extend(_print_methods(classname, 'unsigned int', 'uhdmParentType', '1'))
+            methods.extend(_print_methods(classname, 'string','vpiFile', '1'))
+            methods.extend(_print_methods(classname, 'unsigned int', 'uhdmId', '1'))
+
+            saves[classname].append(f'    {Classname}s[index].setVpiParent(GetId(obj->VpiParent()));')
+            saves[classname].append(f'    {Classname}s[index].setUhdmParentType(obj->UhdmParentType());')
+            saves[classname].append(f'    {Classname}s[index].setVpiFile(obj->GetSerializer()->symbolMaker.Make(obj->VpiFile()));')
+            saves[classname].append(f'    {Classname}s[index].setVpiLineNo(obj->VpiLineNo());')
+            saves[classname].append(f'    {Classname}s[index].setVpiColumnNo(obj->VpiColumnNo());')
+            saves[classname].append(f'    {Classname}s[index].setVpiEndLineNo(obj->VpiEndLineNo());')
+            saves[classname].append(f'    {Classname}s[index].setVpiEndColumnNo(obj->VpiEndColumnNo());')
+            saves[classname].append(f'    {Classname}s[index].setUhdmId(obj->UhdmId());')
+
+            restores[classname].append(f'    {classname}Maker.objects_[index]->UhdmParentType(obj.getUhdmParentType());')
+            restores[classname].append(f'    {classname}Maker.objects_[index]->VpiParent(GetObject(obj.getUhdmParentType(), obj.getVpiParent()-1));')
+            restores[classname].append(f'    {classname}Maker.objects_[index]->VpiFile(symbolMaker.GetSymbol(obj.getVpiFile()));')
+            restores[classname].append(f'    {classname}Maker.objects_[index]->VpiLineNo(obj.getVpiLineNo());')
+            restores[classname].append(f'    {classname}Maker.objects_[index]->VpiColumnNo(obj.getVpiColumnNo());')
+            restores[classname].append(f'    {classname}Maker.objects_[index]->VpiEndLineNo(obj.getVpiEndLineNo());')
+            restores[classname].append(f'    {classname}Maker.objects_[index]->VpiEndColumnNo(obj.getVpiEndColumnNo());')
+            restores[classname].append(f'    {classname}Maker.objects_[index]->UhdmId(obj.getUhdmId());')
+
+        indTmp = 0
+        for key, value in model.allitems():
+            if key == 'property':
+                name = value.get('name')
+                vpi = value.get('vpi')
+                type = value.get('type')
+                card = value.get('card')
+
+                if name == 'type':
+                    continue
+
+                methods.extend(_print_methods(classname, type, vpi, card))
+
+                Vpi_ = vpi[:1].upper() + vpi[1:]
+                Vpi = Vpi_.replace('_', '')
+
+                if type in ['string', 'value', 'delay']:
+                    saves[classname].append(f'    {Classname}s[index].set{Vpi}(obj->GetSerializer()->symbolMaker.Make(obj->{Vpi_}()));')
+                    restores[classname].append(f'    {classname}Maker.objects_[index]->{Vpi_}(symbolMaker.GetSymbol(obj.get{Vpi}()));')
+                else:
+                    saves[classname].append(f'    {Classname}s[index].set{Vpi}(obj->{Vpi_}());')
+                    restores[classname].append(f'    {classname}Maker.objects_[index]->{Vpi_}(obj.get{Vpi}());')
+            
+            elif key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
+                name = value.get('name')
+                type = value.get('type')
+                card = value.get('card')
+                id = value.get('id')
+
+                Type_ = type[:1].upper() + type[1:]
+                Type = Type_.replace('_', '')
+
+                if (card == 'any') and not name.endswith('s'):
+                    name += 's'
+
+                Name_ = name[:1].upper() + name[1:]
+                Name = Name_.replace('_', '')
+
+                real_type = type
+                if key == 'group_ref':
+                    type = 'any'
+
+                methods.extend(_print_methods(classname, type, name, card, real_type))
+
+                if card == '1':
+                    if key in ['class_ref', 'group_ref']:
+                        saves[classname].append(f'    if (obj->{Name_}()) {{')
+                        saves[classname].append(f'      ::ObjIndexType::Builder tmp{indTmp} = {Classname}s[index].get{Name}();')
+                        saves[classname].append(f'      tmp{indTmp}.setIndex(GetId(((BaseClass*) obj->{Name_}())));')
+                        saves[classname].append(f'      tmp{indTmp}.setType(((BaseClass*)obj->{Name_}())->UhdmType());')
+                        saves[classname].append( '    }')
+                        restores[classname].append(f'    {classname}Maker.objects_[index]->{Name_}(({type}*)GetObject(obj.get{Name}().getType(), obj.get{Name}().getIndex()-1));')
+                        indTmp += 1
+                    else:
+                        saves[classname].append(f'    {Classname}s[index].set{Name}(GetId(obj->{Name_}()));')
+                        restores[classname].append(f'    if (obj.get{Name}()) {{')
+                        restores[classname].append(f'      {classname}Maker.objects_[index]->{Name_}({type}Maker.objects_[obj.get{Name}()-1]);')
+                        restores[classname].append( '    }')
+
+                else:
+                    obj_key = '::ObjIndexType' if key in ['class_ref', 'group_ref'] else '::uint64_t'
+
+                    saves[classname].append(f'    if (obj->{Name_}()) {{')
+                    saves[classname].append(f'      ::capnp::List<{obj_key}>::Builder {Name}s = {Classname}s[index].init{Name}(obj->{Name_}()->size());')
+                    saves[classname].append(f'      for (unsigned int ind = 0; ind < obj->{Name_}()->size(); ind++) {{')
+                    restores[classname].append(f'    if (obj.get{Name}().size()) {{')
+                    restores[classname].append(f'      std::vector<{type}*>* vect = {type}VectMaker.Make();')
+                    restores[classname].append(f'      for (unsigned int ind = 0; ind < obj.get{Name}().size(); ind++) {{')
+
+                    if key in ['class_ref', 'group_ref']:
+                        saves[classname].append(f'        ::ObjIndexType::Builder tmp = {Name}s[ind];')
+                        saves[classname].append(f'        tmp.setIndex(GetId(((BaseClass*) (*obj->{Name_}())[ind])));')
+                        saves[classname].append(f'        tmp.setType(((BaseClass*)((*obj->{Name_}())[ind]))->UhdmType());')
+                        restores[classname].append(f'        vect->push_back(({type}*)GetObject(obj.get{Name}()[ind].getType(), obj.get{Name}()[ind].getIndex()-1));')
+                    else:
+                        saves[classname].append(f'        {Name}s.set(ind, GetId((*obj->{Name_}())[ind]));')
+                        restores[classname].append(f'        vect->push_back({type}Maker.objects_[obj.get{Name}()[ind]-1]);')
+
+                    saves[classname].append('      }')
+                    saves[classname].append('    }')
+                    restores[classname].append( '      }')
+                    restores[classname].append(f'      {classname}Maker.objects_[index]->{Name_}(vect);')
+                    restores[classname].append( '    }')
+
+        baseclass = model['extends']
+        while baseclass:
+            Baseclass = (baseclass[:1].upper() + baseclass[1:]).replace('_', '')
+
+            saves[classname].extend([ line.replace(f' {Baseclass}s', f' {Classname}s') for line in saves[baseclass] ])
+            restores[classname].extend([ line.replace(f' {baseclass}Maker', f' {classname}Maker') for line in restores[baseclass] ])
+
+            # Parent class
+            baseclass = models[baseclass]['extends']
+
+    uhdm_name_map = [
+        'std::string UhdmName(UHDM_OBJECT_TYPE type) {',
+        '  switch (type) {'
+    ]
+    uhdm_name_map.extend([ f'  case {name} /* = {id} */: return "{name[4:]}";' for name, id in uhdm_types_h.get_type_map(models).items() ])
+    uhdm_name_map.append('  default: return "NO TYPE";')
+    uhdm_name_map.append('}')
+    uhdm_name_map.append('}')
+    uhdm_name_map.append('')
+
+    factories = []
+    factories_methods = []
+
+    factory_purge = []
+    factory_stats = []
+    factory_object_type_map = []
+    capnp_id = []
+    capnp_save = []
+
+    capnp_init_factories = []
+    capnp_restore_factories = []
+
+    for model in models.values():
+        modeltype = model['type']
+        if modeltype == 'group_def':
+            continue
+
+        classname = model['name']
+        Classname_ = classname[:1].upper() + classname[1:]
+        Classname = Classname_.replace('_', '')
+
+        if modeltype != 'class_def':
+            factories.append(f'    {classname}Factory {classname}Maker;')
+            factories_methods.append(f'    {classname}* Make{Classname_}() {{ {classname}* tmp = {classname}Maker.Make(); tmp->SetSerializer(this); tmp->UhdmId(objId_++); return tmp; }}')
+            factory_object_type_map.append(f'  case uhdm{classname}: return {classname}Maker.objects_[index];')
+
+        factories.append(f'    VectorOf{classname}Factory {classname}VectMaker;')
+        factories_methods.append(f'    std::vector<{classname}*>* Make{Classname_}Vec() {{ return {classname}VectMaker.Make();}}')
+
+        if modeltype == 'class_def':
+            continue
+
+        capnp_id.append( '  index = 1;')
+        capnp_id.append(f'  for (auto obj : {classname}Maker.objects_) {{')
+        capnp_id.append( '    SetId(obj, index);')
+        capnp_id.append( '    index++;')
+        capnp_id.append( '  }')
+
+        capnp_save.append(f'  ::capnp::List<{Classname}>::Builder {Classname}s = cap_root.initFactory{Classname}({classname}Maker.objects_.size());')
+        capnp_save.append( '  index = 0;')
+        capnp_save.append(f'  for (auto obj : {classname}Maker.objects_) {{')
+        capnp_save.extend(saves[classname])
+        capnp_save.append( '    index++;')
+        capnp_save.append( '  }')
+
+        capnp_init_factories.append(f'  ::capnp::List<{Classname}>::Reader {Classname}s = cap_root.getFactory{Classname}();')
+        capnp_init_factories.append(f'  for (unsigned ind = 0; ind < {Classname}s.size(); ind++) {{')
+        capnp_init_factories.append(f'    SetId(Make{Classname_}(), ind);')
+        capnp_init_factories.append( '  }')
+        capnp_init_factories.append( '')
+
+        capnp_restore_factories.append( '  index = 0;')
+        capnp_restore_factories.append(f'  for ({Classname}::Reader obj : {Classname}s) {{')
+        capnp_restore_factories.extend(restores[classname])
+        capnp_restore_factories.append( '    index++;')
+        capnp_restore_factories.append( '  }')
+        capnp_restore_factories.append( '')
+
+        factory_purge.append(f'  for (auto obj : {classname}Maker.objects_) {{')
+        factory_purge.append( '    delete obj;')
+        factory_purge.append( '  }')
+        factory_purge.append(f'  {classname}Maker.objects_.clear();')
+        factory_purge.append('')
+
+        factory_stats.append(f'  stats.insert(std::make_pair("{classname}", {classname}Maker.objects_.size()));')
+
+
+    # Serializer.h
+    with open(config.get_template_filepath('Serializer.h'), 'r+t') as strm:
+        file_content = strm.read()
+
+    file_content = file_content.replace('<FACTORIES>', '\n'.join(factories))
+    file_content = file_content.replace('<FACTORIES_METHODS>', '\n'.join(factories_methods))
+    file_utils.set_content_if_changed(config.get_output_header_filepath('Serializer.h'), file_content)
+
+    # Serializer_save.cpp
+    with open(config.get_template_filepath('Serializer_save.cpp'), 'r+t') as strm:
+        file_content = strm.read()
+
+    file_content = file_content.replace('<METHODS_CPP>', '\n'.join(methods))
+    file_content = file_content.replace('<UHDM_NAME_MAP>', '\n'.join(uhdm_name_map))
+    file_content = file_content.replace('<FACTORY_PURGE>', '\n'.join(factory_purge))
+    file_content = file_content.replace('<FACTORY_STATS>', '\n'.join(factory_stats))
+    file_content = file_content.replace('<FACTORY_OBJECT_TYPE_MAP>', '\n'.join(factory_object_type_map))
+    file_content = file_content.replace('<CAPNP_ID>', '\n'.join(capnp_id))
+    file_content = file_content.replace('<CAPNP_SAVE>', '\n'.join(capnp_save))
+    file_utils.set_content_if_changed(config.get_output_source_filepath('Serializer_save.cpp'), file_content)
+
+    # Serializer_restore.cpp
+    with open(config.get_template_filepath('Serializer_restore.cpp'), 'r+t') as strm:
+        file_content = strm.read()
+
+    file_content = file_content.replace('<CAPNP_INIT_FACTORIES>', '\n'.join(capnp_init_factories))
+    file_content = file_content.replace('<CAPNP_RESTORE_FACTORIES>', '\n'.join(capnp_restore_factories))
+    file_utils.set_content_if_changed(config.get_output_source_filepath('Serializer_restore.cpp'), file_content)
+
+    return True
+
+
+def _main():
+    import loader
+
+    config.configure()
+
+    models = loader.load_models()
+    return generate(models)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if _main() else 1)

--- a/scripts/uhdm_forward_decl_h.py
+++ b/scripts/uhdm_forward_decl_h.py
@@ -1,0 +1,28 @@
+import config
+import file_utils
+
+
+def generate(models):
+    classnames = [ model['name'] for model in models.values() if model['type'] != 'group_def' ]
+    declarations = '\n'.join([f'class {classname};' for classname in sorted(classnames) if classname != 'BaseClass'])
+
+    with open(config.get_template_filepath('uhdm_forward_decl.h'), 'r+t') as strm:
+        file_content = strm.read()
+
+    file_content = file_content.replace('<UHDM_FORWARD_DECL>', declarations)
+    file_utils.set_content_if_changed(config.get_output_header_filepath('uhdm_forward_decl.h'), file_content)
+    return True
+
+
+def _main():
+    import loader
+
+    config.configure()
+
+    models = loader.load_models()
+    return generate(models)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if _main() else 1)

--- a/scripts/uhdm_h.py
+++ b/scripts/uhdm_h.py
@@ -1,0 +1,28 @@
+import config
+import file_utils
+
+
+def generate(models):
+    classnames = [ model['name'] for model in models.values() ]
+    headers = '\n'.join([ f'#include "uhdm/{classname}.h"' for classname in classnames ])
+
+    with open(config.get_template_filepath('uhdm.h'), 'r+t') as strm:
+        file_content = strm.read()
+
+    file_content = file_content.replace('<INCLUDE_FILES>', headers)
+    file_utils.set_content_if_changed(config.get_output_header_filepath('uhdm.h'), file_content)
+    return True
+
+
+def _main():
+    import loader
+
+    config.configure()
+
+    models = loader.load_models()
+    return generate(models)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if _main() else 1)

--- a/scripts/uhdm_types_h.py
+++ b/scripts/uhdm_types_h.py
@@ -1,0 +1,70 @@
+from collections import OrderedDict
+
+import config
+import file_utils
+
+
+_next_objectid = 2001 # above sv_vpi_user.h and vhpi_user.h ranges.
+_object_ids = dict()
+
+
+def _get_type_id(name):
+    global _next_objectid, _object_ids
+
+    id = 0
+    if name in _object_ids:
+        id = _object_ids[name]
+
+    else:
+        id = _next_objectid
+        _next_objectid += 1
+        _object_ids[name] = id
+
+    return id
+
+
+def get_type_map(models):
+    types = OrderedDict()
+    for model in models.values():
+        classname = model['name']
+
+        typename = f'uhdm{classname}'
+        types[typename] = _get_type_id(typename)
+
+        for key, value in model.allitems():
+            if key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
+                name = value.get('name')
+                card = value.get('card')
+
+                if (card == 'any') and not name.endswith('s'):
+                    name += 's'
+
+                typename = f'uhdm{name}'
+                types[typename] = _get_type_id(typename)
+
+    return types
+
+
+def generate(models):
+    types = '\n'.join([f'  {name} = {id},' for name, id in get_type_map(models).items()])
+
+    with open(config.get_template_filepath('uhdm_types.h'), 'r+t') as strm:
+        file_content = strm.read()
+
+    file_content = file_content.replace('<DEFINES>', types)
+    file_utils.set_content_if_changed(config.get_output_header_filepath('uhdm_types.h'), file_content)
+    return True
+
+
+def _main():
+    import loader
+
+    config.configure()
+
+    models = loader.load_models()
+    return generate(models)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if _main() else 1)

--- a/scripts/vpi_listener.py
+++ b/scripts/vpi_listener.py
@@ -1,0 +1,147 @@
+import config
+import file_utils
+from collections import defaultdict
+
+
+def _get_listeners(classname, vpi, type, card):
+    listeners = []
+
+    if vpi in [ 'vpiParent', 'vpiInstance', 'vpiExtends' ]:
+        return listeners # To prevent infinite loops in visitors as these relations are pointing upward in the tree
+
+    elif card == '1':
+        # upward vpiModule, vpiInterface relation (when card == 1, pointing to the parent object) creates loops in visitors
+        if vpi in ['vpiModule', 'vpiInterface']:
+            return listeners
+
+        if 'func_call' in classname and vpi == 'vpiFunction':
+          # Prevent stepping inside functions while processing calls (func_call, method_func_call) to them
+          return listeners
+
+        if 'task_call' in classname and vpi == 'vpiTask':
+          # Prevent stepping inside tasks while processing calls (task_call, method_task_call) to them
+          return listeners
+
+        listeners.append(f'    itr = vpi_handle({vpi}, object);')
+        listeners.append( '    if (itr) {')
+        listeners.append(f'      listen_any(itr, listener, visited);')
+        listeners.append( '      vpi_free_object(itr);')
+        listeners.append( '    }')
+
+    else:
+        listeners.append(f'    itr = vpi_iterate({vpi}, object);')
+        listeners.append( '    if (itr) {')
+        listeners.append( '      while (vpiHandle obj = vpi_scan(itr)) {')
+        listeners.append(f'        listen_any(obj, listener, visited);')
+        listeners.append( '        vpi_free_object(obj);')
+        listeners.append( '      }')
+        listeners.append( '      vpi_free_object(itr);')
+        listeners.append( '    }')
+
+    return listeners
+
+
+def generate(models):
+    declarations = []
+    iterators = {}
+    implementations = []
+    classnames = set()
+
+    decl_appended = False
+    def _append_iterators(iterators):
+        nonlocal decl_appended
+        nonlocal implementations
+        if iterators:
+            if not decl_appended:
+                implementations.append( '    vpiHandle itr;')
+                decl_appended = True
+            implementations.extend(iterators)
+
+    for model in models.values():
+        modeltype = model['type']
+        if modeltype == 'group_def':
+            continue
+
+        classname = model['name']
+        Classname_ = classname[:1].upper() + classname[1:]
+
+        iterators[classname] = []
+        declarations.append(f'void listen_{classname}(vpiHandle object, UHDM::VpiListener* listener, UHDM::VisitedContainer* visited);')
+
+        implementations.append(f'void UHDM::listen_{classname}(vpiHandle object, VpiListener* listener, UHDM::VisitedContainer* visited) {{')
+        implementations.append(f'  {classname}* d = ({classname}*) ((const uhdm_handle*)object)->object;')
+        implementations.append( '  const bool alreadyVisited = (visited->find(d) != visited->end());')
+        implementations.append( '  visited->insert(d);')
+        implementations.append( '  const BaseClass* parent = d->VpiParent();')
+        implementations.append( '  vpiHandle parent_h = parent ? NewVpiHandle(parent) : 0;')
+        implementations.append(f'  listener->enter{Classname_}(d, parent, object, parent_h);')
+        implementations.append( '  if (!alreadyVisited) {')
+
+        if modeltype != 'class_def':
+            classnames.add(classname)
+
+        decl_appended = False
+
+        for key, value in model.allitems():
+            if key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
+                vpi  = value.get('vpi')
+                type = value.get('type')
+                card = value.get('card')
+
+                if key == 'group_ref':
+                    type = 'any'
+
+                _append_iterators(_get_listeners(classname, vpi, type, card))
+                iterators[classname].append((vpi, type, card))
+
+        # process baseclass recursively
+        baseclass = model['extends']
+        while baseclass:
+            for vpi, type, card in iterators[baseclass]:
+                _append_iterators(_get_listeners(classname, vpi, type, card))
+
+            baseclass = models[baseclass]['extends']
+
+        implementations.append( '  }')
+        implementations.append(f'  listener->leave{Classname_}(d, parent, object, parent_h);')
+        implementations.append( '  vpi_release_handle(parent_h);')
+        implementations.append( '}')
+        implementations.append( '')
+
+
+   # vpi_listener.h
+    with open(config.get_template_filepath('vpi_listener.h'), 'r+t') as strm:
+        file_content = strm.read()
+
+    file_content = file_content.replace('<VPI_LISTENERS_HEADER>', '\n'.join(declarations))
+    file_utils.set_content_if_changed(config.get_output_header_filepath('vpi_listener.h'), file_content)
+
+    any_implementation = []
+    for classname in sorted(classnames):
+        any_implementation.append(f'  case uhdm{classname}:')
+        any_implementation.append(f'    listen_{classname}(object, listener, visited);')
+        any_implementation.append( '    break;')
+
+    # vpi_listener.cpp
+    with open(config.get_template_filepath('vpi_listener.cpp'), 'r+t') as strm:
+        file_content = strm.read()
+
+    file_content = file_content.replace('<VPI_LISTENERS>', '\n'.join(implementations))
+    file_content = file_content.replace('<VPI_ANY_LISTENERS>', '\n'.join(any_implementation))
+    file_utils.set_content_if_changed(config.get_output_source_filepath('vpi_listener.cpp'), file_content)
+
+    return True
+
+
+def _main():
+    import loader
+
+    config.configure()
+
+    models = loader.load_models()
+    return generate(models)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if _main() else 1)

--- a/scripts/vpi_user_cpp.py
+++ b/scripts/vpi_user_cpp.py
@@ -1,0 +1,301 @@
+import config
+import file_utils
+
+
+vpi_iterator = {}
+vpi_iterate_body = {}
+vpi_get_str_body_inst = {}
+vpi_get_body_inst = {}
+vpi_handle_by_name_body = {}
+
+vpi_scan_body = []
+vpi_get_body = []
+vpi_get_value_body = []
+vpi_get_delay_body = []
+vpi_get_str_body = []
+vpi_handle_body = {}
+
+vpi_iterate_body_all = []
+vpi_handle_body_all = []
+vpi_handle_by_name_body_all = []
+
+
+def _print_iterate_body(name, classname, vpi, card):
+    content = []
+    if card == 'any':
+        Name_ = name[:1].upper() + name[1:]
+        content.append(f'  if ((handle->type == uhdm{classname}) && (type == {vpi})) {{')
+        content.append(f'    if ((({classname}*)(object))->{Name_}())')
+        content.append(f'      return NewHandle(uhdm{name}, (({classname}*)(object))->{Name_}());')
+        content.append( '    else return 0;')
+        content.append( '  }')
+    return content
+
+
+def _print_get_handle_by_name_body(name, classname, vpi, card):
+    content = []
+    Name_ = name[:1].upper() + name[1:]
+    if card == '1':
+        content.append(f'  if (handle->type == uhdm{classname}) {{')
+        content.append(f'    const {classname}* const obj = (const {classname}*)(object);')
+        content.append(f'    if (obj->{Name_}() && obj->{Name_}()->VpiName() == name) {{')
+        content.append(f'      return NewVpiHandle(obj->{Name_}());')
+        content.append( '    }')
+        content.append( '  }')
+    else:
+        content.append(f'  if (handle->type == uhdm{classname}) {{')
+        content.append(f'    const {classname}* const obj_parent = (const {classname}*)(object);')
+        content.append(f'    if (obj_parent->{Name_}()) {{')
+        content.append(f'      for (const BaseClass *obj : *obj_parent->{Name_}())')
+        content.append(f'        if (obj->VpiName() == name) return NewVpiHandle(obj);')
+        content.append( '    }')
+        content.append( '  }')
+    return content
+
+
+def _print_get_body_prefix(classname):
+    return [
+      f'  if (handle->type == uhdm{classname}) {{',
+       '    switch (property) {'
+    ]
+
+
+def _print_get_body_suffix():
+    return [ '    }', '  }' ]
+
+
+def _print_get_body(classname, type, vpi, card):
+    content = []
+    if vpi in ['vpiType', 'vpiLineNo', 'vpiColumnNo', 'vpiEndLineNo', 'vpiEndColumnNo']:  # These are already handled by base class
+        return content
+
+    if (card == '1') and (type not in ['string', 'value', 'delay']):
+        content.append(f'      case {vpi}: return ((const {classname}*)(obj))->{vpi[:1].upper()}{vpi[1:]}();')
+
+    return content
+
+
+def _print_get_value_body(classname, type, vpi, card):
+    content = []
+    if (card == '1') and (type == 'value'):
+        content.append(f'  if (handle->type == uhdm{classname}) {{')
+        content.append(f'    const s_vpi_value* v = String2VpiValue((({classname}*)(obj))->VpiValue());')
+        content.append( '    if (v) {')
+        content.append( '      *value_p = *v;')
+        content.append( '    }')
+        content.append( '  }')
+
+    return content
+
+
+def _print_get_delay_body(classname, type, vpi, card):
+    content = []
+    if (card == '1') and (type == 'delay'):
+        content.append(f'  if (handle->type == uhdm{classname}) {{')
+        content.append(f'    const s_vpi_delay* v = String2VpiDelays((({classname}*)(obj))->VpiDelay());')
+        content.append( '    if (v) {')
+        content.append( '      *delay_p = *v;')
+        content.append( '    }')
+        content.append( '  }')
+    return content
+
+
+def _print_get_handle_body(classname, type, vpi, object, card):
+    if type == 'BaseClass':
+        type = f'(({classname}*)(object))->UhdmParentType()'
+
+    content = []
+    need_casting = not ((vpi == 'vpiParent') and (object == 'vpiParent'))
+
+    if card == '1':
+        Object_ = object[:1].upper() + object[1:]
+        casted_object1 = f'((BaseClass*)(({classname}*)(object))' if need_casting else '(object'
+        casted_object2 = f'(({classname}*)(object))' if need_casting else 'object'
+        content.append(f'  if ((handle->type == uhdm{classname}) && (type == {vpi})) {{')
+        content.append(f'    if ({casted_object1}->{Object_}()))')
+        content.append(f'      return NewHandle({casted_object1}->{Object_}())->UhdmType(), {casted_object2}->{Object_}());')
+        content.append( '    else return 0;')
+        content.append( '  }')
+    return content
+
+
+def _print_get_str_body(classname, type, vpi, card):
+    # Already handled by the base class
+    content = []
+    if vpi in ['vpiFile', 'vpiName', 'vpiDefName']:
+        return content
+
+    Vpi_ = vpi[:1].upper() + vpi[1:]
+    if (card == '1') and (type == 'string'):
+        content.append(f'  if ((handle->type == uhdm{classname}) && (property == {vpi})) {{')
+        content.append(f'    const {classname}* const o = (const {classname}*)(obj);')
+        if vpi == 'vpiFullName':
+            content.append(f'    return (o->{Vpi_}().empty() || o->{Vpi_}() == o->VpiName())')
+            content.append( '      ? 0')
+            content.append(f'      : (PLI_BYTE8*) o->{Vpi_}().c_str();')
+        else:
+            content.append(f'    return (PLI_BYTE8*) (o->{Vpi_}().empty() ? 0 : o->{Vpi_}().c_str());')
+        content.append( '  }')
+    return content
+
+
+def _print_scan_body(name, classname, type, card):
+    content = []
+    if card == 'any':
+        content.append(f'  if (handle->type == uhdm{name}) {{')
+        content.append(f'    VectorOf{type}* the_vec = (VectorOf{type}*)vect;')
+        content.append( '    if (handle->index < the_vec->size()) {')
+        content.append( '      uhdm_handle* h = new uhdm_handle(((BaseClass*)the_vec->at(handle->index))->UhdmType(), the_vec->at(handle->index));')
+        content.append( '      handle->index++;')
+        content.append( '      return (vpiHandle) h;')
+        content.append( '    }')
+        content.append( '  }')
+    return content
+
+
+def _update_vpi_inst(baseclass, classname):
+    for type, vpi, card in vpi_get_str_body_inst[baseclass]:
+        vpi_get_str_body.extend(_print_get_str_body(classname, type, vpi, card))
+
+    vpi_case_body = []
+    for type, vpi, card in vpi_get_body_inst[baseclass]:
+        vpi_case_body.extend(_print_get_body(classname, type, vpi, card))
+           
+    # The case body can be empty if all propeerties have been handled
+    # in the base class. So only if non-empty, add the if/switch
+    if vpi_case_body:
+        vpi_get_body.extend(_print_get_body_prefix(classname))
+        vpi_get_body.extend(vpi_case_body)
+        vpi_get_body.extend(_print_get_body_suffix())
+
+    for type, vpi, card in vpi_get_body_inst[baseclass]:
+        vpi_get_value_body.extend(_print_get_value_body(classname, type, vpi, card))
+        vpi_get_delay_body.extend(_print_get_delay_body(classname, type, vpi, card))
+
+
+def _process_baseclass(model, models):
+    classname = model['name']
+    baseclass = model['extends']
+    while baseclass:
+        _update_vpi_inst(baseclass, classname)
+
+        vpi_iterate_body_all.extend([
+          line.replace(f'= uhdm{baseclass}', f'= uhdm{classname}')
+          for line in vpi_iterate_body[baseclass]
+        ])
+
+        vpi_handle_body_all.extend([
+          line.replace(f'= uhdm{baseclass}', f'= uhdm{classname}').replace(f'{baseclass}*', f'{classname}*')
+          for line in vpi_handle_body[baseclass]
+        ])
+
+        vpi_handle_by_name_body_all.extend([
+          line.replace(f'= uhdm{baseclass}', f'= uhdm{classname}')
+          for line in vpi_handle_by_name_body[baseclass]
+        ])
+
+        baseclass = models[baseclass]['extends']
+
+
+def generate(models):
+    for model in models.values():
+        modeltype = model['type']
+        if modeltype == 'group_def':
+            continue
+
+        classname = model['name']
+        baseclass = model['extends']
+
+        vpi_iterate_body[classname] = []
+        vpi_iterator[classname] = []
+        vpi_handle_body[classname] = []
+        vpi_get_str_body_inst[classname] = []
+        vpi_get_body_inst[classname] = []
+        vpi_handle_by_name_body[classname] = []
+
+        if modeltype != 'class_def':
+            # Builtin properties do not need to be specified in each models
+            # Builtins: "vpiParent, Parent type, vpiFile, Id" method and field
+            vpi_handle_body[classname] += _print_get_handle_body(classname, 'BaseClass', 'vpiParent', 'vpiParent', '1')
+            vpi_get_str_body_inst[classname].append(('string', 'vpiFile', '1'))
+
+        type_specified = False
+        for key, value in model.allitems():
+            if key == 'property':
+                name = value.get('name')
+                vpi = value.get('vpi')
+                type = value.get('type')
+                card = value.get('card')
+
+                if name == 'type':
+                    type_specified = True
+                    vpi_get_body_inst[classname].append((type, vpi, card))
+                else:
+                    # properties are already defined in vpi_user.h, no need to redefine them
+                    vpi_get_body_inst[classname].append((type, vpi, card))
+                    vpi_get_str_body_inst[classname].append((type, vpi, card))
+
+            elif key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
+                name = value.get('name')
+                vpi = value.get('vpi')
+                type = value.get('type')
+                card = value.get('card')
+
+                if (card == 'any') and not name.endswith('s'):
+                    name += 's'
+
+                if key == 'group_ref':
+                    type = 'any'
+
+                vpi_iterate_body[classname].extend(_print_iterate_body(name, classname, vpi, card))
+                vpi_handle_by_name_body[classname].extend(_print_get_handle_by_name_body(name, classname, vpi, card))
+                vpi_iterator[classname].append((vpi, type, card))
+                vpi_scan_body.extend(_print_scan_body(name, classname, type, card))
+                vpi_handle_body[classname].extend(_print_get_handle_body(classname, f'uhdm{type}', vpi, name, card))
+
+        if not type_specified and (modeltype == 'obj_def'):
+            vpiclasstype = config.make_vpi_name(classname)
+            vpi_get_body_inst[classname].append(('unsigned int', 'vpiType', '1'))
+
+        # VPI
+        _update_vpi_inst(classname, classname)
+
+        vpi_iterate_body_all.extend(vpi_iterate_body[classname])
+        vpi_handle_body_all.extend(vpi_handle_body[classname])
+        vpi_handle_by_name_body_all.extend(vpi_handle_by_name_body[classname])
+
+        # process baseclass recursively
+        _process_baseclass(model, models)
+
+    headers = [ f"#include \"uhdm/{model['name']}.h\"" for model in models.values() ]
+
+    # vpi_user.cpp
+    with open(config.get_template_filepath('vpi_user.cpp'), 'r+t') as strm:
+        file_content = strm.read()
+
+    file_content = file_content.replace('<HEADERS>', '\n'.join(headers))
+    file_content = file_content.replace('<VPI_HANDLE_BY_NAME_BODY>', '\n'.join(vpi_handle_by_name_body_all))
+    file_content = file_content.replace('<VPI_ITERATE_BODY>', '\n'.join(vpi_iterate_body_all))
+    file_content = file_content.replace('<VPI_SCAN_BODY>', '\n'.join(vpi_scan_body))
+    file_content = file_content.replace('<VPI_HANDLE_BODY>', '\n'.join(vpi_handle_body_all))
+    file_content = file_content.replace('<VPI_GET_BODY>', '\n'.join(vpi_get_body))
+    file_content = file_content.replace('<VPI_GET_VALUE_BODY>', '\n'.join(vpi_get_value_body))
+    file_content = file_content.replace('<VPI_GET_DELAY_BODY>', '\n'.join(vpi_get_delay_body))
+    file_content = file_content.replace('<VPI_GET_STR_BODY>', '\n'.join(vpi_get_str_body))
+    file_utils.set_content_if_changed(config.get_output_source_filepath('vpi_user.cpp'), file_content)
+
+    return True
+
+
+def _main():
+    import loader
+
+    config.configure()
+
+    models = loader.load_models()
+    return generate(models)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if _main() else 1)

--- a/scripts/vpi_visitor_cpp.py
+++ b/scripts/vpi_visitor_cpp.py
@@ -1,0 +1,168 @@
+import config
+import file_utils
+
+
+def _get_implementation(classname, vpi, card):
+    shallow_visit = ''
+    content = []
+    if (vpi == 'vpiParent') and (classname != 'part_select'):
+        return content
+
+    if card == '1':
+        if 'func_call' in classname and vpi == 'vpiFunction':
+            # Prevent stepping inside functions while processing calls (func_call, method_func_call) to them
+            shallow_visit = ', true'
+
+        if 'task_call' in classname and vpi == 'vpiTask':
+            # Prevent stepping inside tasks while processing calls (task_call, method_task_call) to them
+            shallow_visit = ', true'
+
+        # Prevent loop in Standard VPI
+        if vpi not in ['vpiModule', 'vpiInterface']:
+            content.append(f'    itr = vpi_handle({vpi}, obj_h);')
+            content.append(f'    visit_object(itr, subobject_indent, "{vpi}", visited, out{shallow_visit});')
+            content.append( '    release_handle(itr);')
+
+    else:
+        if classname == 'design':
+            content.append('    if (indent == 0) visited->clear();')
+
+        # Prevent loop in Standard VPI
+        if vpi != 'vpiUse':
+            content.append(f'    itr = vpi_iterate({vpi}, obj_h);')
+            content.append( '    while (vpiHandle obj = vpi_scan(itr)) {')
+            content.append(f'      visit_object(obj, subobject_indent, "{vpi}", visited, out{shallow_visit});')
+            content.append( '      release_handle(obj);')
+            content.append( '    }')
+            content.append( '    release_handle(itr);')
+
+    return content
+
+
+def _get_vpi_str_visitor(type, vpi, card):
+    content = []
+    if (card == '1') and (type == 'string') and (vpi != 'vpiFile'):
+        content.append(f'    if (const char* s = vpi_get_str({vpi}, obj_h))')
+        content.append(f'      stream_indent(out, indent) << "|{vpi}:" << s << std::endl;')
+    return content
+
+
+def _get_vpi_xxx_visitor(type, vpi, card):
+    content = []
+    if vpi == 'vpiValue':
+        content.append('    s_vpi_value value;')
+        content.append('    vpi_get_value(obj_h, &value);')
+        content.append('    if (value.format) {')
+        content.append('      std::string val = visit_value(&value);')
+        content.append('      if (!val.empty()) {')
+        content.append('        stream_indent(out, indent) << val;')
+        content.append('      }')
+        content.append('    }')
+    elif vpi == 'vpiDelay':
+        content.append('    s_vpi_delay delay;')
+        content.append('    vpi_get_delays(obj_h, &delay);')
+        content.append('    if (delay.da != nullptr) {')
+        content.append('      stream_indent(out, indent) << visit_delays(&delay);')
+        content.append('    }')
+    elif (card == '1') and (type != 'string') and (vpi not in ['vpiType', 'vpiLineNo', 'vpiColumnNo', 'vpiEndLineNo', 'vpiEndColumnNo']):
+        content.append(f'    if (const int n = vpi_get({vpi}, obj_h))')
+        content.append(f'      stream_indent(out, indent) << "|{vpi}:" << n << std::endl;')
+    return content
+
+
+def generate(models):
+    vpi_iterator = {}
+    vpi_get_body = {}
+    vpi_get_str_body = {}
+
+    for model in models.values():
+        modeltype = model['type']
+        if modeltype == 'group_def':
+            continue
+
+        classname = model['name']
+
+        vpi_iterator[classname] = []
+        vpi_get_body[classname] = []
+        vpi_get_str_body[classname] = []
+
+        if modeltype != 'class_def':
+            vpi_iterator[classname].append(('vpiParent', '1'))
+            vpi_get_str_body[classname].append(('string', 'vpiFile', '1'))
+
+        type_specified = False
+        for key, value in model.allitems():
+            if key == 'property':
+                name = value.get('name')
+                vpi = value.get('vpi')
+                type = value.get('type')
+                card = value.get('card')
+
+                vpi_get_body[classname].append((type, vpi, card))
+                if name == 'type':
+                    type_specified = True
+                else:
+                    vpi_get_str_body[classname].append((type, vpi, card))
+
+            elif key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
+                vpi = value.get('vpi')
+                card = value.get('card')
+
+                vpi_iterator[classname].append((vpi, card))
+
+        if not type_specified and (modeltype == 'obj_def'):
+            vpi_get_body[classname].append(('unsigned int', 'vpiType', '1'))
+
+    visitors = []
+    for model in models.values():
+        modeltype = model['type']
+        if modeltype in ['group_def', 'class_def']:
+            continue
+
+        classname = model['name']
+
+        locals = []
+        remotes = []
+        baseclass = classname
+        while baseclass:
+            for type, vpi, card in vpi_get_str_body[baseclass]:
+                locals.extend(_get_vpi_str_visitor(type, vpi, card))
+
+            for type, vpi, card in vpi_get_body[baseclass]:
+                locals.extend(_get_vpi_xxx_visitor(type, vpi, card))
+
+            for vpi, card in vpi_iterator[baseclass]:
+                remotes.extend(_get_implementation(classname, vpi, card))
+
+            baseclass = models[baseclass]['extends']
+
+        if locals or remotes:
+            vpi_name = config.make_vpi_name(classname)
+            visitors.append(f'  if (objectType == {vpi_name}) {{')
+            visitors.extend(locals)
+            visitors.extend(remotes)
+            visitors.append( '    return;')
+            visitors.append( '  }')
+
+    # vpi_visitor.cpp
+    with open(config.get_template_filepath('vpi_visitor.cpp'), 'r+t') as strm:
+        file_content = strm.read()
+
+    file_content = file_content.replace('<OBJECT_VISITORS>', '\n'.join(visitors))
+    file_utils.set_content_if_changed(config.get_output_source_filepath('vpi_visitor.cpp'), file_content)
+
+    return True
+
+
+def _main():
+    import loader
+
+    config.configure()
+
+    models = loader.load_models()
+    return generate(models)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if _main() else 1)

--- a/templates/BaseClass.h
+++ b/templates/BaseClass.h
@@ -26,7 +26,10 @@
 
 #ifndef UHDM_BASE_CLASS_H
 #define UHDM_BASE_CLASS_H
+
 #include <set>
+#include <vector>
+
 #include <uhdm/uhdm_types.h>
 
 namespace UHDM {
@@ -36,7 +39,7 @@ namespace UHDM {
 
   class ClientData {
   public:
-    virtual ~ClientData(){};
+    virtual ~ClientData() = default;
   };
 
   class BaseClass {
@@ -46,7 +49,7 @@ namespace UHDM {
     // Use implicit constructor to initialize all members
     // BaseClass()
 
-    virtual ~BaseClass(){}
+    virtual ~BaseClass() = default;
 
     Serializer* GetSerializer() const { return serializer_; }
 
@@ -100,9 +103,9 @@ namespace UHDM {
   protected:
     void SetSerializer(Serializer* serial) { serializer_ = serial; }
 
-    Serializer* serializer_;
+    Serializer* serializer_ = nullptr;
 
-    ClientData* clientData_;
+    ClientData* clientData_ = nullptr;
 
   private:
     int vpiLineNo_ = 0;
@@ -113,12 +116,38 @@ namespace UHDM {
   };
 
 #ifdef STANDARD_VPI
-typedef std::set<vpiHandle> VisitedContainer;
+  typedef std::set<vpiHandle> VisitedContainer;
 #else
-typedef  std::set<const BaseClass*> VisitedContainer;
+  typedef  std::set<const BaseClass*> VisitedContainer;
 #endif
 
-  
+  template<typename T>
+  class FactoryT {
+    friend Serializer;
+    typedef std::vector<T *> objects_t;
+
+   public:
+    T* Make() {
+      T* obj = new T;
+      objects_.push_back(obj);
+      return obj;
+    }
+
+    bool Erase(T* tps) {
+      for (typename objects_t::const_iterator itr = objects_.begin();
+           itr != objects_.end(); ++itr) {
+        if ((*itr) == tps) {
+          objects_.erase(itr);
+          return true;
+        }
+      }
+      return false;
+    }
+
+   private:
+    objects_t objects_;
+  };
+
 }  // namespace UHDM
 
 #endif

--- a/templates/Serializer.h
+++ b/templates/Serializer.h
@@ -60,7 +60,8 @@ namespace UHDM {
     uhdm_handleFactory uhdm_handleMaker;
 <FACTORIES>
 
-  std::unordered_map<const BaseClass*, unsigned long>& AllObjects() { return allIds_; }
+    std::unordered_map<const BaseClass*, unsigned long>& AllObjects() { return allIds_; }
+
   private:
     BaseClass* GetObject(unsigned int objectType, unsigned int index);
     void SetId(const BaseClass* p, unsigned long id);
@@ -72,6 +73,5 @@ namespace UHDM {
     ErrorHandler errorHandler;
   };
 };
-
 
 #endif

--- a/templates/Serializer_restore.cpp
+++ b/templates/Serializer_restore.cpp
@@ -70,7 +70,6 @@ const std::vector<vpiHandle> Serializer::Restore(const std::string& file) {
   }
 
 <CAPNP_INIT_FACTORIES>
-
 <CAPNP_RESTORE_FACTORIES>
 
    for (auto d : designMaker.objects_) {

--- a/templates/VpiListenerTracer.h
+++ b/templates/VpiListenerTracer.h
@@ -1,0 +1,67 @@
+// -*- c++ -*-
+
+/*
+
+ Copyright 2019 Alain Dargelas
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/*
+ * File:   VpiListenerTracer.h
+ * Author: hs
+ *
+ * Created on October 11, 2020, 9:00 PM
+ */
+
+#ifndef UHDM_VPILISTENERTRACER_CLASS_H
+#define UHDM_VPILISTENERTRACER_CLASS_H
+
+#include "VpiListener.h"
+
+#include <ostream>
+#include <string>
+
+#define TRACE_CONTEXT                 \
+  "[" << object->VpiLineNo() <<       \
+  "," << object->VpiColumnNo() <<     \
+  ":" << object->VpiEndLineNo() <<    \
+  "," << object->VpiEndColumnNo() <<  \
+  "]"
+
+#define TRACE_ENTER strm                \
+  << std::string(++indent * 2, ' ')     \
+  << __func__ << ": " << TRACE_CONTEXT  \
+  << std::endl
+#define TRACE_LEAVE strm                \
+  << std::string(2 * indent--, ' ')     \
+  << __func__ << ": " << TRACE_CONTEXT  \
+  << std::endl
+
+namespace UHDM {
+
+  class VpiListenerTracer : public VpiListener {
+  public:
+    VpiListenerTracer(std::ostream &strm) : strm(strm) {}
+
+    virtual ~VpiListenerTracer() = default;
+
+<VPI_LISTENER_TRACER_METHODS>
+
+  protected:
+   std::ostream &strm;
+   int indent = -1;
+  };
+};
+
+#endif

--- a/templates/class_header.h
+++ b/templates/class_header.h
@@ -30,62 +30,34 @@
 #include <uhdm/uhdm_vpi_user.h>
 
 #include <uhdm/SymbolFactory.h>
-#include <uhdm/BaseClass.h>
 #include <uhdm/containers.h>
-
 #include <uhdm/<EXTENDS>.h>
 
 <GROUP_HEADER_DEPENDENCY>
 
+
 namespace UHDM {
 <TYPE_FORWARD_DECLARE>
 
-class <CLASSNAME> <FINAL_CLASS> : public <EXTENDS> {
+class <CLASSNAME><FINAL_CLASS> : public <EXTENDS> {
 public:
   // Implicit constructor used to initialize all members,
   // comment: <CLASSNAME>();
-  <VIRTUAL>~<CLASSNAME>() <FINAL_DESTRUCTOR> {}
-  <METHODS>
+  <VIRTUAL>~<CLASSNAME>()<FINAL_DESTRUCTOR> = default;
+
+<METHODS>
+
   <VIRTUAL> UHDM_OBJECT_TYPE UhdmType() const <OVERRIDE_OR_FINAL> { return uhdm<CLASSNAME>; }
 
 private:
-  <MEMBERS>
+<MEMBERS>
 };
 
 <DISABLE_OBJECT_FACTORY>
-class <CLASSNAME>Factory {
-  friend Serializer;
-public:
-  <CLASSNAME>* Make() {
-    <CLASSNAME>* obj = new <CLASSNAME>();
-    objects_.push_back(obj);
-    return obj;
-  }
-  void Erase(<CLASSNAME>* tps) {
-    for (std::vector<<CLASSNAME>*>::iterator itr = objects_.begin(); itr != objects_.end(); itr++) {
-      if ((*itr) == tps) {
-        objects_.erase(itr);
-        break;
-      }
-    }
-  }
-
-private:
-  std::vector<<CLASSNAME>*> objects_;
-};
+typedef FactoryT<<CLASSNAME>> <CLASSNAME>Factory;
 <END_DISABLE_OBJECT_FACTORY>
 
-class VectorOf<CLASSNAME>Factory {
-  friend Serializer;
-public:
- std::vector<<CLASSNAME>*>* Make() {
-   std::vector<<CLASSNAME>*>* obj = new std::vector<<CLASSNAME>*>();
-   objects_.push_back(obj);
-   return obj;
- }
-private:
- std::vector<std::vector<<CLASSNAME>*>*> objects_;
-};
+typedef FactoryT<std::vector<<CLASSNAME> *>> VectorOf<CLASSNAME>Factory;
 
 }  // namespace UHDM
 

--- a/templates/clone_tree.cpp
+++ b/templates/clone_tree.cpp
@@ -96,19 +96,19 @@ any* ElaboratorListener::bindTaskFunc(const std::string& name, const class_var* 
     if (tps && tps->UhdmType() == uhdmclass_typespec) {
       const class_defn* def = ((class_typespec*) tps)->Class_defn();
       while (def) {
-	if (def->Task_funcs()) {
-	  for (task_func* tf : *def->Task_funcs()) {
-	    if (tf->VpiName() == name)
-	      return tf;
-	  }
-	}
-	const UHDM::extends* ext = def->Extends();
-	if (ext) {
-	  const class_typespec* tps = ext->Class_typespec();
-	  def = tps->Class_defn();
-	} else {
-	  break;
-	}
+        if (def->Task_funcs()) {
+          for (task_func* tf : *def->Task_funcs()) {
+            if (tf->VpiName() == name)
+              return tf;
+          }
+        }
+        const UHDM::extends* ext = def->Extends();
+        if (ext) {
+          const class_typespec* tps = ext->Class_typespec();
+          def = tps->Class_defn();
+        } else {
+          break;
+        }
       }
     }
   }
@@ -910,12 +910,12 @@ void ElaboratorListener::enterVariables(const variables* object,
 }
 
 void ElaboratorListener::leaveVariables(const variables* object, const BaseClass* parent,
-                   vpiHandle handle, vpiHandle parentHandle) {
+                                        vpiHandle handle, vpiHandle parentHandle) {
 
 }
 
 void ElaboratorListener::enterTask_func(const task_func* object, const BaseClass* parent,
-				       vpiHandle handle, vpiHandle parentHandle) {
+                                        vpiHandle handle, vpiHandle parentHandle) {
 
   // Collect instance elaborated nets
   ComponentMap varMap;
@@ -940,11 +940,12 @@ void ElaboratorListener::enterTask_func(const task_func* object, const BaseClass
 }
 
 void ElaboratorListener::leaveTask_func(const task_func* object, const BaseClass* parent,
-				       vpiHandle handle, vpiHandle parentHandle) {
+                                        vpiHandle handle, vpiHandle parentHandle) {
   instStack_.pop_back();
 }
 
-void ElaboratorListener::enterGen_scope(const gen_scope* object, const BaseClass* parent, vpiHandle handle, vpiHandle parentHandle) {
+void ElaboratorListener::enterGen_scope(const gen_scope* object, const BaseClass* parent,
+                                        vpiHandle handle, vpiHandle parentHandle) {
   // Collect instance elaborated nets
 
   ComponentMap netMap;
@@ -981,7 +982,8 @@ void ElaboratorListener::enterGen_scope(const gen_scope* object, const BaseClass
   instStack_.push_back(std::make_pair(object, std::make_tuple(netMap, paramMap, funcMap)));
 }
 
-void ElaboratorListener::leaveGen_scope(const gen_scope* object, const BaseClass* parent, vpiHandle handle, vpiHandle parentHandle) {
+void ElaboratorListener::leaveGen_scope(const gen_scope* object, const BaseClass* parent,
+                                        vpiHandle handle, vpiHandle parentHandle) {
   instStack_.pop_back();
 }
 

--- a/templates/containers.h
+++ b/templates/containers.h
@@ -23,16 +23,15 @@
  * Created on December 14, 2019, 10:03 PM
  */
 
-#include <vector>
-#include <unordered_map>
-#include <uhdm/uhdm_types.h>
-
 #ifndef UHDM_CONTAINERS_H
 #define UHDM_CONTAINERS_H
 
+#include <vector>
+#include <unordered_map>
+#include <uhdm/uhdm_forward_decl.h>
+
 namespace UHDM {
-  typedef std::vector<any*> VectorOfany;
-  <CONTAINERS>
+<CONTAINERS>
 };
 
 #endif

--- a/templates/group_header.cpp
+++ b/templates/group_header.cpp
@@ -34,7 +34,9 @@ bool <GROUPNAME>GroupCompliant(any* item) {
   }
   BaseClass* the_item = (BaseClass*) item;
   UHDM_OBJECT_TYPE uhdmtype = the_item->UhdmType();
-  if (<CHECKTYPE>) {
+  if (
+<CHECKTYPE>
+  ) {
     item->GetSerializer()->GetErrorHandler()("Internal Error: adding wrong object type (" + UhdmName(uhdmtype) + ") in a <GROUPNAME> group!");
     return false;
   }

--- a/templates/vpi_user.cpp
+++ b/templates/vpi_user.cpp
@@ -217,7 +217,7 @@ vpiHandle vpi_handle_by_name (PLI_BYTE8    *name,
                               vpiHandle    refHandle) {
   const uhdm_handle* const handle = (const uhdm_handle*) refHandle;
   const BaseClass* const object = (const BaseClass*) handle->object;
-  <VPI_HANDLE_BY_NAME_BODY>
+<VPI_HANDLE_BY_NAME_BODY>
   return 0;
 }
 
@@ -225,7 +225,7 @@ vpiHandle vpi_handle (PLI_INT32 type,
                       vpiHandle   refHandle) {
   const uhdm_handle* const handle = (const uhdm_handle*) refHandle;
   const BaseClass* const object = (const BaseClass*) handle->object;
-  <VPI_HANDLE_BODY>
+<VPI_HANDLE_BODY>
   std::cout << "VPI ERROR: Bad usage of vpi_handle" << std::endl;
   return 0;
 }
@@ -242,8 +242,7 @@ vpiHandle vpi_handle_multi (PLI_INT32 type,
 vpiHandle vpi_iterate (PLI_INT32 type, vpiHandle refHandle) {
   const uhdm_handle* const handle = (const uhdm_handle*) refHandle;
   const BaseClass* const object = (const BaseClass*) handle->object;
-
-  <VPI_ITERATE_BODY>
+<VPI_ITERATE_BODY>
   std::cout << "VPI ERROR: Bad usage of vpi_iterate" << std::endl;
   return 0;
 }
@@ -252,7 +251,7 @@ vpiHandle vpi_scan (vpiHandle iterator) {
   if (!iterator) return 0;
   uhdm_handle* handle = (uhdm_handle*) iterator;
   const void* vect = handle->object;
-  <VPI_SCAN_BODY>
+<VPI_SCAN_BODY>
   return 0;
 }
 
@@ -335,7 +334,7 @@ PLI_BYTE8 *vpi_get_str (PLI_INT32 property,
   }
 
   // ... all other properties currently handled 'manually' for now
-  <VPI_GET_STR_BODY>
+<VPI_GET_STR_BODY>
 
   return 0;
 }
@@ -351,7 +350,7 @@ void vpi_get_delays (vpiHandle object,
   const uhdm_handle* const handle = (const uhdm_handle*) object;
   const BaseClass*  const obj = (const BaseClass*) handle->object;
   delay_p->da = nullptr;
-  <VPI_GET_DELAY_BODY>
+<VPI_GET_DELAY_BODY>
 }
 
 void vpi_put_delays (vpiHandle object,
@@ -368,7 +367,7 @@ void vpi_get_value (vpiHandle vexpr,
   const uhdm_handle* const handle = (const uhdm_handle*) vexpr;
   const BaseClass*  const obj = (const BaseClass*) handle->object;
   value_p->format = 0;
-  <VPI_GET_VALUE_BODY>
+<VPI_GET_VALUE_BODY>
 }
 
 vpiHandle vpi_put_value (vpiHandle object,
@@ -399,13 +398,13 @@ void vpi_get_time(vpiHandle object,
 
 PLI_INT32 vpi_get_data (PLI_INT32 id,
                         PLI_BYTE8 *dataLoc,
-			PLI_INT32 numOfBytes) {
+                        PLI_INT32 numOfBytes) {
   return 0;
 }
 
 PLI_INT32 vpi_put_data (PLI_INT32 id,
                         PLI_BYTE8 *dataLoc,
-			PLI_INT32 numOfBytes) {
+                        PLI_INT32 numOfBytes) {
   return 0;
 }
 

--- a/templates/vpi_visitor.cpp
+++ b/templates/vpi_visitor.cpp
@@ -559,30 +559,30 @@ void visit_object (vpiHandle obj_h, int indent, const char *relation, VisitedCon
     if (objectType == vpiModule || objectType == vpiProgram || objectType == vpiClassDefn || objectType == vpiPackage ||
         objectType == vpiInterface || objectType == vpiUdp) {
       if (const char* s = vpi_get_str(vpiFile, obj_h)) {
-	if (int l = vpi_get(vpiLineNo, obj_h)) {
-	  out << " " << s << ":" << l;  // fileName, line
-	  if (int c = vpi_get(vpiColumnNo, obj_h)) {
-	    out << ":" << c << ": ";  // , column
-	  } else {
-	    out << ": ";
-	  }
-	  if (int c = vpi_get(vpiEndLineNo, obj_h)) {
-	    out << ", endln:" << c << ":" << vpi_get(vpiEndColumnNo, obj_h);  // , endline, endCol
-	  }
-	} else {
-	   out << ", file:" << s;  // fileName
-	}
+        if (int l = vpi_get(vpiLineNo, obj_h)) {
+          out << " " << s << ":" << l;  // fileName, line
+          if (int c = vpi_get(vpiColumnNo, obj_h)) {
+            out << ":" << c << ": ";  // , column
+          } else {
+            out << ": ";
+          }
+          if (int c = vpi_get(vpiEndLineNo, obj_h)) {
+            out << ", endln:" << c << ":" << vpi_get(vpiEndColumnNo, obj_h);  // , endline, endCol
+          }
+        } else {
+           out << ", file:" << s;  // fileName
+        }
       }
     } else {
       if (int l = vpi_get(vpiLineNo, obj_h)) {
-	if (int c = vpi_get(vpiColumnNo, obj_h)) {
-	  out << ", line:" << l << ":" << c;
-	} else {
-	  out << ", line:" << l;
-	}
-	if (int c = vpi_get(vpiEndLineNo, obj_h)) {
-	  out << ", endln:" << c << ":" << vpi_get(vpiEndColumnNo, obj_h);  // , endline, endCol
-	}
+        if (int c = vpi_get(vpiColumnNo, obj_h)) {
+          out << ", line:" << l << ":" << c;
+        } else {
+          out << ", line:" << l;
+        }
+        if (int c = vpi_get(vpiEndLineNo, obj_h)) {
+          out << ", endln:" << c << ":" << vpi_get(vpiEndColumnNo, obj_h);  // , endline, endCol
+        }
       }
     }
     if (vpiHandle par = vpi_handle(vpiParent, obj_h)) {
@@ -607,6 +607,7 @@ void visit_object (vpiHandle obj_h, int indent, const char *relation, VisitedCon
   if (strcmp(relation, "vpiParent") == 0) {
     return;
   }
+  vpiHandle itr;
 <OBJECT_VISITORS>
 }
 
@@ -639,5 +640,4 @@ extern "C" {
     UHDM::visit_designs(designs, the_output);
     std::cout << the_output.str().c_str() << std::endl;
   }
-
 }


### PR DESCRIPTION
Issue https://github.com/chipsalliance/Surelog/issues/817 Use Python as build scripting tool

Swap out tcl in favor of Python. Notable changes in transition include the
following:

* Unlike previous tcl based implementation, only the classes account towards
  UHDM ids. This assures that introducing new declarations in existing models
  do not jumble everything.
* Order of the following is now identical to the order of declarations in
  model file
  * Variable & function declarations in header files
  * Order of callbacks in vpi_visitor, VpiListener & Serializer
* Introducing two new outputs
  * VpiListenerTracer - Prints formatted ordered callbacks to assist
     in debugging
  * class_hiearchy - A simple formatted text file that list all models
     in OO hierarchy
* In applicable generated files (uhdm_types, uhdm_forward_decl, containers,
  and alike) the output is sorted
* Each individual script is independently executable