### PR TITLE
Fix-up some obj_ref/class_ref mix-ups.

### DIFF
--- a/model/instance_item.yaml
+++ b/model/instance_item.yaml
@@ -19,7 +19,7 @@
   - obj_ref: program_array
   - class_ref: task_func
   - class_ref: net
-  - class_ref: array_net
+  - obj_ref: array_net
   - class_ref: variables
   - obj_ref: logic_var
   - obj_ref: array_var  
@@ -29,6 +29,6 @@
   - obj_ref: spec_param
   - group_ref: assertion
   - class_ref: typespec
-  - class_ref: class_defn
+  - obj_ref: class_defn
  
 

--- a/model/operand_group.yaml
+++ b/model/operand_group.yaml
@@ -19,7 +19,7 @@
   - group_ref: interface_expr
   - obj_ref: range
   - group_ref: pattern
-  - class_ref: sequence_inst
+  - obj_ref: sequence_inst
   - group_ref: sequence_expr_group
-  - class_ref: property_inst
+  - obj_ref: property_inst
   - group_ref: property_expr_group

--- a/model/simple_expr_use_group.yaml
+++ b/model/simple_expr_use_group.yaml
@@ -20,6 +20,6 @@
   - obj_ref: tchk_term
   - obj_ref: delay_term
   - class_ref: ports
-  - class_ref: stmt
+  - group_ref: stmt
   - obj_ref: cont_assign
   - obj_ref: cont_assign_bit

--- a/model/variables_operation_group.yaml
+++ b/model/variables_operation_group.yaml
@@ -16,4 +16,4 @@
  
 - group_def: variables_operation_group
   - class_ref: variables
-  - class_ref: operation
+  - obj_ref: operation


### PR DESCRIPTION
class_refs that refer to obj_def and vice versa.

Signed-off-by: Henner Zeller <h.zeller@acm.org>