### PR TITLE
Memory Optimization Pass

### DIFF
--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -92,13 +92,13 @@ proc printMethods { classname type vpi card {real_type ""} } {
     global methods_cpp group_headers
     set methods ""
     if {$type == "string"} {
-        set type "std::string"
+        set type "std::string_view"
     }
     if {$type == "value"} {
-        set type "std::string"
+        set type "std::string_view"
     }
     if {$type == "delay"} {
-        set type "std::string"
+        set type "std::string_view"
     }
     if {$vpi == "uhdmType"} {
         set type "UHDM_OBJECT_TYPE"
@@ -117,21 +117,21 @@ proc printMethods { classname type vpi card {real_type ""} } {
     if {$card == "1"} {
         set pointer ""
         set const ""
-        if {($type != "unsigned int") && ($type != "int") && ($type != "bool") && ($type != "std::string")} {
+        if {($type != "unsigned int") && ($type != "int") && ($type != "bool") && ($type != "std::string_view")} {
             set pointer "*"
             set const "const "
         }
 
 
-        if {$type == "std::string"} {
-            append methods "\n  ${virtual}bool [string toupper ${vpi} 0 0](const ${type}${pointer}\\& data)$final;\n"
+        if {$type == "std::string_view"} {
+            append methods "\n  ${virtual}bool [string toupper ${vpi} 0 0](${type}${pointer} data)$final;\n"
             if {$vpi == "vpiFullName" } {
-                append methods "\n  ${virtual}const ${type}${pointer}\\&  [string toupper ${vpi} 0 0]() const$final;\n"
-                append methods_cpp "\nconst ${type}${pointer}\\&  ${classname}::[string toupper ${vpi} 0 0]() const {
+                append methods "\n  ${virtual}${type}${pointer} [string toupper ${vpi} 0 0]() const$final;\n"
+                append methods_cpp "\n${type}${pointer} ${classname}::[string toupper ${vpi} 0 0]() const {
   if (${vpi}_) {
     return serializer_->symbolMaker.GetSymbol(${vpi}_);
   } else {
-    std::vector<std::string> names;
+    std::vector<std::string_view> names;
     const BaseClass* parent = this;
     const BaseClass* child = nullptr;
     bool column = false;
@@ -139,7 +139,7 @@ proc printMethods { classname type vpi card {real_type ""} } {
       const BaseClass* actual_parent = parent->VpiParent();
       if (parent->UhdmType() == uhdmdesign) break;
       if ((parent->UhdmType() == uhdmpackage) || (parent->UhdmType() == uhdmclass_defn)) column = true;
-      const std::string\\& name = (!parent->VpiName().empty()) ? parent->VpiName() : parent->VpiDefName();
+      const std::string_view\\& name = (!parent->VpiName().empty()) ? parent->VpiName() : parent->VpiDefName();
       UHDM_OBJECT_TYPE parent_type = (parent != nullptr) ? parent->UhdmType() : uhdmunsupported_stmt;
       UHDM_OBJECT_TYPE actual_parent_type = (actual_parent != nullptr) ? actual_parent->UhdmType() : uhdmunsupported_stmt;
       bool skip_name = (actual_parent_type == uhdmref_obj) || (parent_type == uhdmmethod_func_call) ||
@@ -170,8 +170,8 @@ proc printMethods { classname type vpi card {real_type ""} } {
     if (names.size()) {
       unsigned int index = names.size() -1;
       while(1) {
-        fullName += names\[index\];
-        if (index > 0) fullName += column ? \"::\" : \".\";
+        fullName.append(names\[index\]);
+        if (index > 0) fullName.append(column ? \"::\" : \".\");
         if (index == 0) break;
         index--;
       }
@@ -183,10 +183,10 @@ proc printMethods { classname type vpi card {real_type ""} } {
   }
 }\n"
             } else {
-                append methods "\n  ${virtual}const ${type}${pointer}\\& [string toupper ${vpi} 0 0]() const$final;\n"
-                append methods_cpp "\nconst ${type}${pointer}\\& ${classname}::[string toupper ${vpi} 0 0]() const { return serializer_->symbolMaker.GetSymbol(${vpi}_); }\n"
+                append methods "\n  ${virtual}${type}${pointer} [string toupper ${vpi} 0 0]() const$final;\n"
+                append methods_cpp "\n${type}${pointer} ${classname}::[string toupper ${vpi} 0 0]() const { return serializer_->symbolMaker.GetSymbol(${vpi}_); }\n"
             }
-            append methods_cpp "\nbool ${classname}::[string toupper ${vpi} 0 0](const ${type}${pointer}\\& data) { ${vpi}_ = serializer_->symbolMaker.Make(data); return true; }\n"
+            append methods_cpp "\nbool ${classname}::[string toupper ${vpi} 0 0](${type}${pointer} data) { ${vpi}_ = serializer_->symbolMaker.Make(data); return true; }\n"
         } else {
             append methods "\n  ${virtual}${const}${type}${pointer} [string toupper ${vpi} 0 0]() const$final { return ${vpi}_; }\n"
             if {$vpi == "vpiParent"} {
@@ -234,16 +234,16 @@ proc printCapnpSchema {type vpi card} {
 proc printMembers { type vpi card } {
     set members ""
     if {$type == "string" || $type == "value" || $type == "delay"} {
-        set type "std::string"
+        set type "std::string_view"
     }
     if {$card == "1"} {
         set pointer ""
         set default_assignment "0"
-        if {($type != "unsigned int") && ($type != "int") && ($type != "bool") && ($type != "std::string")} {
+        if {($type != "unsigned int") && ($type != "int") && ($type != "bool") && ($type != "std::string_view")} {
             set pointer "*"
             set default_assignment "nullptr"
         }
-        if {$type == "std::string"} {
+        if {$type == "std::string_view"} {
             append members "\n  SymbolFactory::ID ${vpi}_ = 0;\n"
         } else {
             append members "\n  ${type}${pointer} ${vpi}_ = ${default_assignment};\n"
@@ -440,13 +440,13 @@ proc printGetStrBody {classname type vpi card} {
     const $classname* const o = (const $classname*)(obj);
     return (o->[string toupper ${vpi} 0 0]().empty() || o->[string toupper ${vpi} 0 0]() == o->VpiName())
         ? 0
-        : (PLI_BYTE8*) o->[string toupper ${vpi} 0 0]().c_str();
+        : (PLI_BYTE8*) o->[string toupper ${vpi} 0 0]().data();
   }"
         } else {
             append vpi_get_str_body "
   if ((handle->type == uhdm${classname}) \\&\\& (property == $vpi)) {
     const $classname* const o = (const $classname*)(obj);
-    return (PLI_BYTE8*) (o->[string toupper ${vpi} 0 0]().empty() ? 0 : o->[string toupper ${vpi} 0 0]().c_str());
+    return (PLI_BYTE8*) (o->[string toupper ${vpi} 0 0]().empty() ? 0 : o->[string toupper ${vpi} 0 0]().data());
   }"
         }
     }
@@ -1036,7 +1036,7 @@ proc write_uhdm_h { headers} {
     set uhdm_content [read $fid]
     close $fid
 
-    set name_id_map "\nstd::string UhdmName(UHDM_OBJECT_TYPE type) \{
+    set name_id_map "\nstd::string_view UhdmName(UHDM_OBJECT_TYPE type) \{
       switch (type) \{
 "
     foreach id [array names DEFINE_ID] {

--- a/scripts/classes_h.py
+++ b/scripts/classes_h.py
@@ -6,13 +6,13 @@ import file_utils
 
 
 def _print_group_headers(type, real_type):
-    return [ f'#include "{real_type}.h"' ] if type == 'any' else []
+    return [ f'#include <uhdm/{real_type}.h>' ] if type == 'any' else []
 
 
 def _print_methods(classname, type, vpi, card, real_type=''):
     content = []
     if type in ['string', 'value', 'delay']:
-        type = 'std::string'
+        type = 'std::string_view'
     if vpi == 'uhdmType':
         type = 'UHDM_OBJECT_TYPE'
 
@@ -32,13 +32,13 @@ def _print_methods(classname, type, vpi, card, real_type=''):
     if card == '1':
         pointer = ''
         const = ''
-        if type not in ['unsigned int', 'int', 'bool', 'std::string']:
+        if type not in ['unsigned int', 'int', 'bool', 'std::string_view']:
             pointer = '*'
             const = 'const '
 
-        if type == 'std::string':
-            content.append(f'  {virtual}bool {Vpi_}(const {type}{pointer}& data){final};')
-            content.append(f'  {virtual}const {type}{pointer}& {Vpi_}() const{final};')
+        if type == 'std::string_view':
+            content.append(f'  {virtual}bool {Vpi_}({type}{pointer} data){final};')
+            content.append(f'  {virtual}{type}{pointer} {Vpi_}() const{final};')
         else:
             content.append(f'  {virtual}{const}{type}{pointer} {Vpi_}() const{final} {{ return {vpi}_; }}')
             if vpi == 'vpiParent':
@@ -56,16 +56,16 @@ def _print_members(type, vpi, card):
     content = []
 
     if type in ['string', 'value', 'delay']:
-        type = 'std::string'
+        type = 'std::string_view'
 
     if card == '1':
         pointer = ''
         default_assignment = '0'
-        if type not in ['unsigned int', 'int', 'bool', 'std::string']:
+        if type not in ['unsigned int', 'int', 'bool', 'std::string_view']:
             pointer = '*'
             default_assignment = 'nullptr'
 
-        if type == 'std::string':
+        if type == 'std::string_view':
             content.append(f'  SymbolFactory::ID {vpi}_ = 0;')
         else:
             content.append(f'  {type}{pointer} {vpi}_ = {default_assignment};')

--- a/scripts/serializer.py
+++ b/scripts/serializer.py
@@ -12,36 +12,26 @@ def _print_methods(classname, type, vpi, card, real_type=''):
         return content
 
     if type in ['string', 'value', 'delay']:
-        type = 'std::string'
+        type = 'std::string_view'
 
     if vpi == 'uhdmType':
         type = 'UHDM_OBJECT_TYPE'
 
-    final = ''
-    virtual = ''
-    if vpi in ['vpiParent', 'uhdmParentType', 'uhdmType', 'vpiLineNo', 'vpiColumnNo', 'vpiEndLineNo', 'vpiEndColumnNo', 'vpiFile', 'vpiName', 'vpiDefName', 'uhdmId']:
-        final = ' final'
-        virtual = 'virtual '
-
-    check = ''
-    if type == 'any':
-        check = f'if (!{real_type}GroupCompliant(data)) return false;'
-
     pointer = ''
     const = ''
-    if type not in ['unsigned int', 'int', 'bool', 'std::string']:
+    if type not in ['unsigned int', 'int', 'bool', 'std::string_view']:
         pointer = '*'
         const = 'const '
 
     Vpi_ = vpi[:1].upper() + vpi[1:]
 
-    if type == 'std::string':
+    if type == 'std::string_view':
         if vpi == 'vpiFullName':
-            content.append(f'const {type}{pointer}& {classname}::{Vpi_}() const {{')
+            content.append(f'{type}{pointer} {classname}::{Vpi_}() const {{')
             content.append(f'  if ({vpi}_) {{')
             content.append(f'    return serializer_->symbolMaker.GetSymbol({vpi}_);')
             content.append( '  } else {')
-            content.append( '    std::vector<std::string> names;')
+            content.append( '    std::vector<std::string_view> names;')
             content.append( '    const BaseClass* parent = this;')
             content.append( '    const BaseClass* child = nullptr;')
             content.append( '    bool column = false;')
@@ -49,7 +39,7 @@ def _print_methods(classname, type, vpi, card, real_type=''):
             content.append( '      const BaseClass* actual_parent = parent->VpiParent();')
             content.append( '      if (parent->UhdmType() == uhdmdesign) break;')
             content.append( '      if ((parent->UhdmType() == uhdmpackage) || (parent->UhdmType() == uhdmclass_defn)) column = true;')
-            content.append( '      const std::string& name = parent->VpiName().empty() ? parent->VpiDefName() : parent->VpiName();')
+            content.append( '      const std::string_view& name = parent->VpiName().empty() ? parent->VpiDefName() : parent->VpiName();')
             content.append( '      UHDM_OBJECT_TYPE parent_type = (parent != nullptr) ? parent->UhdmType() : uhdmunsupported_stmt;')
             content.append( '      UHDM_OBJECT_TYPE actual_parent_type = (actual_parent != nullptr) ? actual_parent->UhdmType() : uhdmunsupported_stmt;')
             content.append( '      bool skip_name = (actual_parent_type == uhdmref_obj) || (parent_type == uhdmmethod_func_call) ||')
@@ -80,8 +70,8 @@ def _print_methods(classname, type, vpi, card, real_type=''):
             content.append( '    if (!names.empty()) {')
             content.append( '      unsigned int index = names.size() - 1;')
             content.append( '      while(1) {')
-            content.append( '        fullName += names[index];')
-            content.append( '        if (index > 0) fullName += column ? "::" : ".";')
+            content.append( '        fullName.append(names[index]);')
+            content.append( '        if (index > 0) fullName.append(column ? "::" : ".");')
             content.append( '        if (index == 0) break;')
             content.append( '        index--;')
             content.append( '      }')
@@ -93,9 +83,9 @@ def _print_methods(classname, type, vpi, card, real_type=''):
             content.append( '  }')
             content.append( '}')
         else:
-            content.append(f'const {type}{pointer}& {classname}::{Vpi_}() const {{ return serializer_->symbolMaker.GetSymbol({vpi}_); }}')
+            content.append(f'{type}{pointer} {classname}::{Vpi_}() const {{ return serializer_->symbolMaker.GetSymbol({vpi}_); }}')
         content.append('')
-        content.append(f'bool {classname}::{Vpi_}(const {type}{pointer}& data) {{ {vpi}_ = serializer_->symbolMaker.Make(data); return true; }}')
+        content.append(f'bool {classname}::{Vpi_}({type}{pointer} data) {{ {vpi}_ = serializer_->symbolMaker.Make(data); return true; }}')
         content.append('')
 
     return content
@@ -237,7 +227,7 @@ def generate(models):
             baseclass = models[baseclass]['extends']
 
     uhdm_name_map = [
-        'std::string UhdmName(UHDM_OBJECT_TYPE type) {',
+        'std::string_view UhdmName(UHDM_OBJECT_TYPE type) {',
         '  switch (type) {'
     ]
     uhdm_name_map.extend([ f'  case {name} /* = {id} */: return "{name[4:]}";' for name, id in uhdm_types_h.get_type_map(models).items() ])

--- a/scripts/vpi_user_cpp.py
+++ b/scripts/vpi_user_cpp.py
@@ -132,9 +132,9 @@ def _print_get_str_body(classname, type, vpi, card):
         if vpi == 'vpiFullName':
             content.append(f'    return (o->{Vpi_}().empty() || o->{Vpi_}() == o->VpiName())')
             content.append( '      ? 0')
-            content.append(f'      : (PLI_BYTE8*) o->{Vpi_}().c_str();')
+            content.append(f'      : (PLI_BYTE8*) o->{Vpi_}().data();')
         else:
-            content.append(f'    return (PLI_BYTE8*) (o->{Vpi_}().empty() ? 0 : o->{Vpi_}().c_str());')
+            content.append(f'    return (PLI_BYTE8*) (o->{Vpi_}().empty() ? 0 : o->{Vpi_}().data());')
         content.append( '  }')
     return content
 

--- a/templates/BaseClass.h
+++ b/templates/BaseClass.h
@@ -36,7 +36,7 @@
 namespace UHDM {
   class Serializer;
   class ElaboratorListener;
-  static std::string nonamebaseclass ("");
+  static constexpr std::string_view nonamebaseclass{""};
 
   class ClientData {
   public:
@@ -65,9 +65,9 @@ namespace UHDM {
 
     virtual bool UhdmParentType(unsigned int data) = 0;
 
-    virtual const std::string& VpiFile() const = 0;
+    virtual std::string_view VpiFile() const = 0;
 
-    virtual bool VpiFile(const std::string& data) = 0;
+    virtual bool VpiFile(std::string_view data) = 0;
 
     virtual int VpiLineNo() const final { return vpiLineNo_; }
 
@@ -85,9 +85,9 @@ namespace UHDM {
 
     virtual bool VpiEndColumnNo(short int data) final { vpiEndColumnNo_ = data; return true; }
 
-    virtual const std::string& VpiName() const { return nonamebaseclass; }
+    virtual std::string_view VpiName() const { return nonamebaseclass; }
 
-    virtual const std::string& VpiDefName() const { return nonamebaseclass; }
+    virtual std::string_view VpiDefName() const { return nonamebaseclass; }
 
     virtual unsigned int VpiType() const = 0;
 

--- a/templates/ElaboratorListener.h
+++ b/templates/ElaboratorListener.h
@@ -49,26 +49,26 @@ public:
   bool uniquifyTypespec() { return uniquifyTypespec_; }
   void bindOnly(bool bindOnly) { clone_ = !bindOnly; }
   bool bindOnly() { return !clone_; }
-  bool isFunctionCall(const std::string& name, const expr* prefix);
+  bool isFunctionCall(std::string_view name, const expr* prefix);
 
-  bool isTaskCall(const std::string& name, const expr* prefix);
+  bool isTaskCall(std::string_view name, const expr* prefix);
 
   // Bind to a net in the current instance
-  any* bindNet(const std::string& name);
+  any* bindNet(std::string_view name);
 
   // Bind to a net or parameter in the current instance
-  any* bindAny(const std::string& name);
+  any* bindAny(std::string_view name);
 
   // Bind to a param in the current instance
-  any* bindParam(const std::string& name);
+  any* bindParam(std::string_view name);
 
   // Bind to a function or task in the current scope
-  any* bindTaskFunc(const std::string& name, const class_var* prefix = nullptr);
+  any* bindTaskFunc(std::string_view name, const class_var* prefix = nullptr);
 
   void scheduleTaskFuncBinding(tf_call* clone) { scheduledTfCallBinding_.push_back(clone); }
 
 protected:
-  typedef std::map<std::string, const BaseClass*> ComponentMap;
+  typedef std::map<std::string_view, const BaseClass*> ComponentMap;
 
   void leaveDesign(const design* object, const BaseClass* parent, vpiHandle handle, vpiHandle parentHandle) override {
     design* root = (design*) object;
@@ -78,11 +78,13 @@ protected:
   void enterModule(const module* object, const BaseClass* parent,
                    vpiHandle handle, vpiHandle parentHandle) override {
     module* inst = (module*) object;
-    bool topLevelModule         = object->VpiTopModule();
-    const std::string& instName = object->VpiName();
-    const std::string& defName  = object->VpiDefName();
-    bool flatModule             = (instName == "") && ((object->VpiParent() == 0) ||
-                                                       ((object->VpiParent() != 0) && (object->VpiParent()->VpiType() != vpiModule)));
+    bool topLevelModule = object->VpiTopModule();
+    const std::string_view& instName = object->VpiName();
+    const std::string_view& defName = object->VpiDefName();
+    bool flatModule =
+        (instName == "") && ((object->VpiParent() == 0) ||
+                             ((object->VpiParent() != 0) &&
+                              (object->VpiParent()->VpiType() != vpiModule)));
                                   // false when it is a module in a hierachy tree
     if (debug_)
       std::cout << "Module: " << defName << " (" << instName << ") Flat:"  << flatModule << ", Top:" << topLevelModule << std::endl;

--- a/templates/ExprEval.cpp
+++ b/templates/ExprEval.cpp
@@ -112,7 +112,7 @@ expr* ExprEval::flattenPatternAssignments(Serializer& s, const typespec* tps,
     }
 
     struct_typespec* stps = (struct_typespec*)tps;
-    std::vector<std::string> fieldNames;
+    std::vector<std::string_view> fieldNames;
     std::vector<const typespec*> fieldTypes;
     for (typespec_member* memb : *stps->Members()) {
       fieldNames.push_back(memb->VpiName());
@@ -125,7 +125,7 @@ expr* ExprEval::flattenPatternAssignments(Serializer& s, const typespec* tps,
       if (oper->UhdmType() == uhdmtagged_pattern) {
         tagged_pattern* tp = (tagged_pattern*)oper;
         const typespec* ttp = tp->Typespec();
-        const std::string& tname = ttp->VpiName();
+        const std::string_view& tname = ttp->VpiName();
         bool found = false;
         for (unsigned int i = 0; i < fieldNames.size(); i++) {
           if (tname == fieldNames[i]) {
@@ -144,8 +144,8 @@ expr* ExprEval::flattenPatternAssignments(Serializer& s, const typespec* tps,
           }
         }
         if (found == false) {
-          s.GetErrorHandler()(ErrorType::UHDM_UNDEFINED_PATTERN_KEY, tname,
-                              exp);
+          s.GetErrorHandler()(ErrorType::UHDM_UNDEFINED_PATTERN_KEY,
+                              std::string(tname), exp);
           return result;
         }
       }
@@ -154,7 +154,7 @@ expr* ExprEval::flattenPatternAssignments(Serializer& s, const typespec* tps,
     for (auto op : tmp) {
       if (op == nullptr) {
         s.GetErrorHandler()(ErrorType::UHDM_UNMATCHED_FIELD_IN_PATTERN_ASSIGN,
-                            fieldNames[index], exp);
+                            std::string(fieldNames[index]), exp);
         return result;
       }
       ordered->push_back(op);

--- a/templates/Serializer.h
+++ b/templates/Serializer.h
@@ -54,7 +54,7 @@ namespace UHDM {
     void SetErrorHandler(ErrorHandler handler) { errorHandler = handler; }
     ErrorHandler GetErrorHandler() { return errorHandler; }
     const std::vector<vpiHandle> Restore(const std::string& file);
-    std::map<std::string, unsigned long> ObjectStats() const;
+    std::map<std::string_view, unsigned long> ObjectStats() const;
 
 <FACTORIES_METHODS>
     std::vector<any*>* MakeAnyVec() { return anyVectMaker.Make(); }

--- a/templates/Serializer_restore.cpp
+++ b/templates/Serializer_restore.cpp
@@ -42,6 +42,7 @@
 
 #include <iostream>
 #include <map>
+#include <string_view>
 #include <vector>
 
 #include <capnp/message.h>
@@ -66,7 +67,7 @@ const std::vector<vpiHandle> Serializer::Restore(const std::string& file) {
 
   ::capnp::List<::capnp::Text>::Reader symbols = cap_root.getSymbols();
   for (auto symbol : symbols) {
-    symbolMaker.Make(symbol);
+    symbolMaker.Make(std::string(symbol));
   }
 
 <CAPNP_INIT_FACTORIES>

--- a/templates/Serializer_save.cpp
+++ b/templates/Serializer_save.cpp
@@ -43,6 +43,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <capnp/message.h>
@@ -78,7 +79,7 @@ unsigned long Serializer::GetId(const BaseClass* p) {
 <UHDM_NAME_MAP>
 
 // From uhdm_types.h
-std::string VpiTypeName(vpiHandle h) {
+std::string_view VpiTypeName(vpiHandle h) {
   uhdm_handle* handle = (uhdm_handle*) h;
   BaseClass* obj = (BaseClass*) handle->object;
   return UhdmName(obj->UhdmType());
@@ -100,8 +101,8 @@ BaseClass* Serializer::GetObject(unsigned int objectType, unsigned int index) {
   return NULL;
 }
 
-std::map<std::string, unsigned long> Serializer::ObjectStats() const {
-  std::map<std::string, unsigned long> stats;
+std::map<std::string_view, unsigned long> Serializer::ObjectStats() const {
+  std::map<std::string_view, unsigned long> stats;
 <FACTORY_STATS>
   return stats;
 }
@@ -137,7 +138,7 @@ void Serializer::Save(const std::string& file) {
   index = 0;
   std::vector<char*> dups; 
   for (auto symbol : symbolMaker.id2SymbolMap_) {
-    char* dup = strdup(symbol.c_str());
+    char* dup = strdup(symbol.data());
     dups.push_back(dup);
     symbols.set(index,dup);
     index++;

--- a/templates/SymbolFactory.cpp
+++ b/templates/SymbolFactory.cpp
@@ -27,22 +27,34 @@
 namespace UHDM {
 
 static constexpr SymbolFactory::ID kBadId = -1;  // setting all the bits.
-static const std::string kBadSymbol = "@@BAD_SYMBOL@@";
+static constexpr std::string_view kBadSymbol{"@@BAD_SYMBOL@@"};
 
-SymbolFactory::ID SymbolFactory::Make(const std::string& symbol) {
-  const auto inserted = symbol2IdMap_.insert({symbol, idCounter_});
-  if (inserted.second) {
+SymbolFactory::ID SymbolFactory::Make(std::string_view symbol) {
+  Symbol2IdMap::const_iterator it = symbol2IdMap_.find(symbol);
+  if (it == symbol2IdMap_.end()) {
+    if (buffers.empty() ||
+        (buffers.back().size() + symbol.length() + 1) > buffers.back().capacity()) {
+      buffers.push_back(buffers_t::value_type());
+      buffers.back().reserve(kBufferCapacity);
+    }
+
+    buffers_t::reference buffer = buffers.back();
+    size_t length = buffer.length();
+    buffer.append(symbol).append(1, '\0');
+    symbol = std::string_view(&buffer[length], symbol.length());
+
+    it = symbol2IdMap_.insert({symbol, idCounter_}).first;
     id2SymbolMap_.emplace_back(symbol);
     idCounter_++;
   }
-  return inserted.first->second;
+  return it->second;
 }
 
-const std::string& SymbolFactory::GetSymbol(ID id) const {
+std::string_view SymbolFactory::GetSymbol(ID id) const {
   return (id < id2SymbolMap_.size()) ? id2SymbolMap_[id] : kBadSymbol;
 }
 
-SymbolFactory::ID SymbolFactory::GetId(const std::string& symbol) const {
+SymbolFactory::ID SymbolFactory::GetId(std::string_view symbol) const {
   auto found = symbol2IdMap_.find(symbol);
   return (found == symbol2IdMap_.end()) ? kBadId : found->second;
 }

--- a/templates/SymbolFactory.h
+++ b/templates/SymbolFactory.h
@@ -39,26 +39,30 @@ class Serializer;
 class SymbolFactory {
   friend Serializer;
 
+  static constexpr int kBufferCapacity = 1024 * 1024;
+  typedef std::vector<std::string> buffers_t;
+
 public:
   typedef unsigned int ID;
-  typedef std::vector<std::string> Id2SymbolMap;
-  typedef std::unordered_map<std::string, ID> Symbol2IdMap;
+  typedef std::vector<std::string_view> Id2SymbolMap;
+  typedef std::unordered_map<std::string_view, ID> Symbol2IdMap;
 
   // Register given "symbol" string as a symbol and return its id.
   // If this is an existing symbol, its ID is returned, otherwise a new one
   // is created.
-  ID Make(const std::string& symbol);
+  ID Make(std::string_view symbol);
 
   // Find id of given "symbol" or return "@@BAD_SYMBOL@@" if it doesn't exist.
-  const std::string& GetSymbol(ID id) const;
+  std::string_view GetSymbol(ID id) const;
 
   // Get symbol string identified by given ID or 0 (zero) if it doesn't exist
-  ID GetId(const std::string& symbol) const;
+  ID GetId(std::string_view symbol) const;
 
 private:
   ID idCounter_ = 0;
   Id2SymbolMap id2SymbolMap_;
   Symbol2IdMap symbol2IdMap_;
+  buffers_t buffers;
 };
 
 class VectorOfanyFactory {

--- a/templates/clone_tree.cpp
+++ b/templates/clone_tree.cpp
@@ -37,7 +37,7 @@ BaseClass* clone_tree (const BaseClass* root, Serializer& s, ElaboratorListener*
 
 // Hardcoded implementations
 
-any* ElaboratorListener::bindNet(const std::string& name) {
+any* ElaboratorListener::bindNet(std::string_view name) {
   for (InstStack::reverse_iterator i = instStack_.rbegin();
        i != instStack_.rend(); ++i ) {
     ComponentMap& netMap = std::get<0>((*i).second);
@@ -50,7 +50,7 @@ any* ElaboratorListener::bindNet(const std::string& name) {
 }
 
 // Bind to a net or parameter in the current instance
-any* ElaboratorListener::bindAny(const std::string& name) {
+any* ElaboratorListener::bindAny(std::string_view name) {
   for (InstStack::reverse_iterator i = instStack_.rbegin();
        i != instStack_.rend(); ++i ) {
     ComponentMap& netMap = std::get<0>((*i).second);
@@ -69,7 +69,7 @@ any* ElaboratorListener::bindAny(const std::string& name) {
 }
 
 // Bind to a param in the current instance
-any* ElaboratorListener::bindParam(const std::string& name) {
+any* ElaboratorListener::bindParam(std::string_view name) {
   for (InstStack::reverse_iterator i = instStack_.rbegin();
        i != instStack_.rend(); ++i ) {
     ComponentMap& paramMap = std::get<1>((*i).second);
@@ -82,7 +82,7 @@ any* ElaboratorListener::bindParam(const std::string& name) {
 }
 
 // Bind to a function or task in the current scope
-any* ElaboratorListener::bindTaskFunc(const std::string& name, const class_var* prefix) {
+any* ElaboratorListener::bindTaskFunc(std::string_view name, const class_var* prefix) {
   for (InstStack::reverse_iterator i = instStack_.rbegin();
        i != instStack_.rend(); ++i ) {
     ComponentMap& funcMap = std::get<2>((*i).second);
@@ -115,7 +115,7 @@ any* ElaboratorListener::bindTaskFunc(const std::string& name, const class_var* 
   return nullptr;
 }
 
-bool ElaboratorListener::isFunctionCall(const std::string& name, const expr* prefix) {
+bool ElaboratorListener::isFunctionCall(std::string_view name, const expr* prefix) {
   if (instStack_.size()) {
     for (InstStack::reverse_iterator i = instStack_.rbegin();
          i != instStack_.rend(); ++i) {
@@ -142,7 +142,7 @@ bool ElaboratorListener::isFunctionCall(const std::string& name, const expr* pre
   return true;
 }
 
-bool ElaboratorListener::isTaskCall(const std::string& name, const expr* prefix) {
+bool ElaboratorListener::isTaskCall(std::string_view name, const expr* prefix) {
   if (instStack_.size()) {
     for (InstStack::reverse_iterator i = instStack_.rbegin();
          i != instStack_.rend(); ++i) {
@@ -819,7 +819,7 @@ static void propagateParamAssign(param_assign* pass, const any* target) {
     case uhdmclass_defn: {
       class_defn* defn = (class_defn*)target;
       const any* lhs = pass->Lhs();
-      const std::string& name = lhs->VpiName();
+      const std::string_view& name = lhs->VpiName();
       VectorOfany* params = defn->Parameters();
       if (params) {
         for (any* param : *params) {
@@ -856,7 +856,7 @@ static void propagateParamAssign(param_assign* pass, const any* target) {
     case uhdmclass_typespec: {
       class_typespec* defn = (class_typespec*)target;
       const any* lhs = pass->Lhs();
-      const std::string& name = lhs->VpiName();
+      const std::string_view& name = lhs->VpiName();
       VectorOfany* params = defn->Parameters();
       if (params) {
         for (any* param : *params) {
@@ -1004,7 +1004,7 @@ hier_path* hier_path::DeepClone(Serializer* serializer,
       clone_vec->push_back(current);
       bool found = false;
       if (previous) {
-        const std::string& name = obj->VpiName();
+        const std::string_view& name = obj->VpiName();
         if (previous->UhdmType() == uhdmref_obj) {
           ref_obj* ref = (ref_obj*)previous;
           const any* actual = ref->Actual_group();
@@ -1016,22 +1016,22 @@ hier_path* hier_path::DeepClone(Serializer* serializer,
                 if (member->VpiName() == name) {
                   if (current->UhdmType() == uhdmref_obj) {
                     ((ref_obj*)current)->Actual_group(member);
-		  } else if (current->UhdmType() == uhdmbit_select) {
-		    const any* parent = current->VpiParent();
-		    if (parent && (parent->UhdmType() == uhdmref_obj))
-		      ((ref_obj*)parent)->Actual_group(member);
-		  }  
-		  previous = member;
-		  found = true;
-		  break;
+                  } else if (current->UhdmType() == uhdmbit_select) {
+                    const any* parent = current->VpiParent();
+                    if (parent && (parent->UhdmType() == uhdmref_obj))
+                      ((ref_obj*)parent)->Actual_group(member);
+                  }
+                  previous = member;
+                  found = true;
+                  break;
                 }
               }
             } else if (actual->UhdmType() == uhdminterface) {
-              interface* interf = (interface*) actual;
+              interface* interf = (interface*)actual;
               if (interf->Variables()) {
                 for (variables* var : *interf->Variables()) {
                   if (var->VpiName() == name) {
-		    if (current->UhdmType() == uhdmref_obj) {
+                    if (current->UhdmType() == uhdmref_obj) {
                       ((ref_obj*)current)->Actual_group(var);
                     } else if (current->UhdmType() == uhdmbit_select) {
                       const any* parent = current->VpiParent();

--- a/templates/group_header.cpp
+++ b/templates/group_header.cpp
@@ -37,7 +37,11 @@ bool <GROUPNAME>GroupCompliant(any* item) {
   if (
 <CHECKTYPE>
   ) {
-    item->GetSerializer()->GetErrorHandler()(ErrorType::UHDM_WRONG_OBJECT_TYPE, "Internal Error: adding wrong object type (" + UhdmName(uhdmtype) + ") in a <GROUPNAME> group!", the_item);
+    std::string message("Internal Error: adding wrong object type (");
+    message.append(UhdmName(uhdmtype))
+        .append(") in a enum_struct_union_packed_var_group group!");
+    item->GetSerializer()->GetErrorHandler()(ErrorType::UHDM_WRONG_OBJECT_TYPE,
+                                             message, the_item);
     return false;
   }
   return true;

--- a/templates/uhdm_types.h
+++ b/templates/uhdm_types.h
@@ -26,7 +26,7 @@
 #ifndef UHDM_TYPES_H
 #define UHDM_TYPES_H
 
-#include <string>
+#include <string_view>
 #include <uhdm/vpi_user.h>
 
 namespace UHDM {
@@ -37,9 +37,9 @@ enum UHDM_OBJECT_TYPE {
 <DEFINES>
 };
 
-std::string UhdmName(UHDM_OBJECT_TYPE type);
+std::string_view UhdmName(UHDM_OBJECT_TYPE type);
 
-std::string VpiTypeName(vpiHandle h);
+std::string_view VpiTypeName(vpiHandle h);
 
 };
 

--- a/templates/vpi_uhdm.h
+++ b/templates/vpi_uhdm.h
@@ -60,9 +60,9 @@ class uhdm_handleFactory {
 /** Obtain a vpiHandle from a BaseClass (any) object */
 vpiHandle NewVpiHandle (const UHDM::BaseClass* object);
 
-s_vpi_value* String2VpiValue(const std::string& s);
+s_vpi_value* String2VpiValue(std::string_view s);
 
-s_vpi_delay* String2VpiDelays(const std::string& s);
+s_vpi_delay* String2VpiDelays(std::string_view s);
 
 std::string VpiValue2String(const s_vpi_value* value);
 

--- a/tests/full_elab_test.cpp
+++ b/tests/full_elab_test.cpp
@@ -175,13 +175,13 @@ std::vector<vpiHandle> build_designs(Serializer* s) {
 }
 
 std::string dumpStats(const Serializer& serializer) {
-  std::string result;
-  std::map<std::string, unsigned long> stats = serializer.ObjectStats();
+  std::ostringstream result;
+  std::map<std::string_view, unsigned long> stats = serializer.ObjectStats();
   for (const auto& stat : stats) {
     if (!stat.second) continue;
-    result += stat.first + " " + std::to_string(stat.second) + "\n";
+    result << stat.first << " " << std::to_string(stat.second) << std::endl;
   }
-  return result;
+  return result.str();
 }
 
 // TODO: this is too coarse-grained.
@@ -191,8 +191,8 @@ TEST(FullElabTest, ElaborationRoundtrip) {
   const std::string before = visit_designs(designs);
 
   bool elaborated = false;
-  for (auto design : designs) {
-    elaborated |= vpi_get(vpiElaborated, design);
+  for(auto design : designs) {
+    elaborated = elaborated || vpi_get(vpiElaborated, design);
   }
   EXPECT_FALSE(elaborated);
 
@@ -209,7 +209,7 @@ TEST(FullElabTest, ElaborationRoundtrip) {
 
   elaborated = false;
   for (auto design : designs) {
-    elaborated |= vpi_get(vpiElaborated, design);
+    elaborated = elaborated || vpi_get(vpiElaborated, design);
   }
   EXPECT_TRUE(elaborated);
 

--- a/tests/listener_elab_test.cpp
+++ b/tests/listener_elab_test.cpp
@@ -185,7 +185,7 @@ class MyElaboratorListener : public VpiListener {
   MyElaboratorListener() {}
 
  protected:
-  typedef std::map<std::string, const BaseClass*> ComponentMap;
+  typedef std::map<std::string_view, const BaseClass*> ComponentMap;
 
   void leaveDesign(const design* object, const BaseClass* parent,
                    vpiHandle handle, vpiHandle parentHandle) override {
@@ -196,8 +196,8 @@ class MyElaboratorListener : public VpiListener {
   void enterModule(const module* object, const BaseClass* parent,
                    vpiHandle handle, vpiHandle parentHandle) override {
     bool topLevelModule = object->VpiTopModule();
-    const std::string& instName = object->VpiName();
-    const std::string& defName = object->VpiDefName();
+    const std::string_view instName = object->VpiName();
+    const std::string_view defName = object->VpiDefName();
     bool flatModule =
         (instName == "") && ((object->VpiParent() == 0) ||
                              ((object->VpiParent() != 0) &&
@@ -284,7 +284,7 @@ class MyElaboratorListener : public VpiListener {
 
   void leaveModule(const module* object, const BaseClass* parent,
                    vpiHandle handle, vpiHandle parentHandle) override {
-    const std::string& instName = object->VpiName();
+    const std::string_view instName = object->VpiName();
     bool flatModule =
         (instName == "") && ((object->VpiParent() == 0) ||
                              ((object->VpiParent() != 0) &&
@@ -331,7 +331,7 @@ class MyElaboratorListener : public VpiListener {
 
  private:
   // Bind to a net in the parent instace
-  net* bindParentNet_(const std::string& name) {
+  net* bindParentNet_(std::string_view name) {
     std::pair<const BaseClass*, ComponentMap> mem = instStack_.top();
     instStack_.pop();
     ComponentMap& netMap = instStack_.top().second;
@@ -344,7 +344,7 @@ class MyElaboratorListener : public VpiListener {
   }
 
   // Bind to a net in the current instace
-  net* bindNet_(const std::string& name) {
+  net* bindNet_(std::string_view name) {
     ComponentMap& netMap = instStack_.top().second;
     ComponentMap::iterator netItr = netMap.find(name);
     if (netItr != netMap.end()) {
@@ -370,7 +370,7 @@ TEST(ListenerElabTest, RoundTrip) {
   std::cout << orig;
   bool elaborated = false;
   for (auto design : designs) {
-    elaborated |= vpi_get(vpiElaborated, design);
+    elaborated = elaborated || vpi_get(vpiElaborated, design);
   }
   if (!elaborated) {
     std::cout << "Elaborating...\n";
@@ -379,7 +379,7 @@ TEST(ListenerElabTest, RoundTrip) {
   }
   std::string post_elab1 = visit_designs(designs);
   for (auto design : designs) {
-    elaborated |= vpi_get(vpiElaborated, design);
+    elaborated = elaborated || vpi_get(vpiElaborated, design);
   }
   EXPECT_TRUE(elaborated);
 

--- a/tests/vpi_listener_test.cpp
+++ b/tests/vpi_listener_test.cpp
@@ -40,12 +40,17 @@ class MyVpiListener : public VpiListener {
   }
 
  public:
-  void CollectLine(const std::string& prefix, const BaseClass* object,
+  void CollectLine(std::string_view prefix, const BaseClass* object,
                    vpiHandle parentHandle) {
     const char* const parentName = vpi_get_str(vpiName, parentHandle);
     collected_.push_back(
-        prefix + ": " + object->VpiName() + "/" + object->VpiDefName() +
-        " parent: " + ((parentName != nullptr) ? parentName : "-"));
+        std::string(prefix)
+            .append(": ")
+            .append(object->VpiName())
+            .append("/")
+            .append(object->VpiDefName())
+            .append(" parent: ")
+            .append(((parentName != nullptr) ? parentName : "-")));
   }
 
   const std::vector<std::string>& collected() const { return collected_; }


### PR DESCRIPTION
Memory Optimization Pass

Use std::string_view in place of std::string in SymbolFactory.
Updated all code generation scripts to use std::string_view.

Revert "Revert "Memory Optimization Pass""

This reverts commit 723ef9d224f1f9d87e774148afc9ca17161f00ef.