### PR TITLE
Fix CI builds - Use a specific/fixed version of python

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,12 @@ jobs:
         sudo apt-get update -qq
         sudo apt install -y g++-9 build-essential cmake tclsh
 
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+        architecture: x64
+
     - name: Git pull
       uses: actions/checkout@v2
       with:
@@ -39,8 +45,9 @@ jobs:
       run: |
         echo 'CC=gcc-9' >> $GITHUB_ENV
         echo 'CXX=g++-9' >> $GITHUB_ENV
-        echo 'PATH=/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
         echo 'PREFIX=/tmp/uhdm-install' >> $GITHUB_ENV
+        echo 'ADDITIONAL_CMAKE_OPTIONS=-DPython3_ROOT_DIR=$pythonLocation' >> $GITHUB_ENV
+        echo 'PATH=/usr/lib/ccache:'"$pythonLocation""$PATH" >> $GITHUB_ENV
 
         if [[ "${{ matrix.mode }}" = "pygen" ]] ; then
           echo 'WITH_PYTHON_GENERATOR=ON' >> $GITHUB_ENV
@@ -191,6 +198,12 @@ jobs:
       run: |
         choco install -y make
 
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+        architecture: x64
+
     - run: git config --global core.autocrlf input
       shell: bash
 
@@ -212,8 +225,9 @@ jobs:
 
         set MAKE_DIR=C:\make\bin
         set TCL_DIR=%PROGRAMFILES%\Git\mingw64\bin
-        set PATH=%MAKE_DIR%;%TCL_DIR%;%PATH%
         set TEST_TMPDIR=C:\temp
+        set ADDITIONAL_CMAKE_OPTIONS=-DPython3_ROOT_DIR=%pythonLocation%
+        set PATH=%pythonLocation%;%MAKE_DIR%;%TCL_DIR%;%PATH%
 
         if "${{ matrix.mode }}" == "pygen" (
           set WITH_PYTHON_GENERATOR=ON

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,14 @@ ifeq ($(CPU_CORES),)
 endif
 
 PREFIX?=/usr/local
+ADDITIONAL_CMAKE_OPTIONS ?=
 
 release: build
 	cmake --build build --config Release -j $(CPU_CORES)
 
 debug:
 	mkdir -p dbuild
-	cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$(PREFIX) -S . -B dbuild
+	cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$(PREFIX) $(ADDITIONAL_CMAKE_OPTIONS) -S . -B dbuild
 	cmake --build dbuild --config Debug -j $(CPU_CORES)
 
 test: build
@@ -45,7 +46,7 @@ uninstall:
 
 build:
 	mkdir -p build
-	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(PREFIX) -S . -B build
+	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(PREFIX) $(ADDITIONAL_CMAKE_OPTIONS) -S . -B build
 
 test_install:
 	cmake --build build --target test_inst --config Release -j $(CPU_CORES)


### PR DESCRIPTION
Use a specific/fixed version of python, currently locking it to v3.8.