### PR TITLE
Modularization Pass 2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,12 @@ jobs:
         sudo apt-get update -qq
         sudo apt install -y g++-9 build-essential cmake tclsh
 
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+        architecture: x64
+
     - name: Git pull
       uses: actions/checkout@v2
       with:
@@ -39,8 +45,9 @@ jobs:
       run: |
         echo 'CC=gcc-9' >> $GITHUB_ENV
         echo 'CXX=g++-9' >> $GITHUB_ENV
-        echo 'PATH=/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
         echo 'PREFIX=/tmp/uhdm-install' >> $GITHUB_ENV
+        echo 'ADDITIONAL_CMAKE_OPTIONS=-DPython3_ROOT_DIR=$pythonLocation' >> $GITHUB_ENV
+        echo 'PATH=/usr/lib/ccache:'"$pythonLocation""$PATH" >> $GITHUB_ENV
 
         if [[ "${{ matrix.mode }}" = "pygen" ]] ; then
           echo 'WITH_PYTHON_GENERATOR=ON' >> $GITHUB_ENV
@@ -191,6 +198,12 @@ jobs:
       run: |
         choco install -y make
 
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+        architecture: x64
+
     - run: git config --global core.autocrlf input
       shell: bash
 
@@ -212,8 +225,9 @@ jobs:
 
         set MAKE_DIR=C:\make\bin
         set TCL_DIR=%PROGRAMFILES%\Git\mingw64\bin
-        set PATH=%MAKE_DIR%;%TCL_DIR%;%PATH%
         set TEST_TMPDIR=C:\temp
+        set ADDITIONAL_CMAKE_OPTIONS=-DPython3_ROOT_DIR=%pythonLocation%
+        set PATH=%pythonLocation%;%MAKE_DIR%;%TCL_DIR%;%PATH%
 
         if "${{ matrix.mode }}" == "pygen" (
           set WITH_PYTHON_GENERATOR=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,10 @@ endforeach(src_file ${uhdm-GENERATED_SRC})
 add_library(uhdm STATIC ${uhdm-GENERATED_SRC})
 set_target_properties(uhdm PROPERTIES PUBLIC_HEADER ${GENDIR}/uhdm/uhdm.h)
 
+if(WITH_PYTHON_GENERATOR)
+  target_compile_definitions(uhdm PUBLIC PYGEN_ENABLED=1)
+endif()
+
 # Our uhdm headers come with angle brackets (indicating system headers),
 # make sure that the compiler looks here first before finding an existing UHDM
 # installation. Hence we use SYSTEM
@@ -276,6 +280,9 @@ if (UHDM_BUILD_TESTS)
       add_test(
         NAME ${test_prefix}/${test_bin} COMMAND ${test_bin}
         WORKING_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+      if(WITH_PYTHON_GENERATOR)
+        target_compile_definitions(${test_bin} PUBLIC PYGEN_ENABLED=1)
+      endif()
       gtest_discover_tests(${test_bin} TEST_PREFIX "${test_prefix}/")
       # Now, add this binary to our UnitTests target that it builds this
       add_dependencies(UnitTests ${test_bin})

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,14 @@ ifeq ($(CPU_CORES),)
 endif
 
 PREFIX?=/usr/local
+ADDITIONAL_CMAKE_OPTIONS ?=
 
 release: build
 	cmake --build build --config Release -j $(CPU_CORES)
 
 debug:
 	mkdir -p dbuild
-	cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$(PREFIX) -S . -B dbuild
+	cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$(PREFIX) $(ADDITIONAL_CMAKE_OPTIONS) -S . -B dbuild
 	cmake --build dbuild --config Debug -j $(CPU_CORES)
 
 test: build
@@ -45,7 +46,7 @@ uninstall:
 
 build:
 	mkdir -p build
-	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(PREFIX) -S . -B build
+	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(PREFIX) $(ADDITIONAL_CMAKE_OPTIONS) -S . -B build
 
 test_install:
 	cmake --build build --target test_inst --config Release -j $(CPU_CORES)

--- a/scripts/classes.py
+++ b/scripts/classes.py
@@ -1,15 +1,14 @@
 import os
-from collections import OrderedDict
 
 import config
 import file_utils
 
 
-def _print_group_headers(type, real_type):
+def _get_group_headers(type, real_type):
     return [ f'#include "{real_type}.h"' ] if type == 'any' else []
 
 
-def _print_declaration(classname, type, vpi, card, real_type=''):
+def _get_declaration(classname, type, vpi, card, real_type=''):
     content = []
     if type in ['string', 'value', 'delay']:
         type = 'std::string'
@@ -42,7 +41,7 @@ def _print_declaration(classname, type, vpi, card, real_type=''):
         else:
             content.append(f'  {virtual}{const}{type}{pointer} {Vpi_}() const{final} {{ return {vpi}_; }}')
             if vpi == 'vpiParent':
-                content.append(f'  virtual bool {Vpi_}({type}{pointer} data) final {{ {check}{vpi}_ = data; if (data) uhdmParentType_ = data->UhdmType(); return true; }}')
+                content.append(f'  virtual bool {Vpi_}({type}{pointer} data) final {{ {check}{vpi}_ = data; uhdmParentType_ = (data != nullptr) ? data->UhdmType() : 0; return true; }}')
             else:
                 content.append(f'  {virtual}bool {Vpi_}({type}{pointer} data){final} {{ {check}{vpi}_ = data; return true; }}')
     elif card == 'any':
@@ -52,7 +51,7 @@ def _print_declaration(classname, type, vpi, card, real_type=''):
     return content
 
 
-def _print_implementation(classname, type, vpi, card, real_type=''):
+def _get_implementation(classname, type, vpi, card, real_type=''):
     content = []
     if card != '1':
         return content
@@ -60,18 +59,11 @@ def _print_implementation(classname, type, vpi, card, real_type=''):
     if type in ['string', 'value', 'delay']:
         type = 'std::string'
 
+    if type != 'std::string':
+        return content
+
     if vpi == 'uhdmType':
         type = 'UHDM_OBJECT_TYPE'
-
-    final = ''
-    virtual = ''
-    if vpi in ['vpiParent', 'uhdmParentType', 'uhdmType', 'vpiLineNo', 'vpiColumnNo', 'vpiEndLineNo', 'vpiEndColumnNo', 'vpiFile', 'vpiName', 'vpiDefName', 'uhdmId']:
-        final = ' final'
-        virtual = 'virtual '
-
-    check = ''
-    if type == 'any':
-        check = f'if (!{real_type}GroupCompliant(data)) return false;'
 
     pointer = ''
     const = ''
@@ -81,73 +73,74 @@ def _print_implementation(classname, type, vpi, card, real_type=''):
 
     Vpi_ = vpi[:1].upper() + vpi[1:]
 
-    if type == 'std::string':
-        if vpi == 'vpiFullName':
-            content.append(f'const {type}{pointer}& {classname}::{Vpi_}() const {{')
-            content.append(f'  if ({vpi}_) {{')
-            content.append(f'    return serializer_->symbolMaker.GetSymbol({vpi}_);')
-            content.append( '  } else {')
-            content.append( '    std::vector<std::string> names;')
-            content.append( '    const BaseClass* parent = this;')
-            content.append( '    const BaseClass* child = nullptr;')
-            content.append( '    bool column = false;')
-            content.append( '    while (parent != nullptr) {')
-            content.append( '      const BaseClass* actual_parent = parent->VpiParent();')
-            content.append( '      if (parent->UhdmType() == uhdmdesign) break;')
-            content.append( '      if ((parent->UhdmType() == uhdmpackage) || (parent->UhdmType() == uhdmclass_defn)) column = true;')
-            content.append( '      const std::string& name = parent->VpiName().empty() ? parent->VpiDefName() : parent->VpiName();')
-            content.append( '      UHDM_OBJECT_TYPE parent_type = (parent != nullptr) ? parent->UhdmType() : uhdmunsupported_stmt;')
-            content.append( '      UHDM_OBJECT_TYPE actual_parent_type = (actual_parent != nullptr) ? actual_parent->UhdmType() : uhdmunsupported_stmt;')
-            content.append( '      bool skip_name = (actual_parent_type == uhdmref_obj) || (parent_type == uhdmmethod_func_call) ||')
-            content.append( '                       (parent_type == uhdmmethod_task_call) || (parent_type == uhdmfunc_call) ||')
-            content.append( '                       (parent_type == uhdmtask_call) || (parent_type == uhdmsys_func_call) ||')
-            content.append( '                       (parent_type == uhdmsys_task_call);')
-            content.append( '      if (child != nullptr) {')
-            content.append( '        UHDM_OBJECT_TYPE child_type = child->UhdmType();')
-            content.append( '        if ((child_type == uhdmbit_select) && (parent_type == uhdmport)) {')
-            content.append( '          skip_name = true;')
-            content.append( '        }')
-            content.append( '        if ((child_type == uhdmref_obj) && (parent_type == uhdmbit_select)) {')
-            content.append( '          skip_name = true;')
-            content.append( '        }')
-            content.append( '        if ((child_type == uhdmref_obj) && (parent_type == uhdmindexed_part_select)) {')
-            content.append( '          skip_name = true;')
-            content.append( '        }')
-            content.append( '        if ((child_type == uhdmref_obj) && (parent_type == uhdmhier_path)) {')
-            content.append( '          skip_name = true;')
-            content.append( '        }')
-            content.append( '      }')
-            content.append( '      if ((!name.empty()) && (!skip_name))')
-            content.append( '        names.push_back(name);')
-            content.append( '      child = parent;')
-            content.append( '      parent = parent->VpiParent();')
-            content.append( '    }')
-            content.append( '    std::string fullName;')
-            content.append( '    if (!names.empty()) {')
-            content.append( '      size_t index = names.size() - 1;')
-            content.append( '      while(1) {')
-            content.append( '        fullName += names[index];')
-            content.append( '        if (index > 0) fullName += column ? "::" : ".";')
-            content.append( '        if (index == 0) break;')
-            content.append( '        index--;')
-            content.append( '      }')
-            content.append( '    }')
-            content.append( '    if (!fullName.empty()) {')
-            content.append(f'      (({classname}*)this)->VpiFullName(fullName);')
-            content.append( '    }')
-            content.append(f'    return serializer_->symbolMaker.GetSymbol({vpi}_);')
-            content.append( '  }')
-            content.append( '}')
-        else:
-            content.append(f'const {type}{pointer}& {classname}::{Vpi_}() const {{ return serializer_->symbolMaker.GetSymbol({vpi}_); }}')
-        content.append('')
-        content.append(f'bool {classname}::{Vpi_}(const {type}{pointer}& data) {{ {vpi}_ = serializer_->symbolMaker.Make(data); return true; }}')
-        content.append('')
+    if vpi == 'vpiFullName':
+        content.append(f'const {type}{pointer}& {classname}::{Vpi_}() const {{')
+        content.append(f'  if ({vpi}_) {{')
+        content.append(f'    return serializer_->symbolMaker.GetSymbol({vpi}_);')
+        content.append( '  } else {')
+        content.append( '    std::vector<std::string> names;')
+        content.append( '    const BaseClass* parent = this;')
+        content.append( '    const BaseClass* child = nullptr;')
+        content.append( '    bool column = false;')
+        content.append( '    while (parent != nullptr) {')
+        content.append( '      const BaseClass* actual_parent = parent->VpiParent();')
+        content.append( '      if (parent->UhdmType() == uhdmdesign) break;')
+        content.append( '      if ((parent->UhdmType() == uhdmpackage) || (parent->UhdmType() == uhdmclass_defn)) column = true;')
+        content.append( '      const std::string& name = parent->VpiName().empty() ? parent->VpiDefName() : parent->VpiName();')
+        content.append( '      UHDM_OBJECT_TYPE parent_type = (parent != nullptr) ? parent->UhdmType() : uhdmunsupported_stmt;')
+        content.append( '      UHDM_OBJECT_TYPE actual_parent_type = (actual_parent != nullptr) ? actual_parent->UhdmType() : uhdmunsupported_stmt;')
+        content.append( '      bool skip_name = (actual_parent_type == uhdmref_obj) || (parent_type == uhdmmethod_func_call) ||')
+        content.append( '                       (parent_type == uhdmmethod_task_call) || (parent_type == uhdmfunc_call) ||')
+        content.append( '                       (parent_type == uhdmtask_call) || (parent_type == uhdmsys_func_call) ||')
+        content.append( '                       (parent_type == uhdmsys_task_call);')
+        content.append( '      if (child != nullptr) {')
+        content.append( '        UHDM_OBJECT_TYPE child_type = child->UhdmType();')
+        content.append( '        if ((child_type == uhdmbit_select) && (parent_type == uhdmport)) {')
+        content.append( '          skip_name = true;')
+        content.append( '        }')
+        content.append( '        if ((child_type == uhdmref_obj) && (parent_type == uhdmbit_select)) {')
+        content.append( '          skip_name = true;')
+        content.append( '        }')
+        content.append( '        if ((child_type == uhdmref_obj) && (parent_type == uhdmindexed_part_select)) {')
+        content.append( '          skip_name = true;')
+        content.append( '        }')
+        content.append( '        if ((child_type == uhdmref_obj) && (parent_type == uhdmhier_path)) {')
+        content.append( '          skip_name = true;')
+        content.append( '        }')
+        content.append( '      }')
+        content.append( '      if ((!name.empty()) && (!skip_name)) {')
+        content.append( '        names.push_back(name);')
+        content.append( '      }')
+        content.append( '      child = parent;')
+        content.append( '      parent = parent->VpiParent();')
+        content.append( '    }')
+        content.append( '    std::string fullName;')
+        content.append( '    if (!names.empty()) {')
+        content.append( '      size_t index = names.size() - 1;')
+        content.append( '      while(1) {')
+        content.append( '        fullName += names[index];')
+        content.append( '        if (index > 0) fullName += column ? "::" : ".";')
+        content.append( '        if (index == 0) break;')
+        content.append( '        index--;')
+        content.append( '      }')
+        content.append( '    }')
+        content.append( '    if (!fullName.empty()) {')
+        content.append(f'      const_cast<{classname}*>(this)->VpiFullName(fullName);')
+        content.append( '    }')
+        content.append(f'    return serializer_->symbolMaker.GetSymbol({vpi}_);')
+        content.append( '  }')
+        content.append( '}')
+    else:
+        content.append(f'const {type}{pointer}& {classname}::{Vpi_}() const {{ return serializer_->symbolMaker.GetSymbol({vpi}_); }}')
+
+    content.append('')
+    content.append(f'bool {classname}::{Vpi_}(const {type}{pointer}& data) {{ {vpi}_ = serializer_->symbolMaker.Make(data); return true; }}')
+    content.append('')
 
     return content
 
 
-def _print_data_member(type, vpi, card):
+def _get_data_member(type, vpi, card):
     content = []
 
     if type in ['string', 'value', 'delay']:
@@ -171,16 +164,12 @@ def _print_data_member(type, vpi, card):
     return content
 
 
-def _print_clone_implementation(model, models):
+def _get_clone_implementation(model, models):
     classname = model.get('name')
 
     content = []
     content.append(f'void {classname}::DeepCopy({classname}* clone, Serializer* serializer, ElaboratorListener* elaborator, BaseClass* parent) const {{')
     content.append(f'  basetype_t::DeepCopy(clone, serializer, elaborator, parent);')
-
-    if '_call' in classname or classname in [ 'function', 'task', 'constant', 'tagged_pattern', 'gen_scope_array', 'hier_path', 'cont_assign' ]:
-        content.append('}')
-        return content  # Use hardcoded implementations
 
     modeltype = model.get('type')
     basename = model.get('extends', 'BaseClass')
@@ -202,7 +191,7 @@ def _print_clone_implementation(model, models):
         content.append('        ref->Actual_group((any*) ((ref_obj*) VpiParent())->Actual_group());')
         content.append('      }')
         content.append('  }')
-    else:
+    elif modeltype == 'obj_def':
         content.append('  clone->VpiParent(parent);')
 
     if 'BitSelect' in vpi_name:
@@ -306,6 +295,9 @@ def _print_clone_implementation(model, models):
     content.append('}')
     content.append('')
 
+    if '_call' in classname or classname in [ 'function', 'task', 'constant', 'tagged_pattern', 'gen_scope_array', 'hier_path', 'cont_assign' ]:
+        return content  # Use hardcoded implementations of DeepClone
+
     if modeltype == 'obj_def':
         # DeepClone() not implemented for class_def; just declare to narrow the covariant return type.
         content.append(f'{classname}* {classname}::DeepClone(Serializer* serializer, ElaboratorListener* elaborator, BaseClass* parent) const {{')
@@ -335,6 +327,142 @@ def _print_clone_implementation(model, models):
 
     return content
 
+
+def _get_GetByVpiName_implementation(model):
+    classname = model['name']
+
+    content = []
+    content.append(f'const BaseClass* {classname}::GetByVpiName(std::string_view name) const {{')
+
+    for key, value in model.allitems():
+        if key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
+            name = value.get('name')
+            vpi = value.get('vpi')
+            card = value.get('card')
+
+            if (card == 'any') and not name.endswith('s'):
+                name += 's'
+
+            if card == '1':
+                content.append(f'  if (({name}_ != nullptr) && ({name}_->VpiName().compare(name) == 0)) {{')
+                content.append(f'    return {name}_;')
+                content.append( '  }')
+            else:
+                content.append(f'  if ({name}_ != nullptr) {{')
+                content.append(f'    for (const BaseClass *ref : *{name}_) {{')
+                content.append(f'      if (ref->VpiName().compare(name) == 0) return ref;')
+                content.append( '    }')
+                content.append( '  }')
+
+    content.append(f'  return basetype_t::GetByVpiName(name);')
+    content.append( '}')
+    content.append( '')
+
+    return content
+
+
+def _get_GetByVpiType_implementation(model):
+    classname = model['name']
+    modeltype = model['type']
+
+    case_bodies = {}
+    for key, value in model.allitems():
+        if key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
+            card = value.get('card')
+            name = value.get('name')
+            vpi = value.get('vpi')
+
+            if card == '1':
+                case_bodies[vpi] = (name, case_bodies.get(vpi, (None, None))[1])
+
+            elif card == 'any':
+                if not name.endswith('s'):
+                    name += 's'
+                case_bodies[vpi] = (case_bodies.get(vpi, (None, None))[0], name)
+
+    content = []
+    content.append(f'std::tuple<const BaseClass*, UHDM_OBJECT_TYPE, const std::vector<const BaseClass*>*> {classname}::GetByVpiType(int type) const {{')
+
+    if modeltype == 'obj_def' or case_bodies:
+        content.append(f'  switch (type) {{')
+
+    if modeltype == 'obj_def':
+        content.append( '  case vpiParent: return std::make_tuple(vpiParent_, static_cast<UHDM_OBJECT_TYPE>(0), nullptr);')
+
+    if case_bodies:
+        for vpi in sorted(case_bodies.keys()):
+            name1, name_any = case_bodies[vpi]
+            if name1 and name_any:
+                content.append(f'    case {vpi}: return std::make_tuple({name1}_, uhdm{name_any}, (const std::vector<const BaseClass*>*){name_any}_);')
+            elif name1:
+                content.append(f'    case {vpi}: return std::make_tuple({name1}_, static_cast<UHDM_OBJECT_TYPE>(0), nullptr);')
+            else:
+                content.append(f'    case {vpi}: return std::make_tuple(nullptr, uhdm{name_any}, (const std::vector<const BaseClass*>*){name_any}_);')
+
+    if modeltype == 'obj_def' or case_bodies:
+        content.append( '  }')
+
+    content.append( '  return basetype_t::GetByVpiType(type);')
+    content.append( '}')
+    content.append( '')
+
+    return content
+
+
+def _get_GetVpiPropertyValue_implementation(model):
+    classname = model['name']
+    modeltype = model['type']
+
+    type_specified = False
+    case_bodies = {}
+    for key, value in model.allitems():
+        if key == 'property':
+            name = value.get('name')
+            vpi = value.get('vpi')
+            type = value.get('type')
+            card = value.get('card')
+
+            Vpi_ = vpi[:1].upper() + vpi[1:]
+
+            if name == 'type':
+                type_specified = True
+
+            if (card == '1') and (type not in ['value', 'delay']):
+                if type == 'string':
+                    case_bodies[vpi] = [ f'    case {vpi}: {{' ]
+                    if vpi == 'vpiFullName':
+                        case_bodies[vpi].extend([
+                            f'      const std::string &fullname = VpiFullName();',
+                            f'      if (!fullname.empty() && (VpiName() != fullname)) {{',
+                            f'        return vpi_property_value_t(fullname.c_str());',
+                            f'      }}'
+                          ])
+                    else:
+                        case_bodies[vpi].extend([
+                            f'      const std::string &data = {Vpi_}();',
+                            f'      if (!data.empty()) return vpi_property_value_t(data.c_str());'
+                        ])
+                    case_bodies[vpi].append(f'    }} break;')
+                else:
+                    case_bodies[vpi] = [ f'    case {vpi}: return vpi_property_value_t({Vpi_}());' ]
+
+    if not type_specified and (modeltype == 'obj_def'):
+        case_bodies['vpiType']= [ f'    case vpiType: return vpi_property_value_t(VpiType());' ]
+
+    content = []
+    content.append(f'{classname}::vpi_property_value_t {classname}::GetVpiPropertyValue(int property) const {{')
+
+    if case_bodies:
+        content.append(f'  switch (property) {{')
+        for vpi in sorted(case_bodies.keys()):
+          content.extend(case_bodies[vpi])
+        content.append(f'  }}')
+
+    content.append(f'  return basetype_t::GetVpiPropertyValue(property);')
+    content.append(f'}}')
+    content.append(f'')
+
+    return content
 
 _members = {}
 def _generate_group_checker(model, models, templates):
@@ -393,33 +521,24 @@ def _generate_one_class(model, models, templates):
     Classname_ = classname[:1].upper() + classname[1:]
     Classname = Classname_.replace('_', '')
 
-    if modeltype == 'class_def':
-        # DeepClone() not implemented for class_def; just declare to narrow the covariant return type.
-        declarations.append(f'  virtual {classname}* DeepClone(Serializer* serializer, ElaboratorListener* elaborator, BaseClass* parent) const override = 0;')
-    else:
+    if modeltype != 'class_def':
         # Builtin properties do not need to be specified in each models
         # Builtins: "vpiParent, Parent type, vpiFile, Id" method and field
-        data_members.extend(_print_data_member('BaseClass', 'vpiParent', '1'))
-        declarations.extend(_print_declaration(classname, 'BaseClass', 'vpiParent', '1'))
-        implementations.extend(_print_implementation(classname, 'BaseClass', 'vpiParent', '1'))
+        data_members.extend(_get_data_member('BaseClass', 'vpiParent', '1'))
+        declarations.extend(_get_declaration(classname, 'BaseClass', 'vpiParent', '1'))
+        implementations.extend(_get_implementation(classname, 'BaseClass', 'vpiParent', '1'))
 
-        data_members.extend(_print_data_member('unsigned int', 'uhdmParentType', '1'))
-        declarations.extend(_print_declaration(classname, 'unsigned int', 'uhdmParentType', '1'))
-        implementations.extend(_print_implementation(classname, 'unsigned int', 'uhdmParentType', '1'))
+        data_members.extend(_get_data_member('unsigned int', 'uhdmParentType', '1'))
+        declarations.extend(_get_declaration(classname, 'unsigned int', 'uhdmParentType', '1'))
+        implementations.extend(_get_implementation(classname, 'unsigned int', 'uhdmParentType', '1'))
 
-        data_members.extend(_print_data_member('string', 'vpiFile', '1'))
-        declarations.extend(_print_declaration(classname, 'string','vpiFile', '1'))
-        implementations.extend(_print_implementation(classname, 'string','vpiFile', '1'))
+        data_members.extend(_get_data_member('string', 'vpiFile', '1'))
+        declarations.extend(_get_declaration(classname, 'string','vpiFile', '1'))
+        implementations.extend(_get_implementation(classname, 'string','vpiFile', '1'))
 
-        data_members.extend(_print_data_member('unsigned int', 'uhdmId', '1'))
-        declarations.extend(_print_declaration(classname, 'unsigned int', 'uhdmId', '1'))
-        implementations.extend(_print_implementation(classname, 'unsigned int', 'uhdmId', '1'))
-
-        if '_call' in classname:
-            declarations.append(f'  virtual tf_call* DeepClone(Serializer* serializer, ElaboratorListener* elaborator, BaseClass* parent) const override;')
-        else:
-            declarations.append(f'  virtual {classname}* DeepClone(Serializer* serializer, ElaboratorListener* elaborator, BaseClass* parent) const override;')
-    implementations.extend(_print_clone_implementation(model, models))
+        data_members.extend(_get_data_member('unsigned int', 'uhdmId', '1'))
+        declarations.extend(_get_declaration(classname, 'unsigned int', 'uhdmId', '1'))
+        implementations.extend(_get_implementation(classname, 'unsigned int', 'uhdmId', '1'))
 
     type_specified = False
     for key, value in model.allitems():
@@ -435,9 +554,9 @@ def _generate_one_class(model, models, templates):
                 type_specified = True
                 declarations.append(f'  {type} {Vpi}() const final {{ return {value.get("vpiname")}; }}')
             else: # properties are already defined in vpi_user.h, no need to redefine them
-                data_members.extend(_print_data_member(type, vpi, card))
-                declarations.extend(_print_declaration(classname, type, vpi, card))
-                implementations.extend(_print_implementation(classname, type, vpi, card))
+                data_members.extend(_get_data_member(type, vpi, card))
+                declarations.extend(_get_declaration(classname, type, vpi, card))
+                implementations.extend(_get_implementation(classname, type, vpi, card))
 
         elif key == 'extends' and value:
             header_file_content = header_file_content.replace('<EXTENDS>', value)
@@ -459,14 +578,30 @@ def _generate_one_class(model, models, templates):
             if type != 'any' and card == '1':
                 forward_declares.add(f'class {type};')
 
-            group_headers.update(_print_group_headers(type, real_type))
-            data_members.extend(_print_data_member(type, name, card))
-            declarations.extend(_print_declaration(classname, type, name, card, real_type))
-            implementations.extend(_print_implementation(classname, type, name, card, real_type))
+            group_headers.update(_get_group_headers(type, real_type))
+            data_members.extend(_get_data_member(type, name, card))
+            declarations.extend(_get_declaration(classname, type, name, card, real_type))
+            implementations.extend(_get_implementation(classname, type, name, card, real_type))
 
     if not type_specified and (modeltype == 'obj_def'):
         vpiclasstype = config.make_vpi_name(classname)
         declarations.append(f'  virtual unsigned int VpiType() const final {{ return {vpiclasstype}; }}')
+
+    if modeltype == 'class_def':
+        # DeepClone() not implemented for class_def; just declare to narrow the covariant return type.
+        declarations.append(f'  virtual {classname}* DeepClone(Serializer* serializer, ElaboratorListener* elaborator, BaseClass* parent) const override = 0;')
+    else:
+        return_type = 'tf_call' if '_call' in classname else classname
+        declarations.append(f'  virtual {return_type}* DeepClone(Serializer* serializer, ElaboratorListener* elaborator, BaseClass* parent) const override;')
+
+    declarations.append('  virtual const BaseClass* GetByVpiName(std::string_view name) const override;')
+    declarations.append('  virtual std::tuple<const BaseClass*, UHDM_OBJECT_TYPE, const std::vector<const BaseClass*>*> GetByVpiType(int type) const override;')
+    declarations.append('  virtual vpi_property_value_t GetVpiPropertyValue(int property) const override;')
+
+    implementations.extend(_get_clone_implementation(model, models))
+    implementations.extend(_get_GetByVpiName_implementation(model))
+    implementations.extend(_get_GetByVpiType_implementation(model))
+    implementations.extend(_get_GetVpiPropertyValue_implementation(model))
 
     if modeltype == 'class_def':
         header_file_content = header_file_content.replace('<FINAL_CLASS>', '')

--- a/scripts/vpi_user_cpp.py
+++ b/scripts/vpi_user_cpp.py
@@ -2,286 +2,94 @@ import config
 import file_utils
 
 
-vpi_iterator = {}
-vpi_iterate_body = {}
-vpi_get_str_body_inst = {}
-vpi_get_body_inst = {}
-vpi_handle_by_name_body = {}
-
-vpi_scan_body = []
-vpi_get_body = []
-vpi_get_value_body = []
-vpi_get_delay_body = []
-vpi_get_str_body = []
-vpi_handle_body = {}
-
-vpi_iterate_body_all = []
-vpi_handle_body_all = []
-vpi_handle_by_name_body_all = []
-
-
-def _print_iterate_body(name, classname, vpi, card):
-    content = []
-    if card == 'any':
-        Name_ = name[:1].upper() + name[1:]
-        content.append(f'  if ((handle->type == uhdm{classname}) && (type == {vpi})) {{')
-        content.append(f'    if ((({classname}*)(object))->{Name_}())')
-        content.append(f'      return NewHandle(uhdm{name}, (({classname}*)(object))->{Name_}());')
-        content.append( '    else return 0;')
-        content.append( '  }')
-    return content
-
-
-def _print_get_handle_by_name_body(name, classname, vpi, card):
-    content = []
-    Name_ = name[:1].upper() + name[1:]
-    if card == '1':
-        content.append(f'  if (handle->type == uhdm{classname}) {{')
-        content.append(f'    const {classname}* const obj = (const {classname}*)(object);')
-        content.append(f'    if (obj->{Name_}() && obj->{Name_}()->VpiName() == name) {{')
-        content.append(f'      return NewVpiHandle(obj->{Name_}());')
-        content.append( '    }')
-        content.append( '  }')
-    else:
-        content.append(f'  if (handle->type == uhdm{classname}) {{')
-        content.append(f'    const {classname}* const obj_parent = (const {classname}*)(object);')
-        content.append(f'    if (obj_parent->{Name_}()) {{')
-        content.append(f'      for (const BaseClass *obj : *obj_parent->{Name_}())')
-        content.append(f'        if (obj->VpiName() == name) return NewVpiHandle(obj);')
-        content.append( '    }')
-        content.append( '  }')
-    return content
-
-
-def _print_get_body_prefix(classname):
-    return [
-      f'  if (handle->type == uhdm{classname}) {{',
-       '    switch (property) {'
-    ]
-
-
-def _print_get_body_suffix():
-    return [ '    }', '  }' ]
-
-
-def _print_get_body(classname, type, vpi, card):
-    content = []
-    if vpi in ['vpiType', 'vpiLineNo', 'vpiColumnNo', 'vpiEndLineNo', 'vpiEndColumnNo']:  # These are already handled by base class
-        return content
-
-    if (card == '1') and (type not in ['string', 'value', 'delay']):
-        content.append(f'      case {vpi}: return ((const {classname}*)(obj))->{vpi[:1].upper()}{vpi[1:]}();')
-
-    return content
-
-
-def _print_get_value_body(classname, type, vpi, card):
-    content = []
-    if (card == '1') and (type == 'value'):
-        content.append(f'  if (handle->type == uhdm{classname}) {{')
-        content.append(f'    const s_vpi_value* v = String2VpiValue((({classname}*)(obj))->VpiValue());')
-        content.append( '    if (v) {')
-        content.append( '      *value_p = *v;')
-        content.append( '    }')
-        content.append( '  }')
-
-    return content
-
-
-def _print_get_delay_body(classname, type, vpi, card):
-    content = []
-    if (card == '1') and (type == 'delay'):
-        content.append(f'  if (handle->type == uhdm{classname}) {{')
-        content.append(f'    const s_vpi_delay* v = String2VpiDelays((({classname}*)(obj))->VpiDelay());')
-        content.append( '    if (v) {')
-        content.append( '      *delay_p = *v;')
-        content.append( '    }')
-        content.append( '  }')
-    return content
-
-
-def _print_get_handle_body(classname, type, vpi, object, card):
-    if type == 'BaseClass':
-        type = f'(({classname}*)(object))->UhdmParentType()'
-
-    content = []
-    need_casting = not ((vpi == 'vpiParent') and (object == 'vpiParent'))
-
-    if card == '1':
-        Object_ = object[:1].upper() + object[1:]
-        casted_object1 = f'((BaseClass*)(({classname}*)(object))' if need_casting else '(object'
-        casted_object2 = f'(({classname}*)(object))' if need_casting else 'object'
-        content.append(f'  if ((handle->type == uhdm{classname}) && (type == {vpi})) {{')
-        content.append(f'    if ({casted_object1}->{Object_}()))')
-        content.append(f'      return NewHandle({casted_object1}->{Object_}())->UhdmType(), {casted_object2}->{Object_}());')
-        content.append( '    else return 0;')
-        content.append( '  }')
-    return content
-
-
-def _print_get_str_body(classname, type, vpi, card):
-    # Already handled by the base class
-    content = []
-    if vpi in ['vpiFile', 'vpiName', 'vpiDefName']:
-        return content
-
-    Vpi_ = vpi[:1].upper() + vpi[1:]
-    if (card == '1') and (type == 'string'):
-        content.append(f'  if ((handle->type == uhdm{classname}) && (property == {vpi})) {{')
-        content.append(f'    const {classname}* const o = (const {classname}*)(obj);')
-        if vpi == 'vpiFullName':
-            content.append(f'    return (o->{Vpi_}().empty() || o->{Vpi_}() == o->VpiName())')
-            content.append( '      ? 0')
-            content.append(f'      : (PLI_BYTE8*) o->{Vpi_}().c_str();')
-        else:
-            content.append(f'    return (PLI_BYTE8*) (o->{Vpi_}().empty() ? 0 : o->{Vpi_}().c_str());')
-        content.append( '  }')
-    return content
-
-
-def _print_scan_body(name, classname, type, card):
-    content = []
-    if card == 'any':
-        content.append(f'  if (handle->type == uhdm{name}) {{')
-        content.append(f'    VectorOf{type}* the_vec = (VectorOf{type}*)vect;')
-        content.append( '    if (handle->index < the_vec->size()) {')
-        content.append( '      uhdm_handle* h = new uhdm_handle(((BaseClass*)the_vec->at(handle->index))->UhdmType(), the_vec->at(handle->index));')
-        content.append( '      handle->index++;')
-        content.append( '      return (vpiHandle) h;')
-        content.append( '    }')
-        content.append( '  }')
-    return content
-
-
-def _update_vpi_inst(baseclass, classname):
-    for type, vpi, card in vpi_get_str_body_inst[baseclass]:
-        vpi_get_str_body.extend(_print_get_str_body(classname, type, vpi, card))
-
-    vpi_case_body = []
-    for type, vpi, card in vpi_get_body_inst[baseclass]:
-        vpi_case_body.extend(_print_get_body(classname, type, vpi, card))
-           
-    # The case body can be empty if all propeerties have been handled
-    # in the base class. So only if non-empty, add the if/switch
-    if vpi_case_body:
-        vpi_get_body.extend(_print_get_body_prefix(classname))
-        vpi_get_body.extend(vpi_case_body)
-        vpi_get_body.extend(_print_get_body_suffix())
-
-    for type, vpi, card in vpi_get_body_inst[baseclass]:
-        vpi_get_value_body.extend(_print_get_value_body(classname, type, vpi, card))
-        vpi_get_delay_body.extend(_print_get_delay_body(classname, type, vpi, card))
-
-
-def _process_baseclass(model, models):
-    classname = model['name']
-    baseclass = model['extends']
-    while baseclass:
-        _update_vpi_inst(baseclass, classname)
-
-        vpi_iterate_body_all.extend([
-          line.replace(f'= uhdm{baseclass}', f'= uhdm{classname}')
-          for line in vpi_iterate_body[baseclass]
-        ])
-
-        vpi_handle_body_all.extend([
-          line.replace(f'= uhdm{baseclass}', f'= uhdm{classname}').replace(f'{baseclass}*', f'{classname}*')
-          for line in vpi_handle_body[baseclass]
-        ])
-
-        vpi_handle_by_name_body_all.extend([
-          line.replace(f'= uhdm{baseclass}', f'= uhdm{classname}')
-          for line in vpi_handle_by_name_body[baseclass]
-        ])
-
-        baseclass = models[baseclass]['extends']
-
-
 def generate(models):
+    vpi_get_value_classes = set()
+    vpi_get_delay_classes = set()
     for model in models.values():
         modeltype = model['type']
-        if modeltype == 'group_def':
+        if modeltype != 'obj_def':
             continue
 
         classname = model['name']
-        baseclass = model['extends']
 
-        vpi_iterate_body[classname] = []
-        vpi_iterator[classname] = []
-        vpi_handle_body[classname] = []
-        vpi_get_str_body_inst[classname] = []
-        vpi_get_body_inst[classname] = []
-        vpi_handle_by_name_body[classname] = []
+        baseclass = classname
+        while baseclass:
+            for key, value in models[baseclass].allitems():
+                if key == 'property' and value.get('card') == '1':
+                    type = value.get('type')
 
-        if modeltype != 'class_def':
-            # Builtin properties do not need to be specified in each models
-            # Builtins: "vpiParent, Parent type, vpiFile, Id" method and field
-            vpi_handle_body[classname] += _print_get_handle_body(classname, 'BaseClass', 'vpiParent', 'vpiParent', '1')
-            vpi_get_str_body_inst[classname].append(('string', 'vpiFile', '1'))
+                    if type == 'value':
+                        vpi_get_value_classes.add(classname)
 
-        type_specified = False
-        for key, value in model.allitems():
-            if key == 'property':
-                name = value.get('name')
-                vpi = value.get('vpi')
-                type = value.get('type')
-                card = value.get('card')
+                    if type == 'delay':
+                        vpi_get_delay_classes.add(classname)
 
-                if name == 'type':
-                    type_specified = True
-                    vpi_get_body_inst[classname].append((type, vpi, card))
-                else:
-                    # properties are already defined in vpi_user.h, no need to redefine them
-                    vpi_get_body_inst[classname].append((type, vpi, card))
-                    vpi_get_str_body_inst[classname].append((type, vpi, card))
+            baseclass = models[baseclass]['extends']
 
-            elif key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
-                name = value.get('name')
-                vpi = value.get('vpi')
-                type = value.get('type')
-                card = value.get('card')
+    # headers = [ f"#include <uhdm/{model['name']}.h>" for model in models.values() ]
+    headers = [ f"#include <uhdm/{name}.h>" for name in sorted(set.union(vpi_get_value_classes, vpi_get_delay_classes)) ]
 
-                if (card == 'any') and not name.endswith('s'):
-                    name += 's'
+    vpi_handle_by_name_body = [
+        f'  if (object->GetSerializer()->symbolMaker.GetId(name) == static_cast<SymbolFactory::ID>(-1)) {{',
+         '    return nullptr;',
+         '  }',
+         '  const BaseClass *const ref = object->GetByVpiName(std::string_view(name));',
+         '  return (ref != nullptr) ? NewVpiHandle(ref) : nullptr;'
+    ]
 
-                if key == 'group_ref':
-                    type = 'any'
+    vpi_handle_body = [
+        '  auto [ref, ignored1, ignored2] = object->GetByVpiType(type);',
+        '  return (ref != nullptr) ? NewHandle(ref->UhdmType(), ref) : nullptr;'
+    ]
 
-                vpi_iterate_body[classname].extend(_print_iterate_body(name, classname, vpi, card))
-                vpi_handle_by_name_body[classname].extend(_print_get_handle_by_name_body(name, classname, vpi, card))
-                vpi_iterator[classname].append((vpi, type, card))
-                vpi_scan_body.extend(_print_scan_body(name, classname, type, card))
-                vpi_handle_body[classname].extend(_print_get_handle_body(classname, f'uhdm{type}', vpi, name, card))
+    vpi_iterate_body = [
+        '  auto [ignored, refType, refVector] = object->GetByVpiType(type);',
+        '  return (refVector != nullptr) ? NewHandle(refType, refVector) : nullptr;'
+    ]
 
-        if not type_specified and (modeltype == 'obj_def'):
-            vpiclasstype = config.make_vpi_name(classname)
-            vpi_get_body_inst[classname].append(('unsigned int', 'vpiType', '1'))
+    vpi_get_body = [
+        '  BaseClass::vpi_property_value_t value = obj->GetVpiPropertyValue(property);',
+        '  return std::holds_alternative<int64_t>(value) ? std::get<int64_t>(value) : 0;'
+    ]
 
-        # VPI
-        _update_vpi_inst(classname, classname)
+    vpi_get_str_body = [
+        '  BaseClass::vpi_property_value_t value = obj->GetVpiPropertyValue(property);',
+        '  return std::holds_alternative<const char *>(value) ? const_cast<char *>(std::get<const char *>(value)) : nullptr;'
+    ]
 
-        vpi_iterate_body_all.extend(vpi_iterate_body[classname])
-        vpi_handle_body_all.extend(vpi_handle_body[classname])
-        vpi_handle_by_name_body_all.extend(vpi_handle_by_name_body[classname])
+    vpi_get_value_body = [
+        f'  const s_vpi_value* v = nullptr;',
+        f'  switch (handle->type) {{'
+    ] + [
+        f'    case uhdm{classname}: v = String2VpiValue((({classname}*)obj)->VpiValue()); break;' for classname in sorted(vpi_get_value_classes)
+    ] + [
+        f'  }}',
+        f'  if (v != nullptr) *value_p = *v;'
+    ] if vpi_get_value_classes else []
 
-        # process baseclass recursively
-        _process_baseclass(model, models)
-
-    headers = [ f"#include \"uhdm/{model['name']}.h\"" for model in models.values() ]
+    vpi_get_delay_body = [
+        f'  const s_vpi_delay* v = nullptr;',
+        f'  switch (handle->type) {{',
+    ] + [
+        f'    case uhdm{classname}: v = String2VpiDelays((({classname}*)obj)->VpiDelay()); break;' for classname in sorted(vpi_get_delay_classes)
+    ] + [
+        f'  }}',
+        f'  if (v != nullptr) *delay_p = *v;'
+    ] if vpi_get_delay_classes else []
 
     # vpi_user.cpp
     with open(config.get_template_filepath('vpi_user.cpp'), 'r+t') as strm:
         file_content = strm.read()
 
     file_content = file_content.replace('<HEADERS>', '\n'.join(headers))
-    file_content = file_content.replace('<VPI_HANDLE_BY_NAME_BODY>', '\n'.join(vpi_handle_by_name_body_all))
-    file_content = file_content.replace('<VPI_ITERATE_BODY>', '\n'.join(vpi_iterate_body_all))
-    file_content = file_content.replace('<VPI_SCAN_BODY>', '\n'.join(vpi_scan_body))
-    file_content = file_content.replace('<VPI_HANDLE_BODY>', '\n'.join(vpi_handle_body_all))
+    file_content = file_content.replace('<VPI_HANDLE_BY_NAME_BODY>', '\n'.join(vpi_handle_by_name_body))
+    file_content = file_content.replace('<VPI_HANDLE_BODY>', '\n'.join(vpi_handle_body))
+    file_content = file_content.replace('<VPI_ITERATE_BODY>', '\n'.join(vpi_iterate_body))
+    file_content = file_content.replace('<VPI_SCAN_BODY>', '')
     file_content = file_content.replace('<VPI_GET_BODY>', '\n'.join(vpi_get_body))
+    file_content = file_content.replace('<VPI_GET_STR_BODY>', '\n'.join(vpi_get_str_body))
     file_content = file_content.replace('<VPI_GET_VALUE_BODY>', '\n'.join(vpi_get_value_body))
     file_content = file_content.replace('<VPI_GET_DELAY_BODY>', '\n'.join(vpi_get_delay_body))
-    file_content = file_content.replace('<VPI_GET_STR_BODY>', '\n'.join(vpi_get_str_body))
     file_utils.set_content_if_changed(config.get_output_source_filepath('vpi_user.cpp'), file_content)
 
     return True

--- a/scripts/vpi_visitor_cpp.py
+++ b/scripts/vpi_visitor_cpp.py
@@ -1,9 +1,11 @@
+from collections import OrderedDict
+
 import config
 import file_utils
 
 
 def _get_implementation(classname, vpi, card):
-    shallow_visit = ''
+    shallow_visit = 'false'
     content = []
     if (vpi == 'vpiParent') and (classname != 'part_select'):
         return content
@@ -11,69 +13,66 @@ def _get_implementation(classname, vpi, card):
     if card == '1':
         if 'func_call' in classname and vpi == 'vpiFunction':
             # Prevent stepping inside functions while processing calls (func_call, method_func_call) to them
-            shallow_visit = ', true'
+            shallow_visit = 'true'
 
         if 'task_call' in classname and vpi == 'vpiTask':
             # Prevent stepping inside tasks while processing calls (task_call, method_task_call) to them
-            shallow_visit = ', true'
+            shallow_visit = 'true'
 
         # Prevent loop in Standard VPI
         if vpi not in ['vpiModule', 'vpiInterface']:
-            content.append(f'    itr = vpi_handle({vpi}, obj_h);')
-            content.append(f'    visit_object(itr, subobject_indent, "{vpi}", visited, out{shallow_visit});')
-            content.append( '    release_handle(itr);')
+            content.append(f'  itr = vpi_handle({vpi}, obj_h);')
+            content.append(f'  visit_object(itr, indent + kLevelIndent, "{vpi}", visited, out, {shallow_visit});')
+            content.append( '  release_handle(itr);')
 
     else:
         if classname == 'design':
-            content.append('    if (indent == 0) visited->clear();')
+            content.append('  if (indent == 0) visited->clear();')
 
         # Prevent loop in Standard VPI
         if vpi != 'vpiUse':
-            content.append(f'    itr = vpi_iterate({vpi}, obj_h);')
-            content.append( '    while (vpiHandle obj = vpi_scan(itr)) {')
-            content.append(f'      visit_object(obj, subobject_indent, "{vpi}", visited, out{shallow_visit});')
-            content.append( '      release_handle(obj);')
-            content.append( '    }')
-            content.append( '    release_handle(itr);')
+            content.append(f'  itr = vpi_iterate({vpi}, obj_h);')
+            content.append( '  while (vpiHandle obj = vpi_scan(itr)) {')
+            content.append(f'    visit_object(obj, indent + kLevelIndent, "{vpi}", visited, out, {shallow_visit});')
+            content.append( '    release_handle(obj);')
+            content.append( '  }')
+            content.append( '  release_handle(itr);')
 
-    return content
-
-
-def _get_vpi_str_visitor(type, vpi, card):
-    content = []
-    if (card == '1') and (type == 'string') and (vpi != 'vpiFile'):
-        content.append(f'    if (const char* s = vpi_get_str({vpi}, obj_h))')
-        content.append(f'      stream_indent(out, indent) << "|{vpi}:" << s << std::endl;')
     return content
 
 
 def _get_vpi_xxx_visitor(type, vpi, card):
     content = []
     if vpi == 'vpiValue':
-        content.append('    s_vpi_value value;')
-        content.append('    vpi_get_value(obj_h, &value);')
-        content.append('    if (value.format) {')
-        content.append('      std::string val = visit_value(&value);')
-        content.append('      if (!val.empty()) {')
-        content.append('        stream_indent(out, indent) << val;')
-        content.append('      }')
+        content.append('  s_vpi_value value;')
+        content.append('  vpi_get_value(obj_h, &value);')
+        content.append('  if (value.format) {')
+        content.append('    std::string val = visit_value(&value);')
+        content.append('    if (!val.empty()) {')
+        content.append('      stream_indent(out, indent) << val;')
         content.append('    }')
+        content.append('  }')
     elif vpi == 'vpiDelay':
-        content.append('    s_vpi_delay delay;')
-        content.append('    vpi_get_delays(obj_h, &delay);')
-        content.append('    if (delay.da != nullptr) {')
-        content.append('      stream_indent(out, indent) << visit_delays(&delay);')
-        content.append('    }')
-    elif (card == '1') and (type != 'string') and (vpi not in ['vpiType', 'vpiLineNo', 'vpiColumnNo', 'vpiEndLineNo', 'vpiEndColumnNo']):
-        content.append(f'    if (const int n = vpi_get({vpi}, obj_h))')
-        content.append(f'      stream_indent(out, indent) << "|{vpi}:" << n << std::endl;')
+        content.append('  s_vpi_delay delay;')
+        content.append('  vpi_get_delays(obj_h, &delay);')
+        content.append('  if (delay.da != nullptr) {')
+        content.append('    stream_indent(out, indent) << visit_delays(&delay);')
+        content.append('  }')
+    elif (card == '1') and (vpi not in ['vpiType', 'vpiFile', 'vpiLineNo', 'vpiColumnNo', 'vpiEndLineNo', 'vpiEndColumnNo']):
+        if type == 'string':
+            content.append(f'  if (const char* s = vpi_get_str({vpi}, obj_h))')
+            content.append(f'    stream_indent(out, indent) << "|{vpi}:" << s << std::endl;')
+        else:
+            content.append(f'  if (const int n = vpi_get({vpi}, obj_h))')
+            content.append(f'    stream_indent(out, indent) << "|{vpi}:" << n << std::endl;')
     return content
 
 
 def generate(models):
-    vpi_iterator = {}
-    vpi_get_body = {}
-    vpi_get_str_body = {}
+    visit_object_body = []
+    private_visitor_bodies = []
+
+    ignored_objects = set(['vpiNet'])
 
     for model in models.values():
         modeltype = model['type']
@@ -81,15 +80,29 @@ def generate(models):
             continue
 
         classname = model['name']
+        if classname in ['net_drivers', 'net_loads']:
+            continue
 
-        vpi_iterator[classname] = []
-        vpi_get_body[classname] = []
-        vpi_get_str_body[classname] = []
+        vpi_name = config.make_vpi_name(classname)
+        if vpi_name not in ignored_objects:
+            visit_object_body.append(f'    case {vpi_name}: visit_{classname}(obj_h, indent, relation, visited, out, shallowVisit); break;')
+
+        private_visitor_bodies.append(f'static void visit_{classname}(vpiHandle obj_h, int indent, const char *relation, VisitedContainer* visited, std::ostream& out, bool shallowVisit) {{')
+
+        baseclass = model.get('extends', None)
+        if baseclass:
+            private_visitor_bodies.append(f'  visit_{baseclass}(obj_h, indent, relation, visited, out, shallowVisit);')
+
+        itr_required = False
+        private_visitor_body = []
+
+        if classname == 'part_select':
+            private_visitor_body.extend(_get_implementation(classname, 'vpiParent', '1'))
+            itr_required = True
 
         if modeltype != 'class_def':
-            vpi_iterator[classname].append(('vpiParent', '1'))
-            vpi_get_str_body[classname].append(('string', 'vpiFile', '1'))
-
+            private_visitor_body.extend(_get_vpi_xxx_visitor('string', 'vpiFile', '1'))
+        
         type_specified = False
         for key, value in model.allitems():
             if key == 'property':
@@ -98,57 +111,35 @@ def generate(models):
                 type = value.get('type')
                 card = value.get('card')
 
-                vpi_get_body[classname].append((type, vpi, card))
-                if name == 'type':
-                    type_specified = True
-                else:
-                    vpi_get_str_body[classname].append((type, vpi, card))
+                type_specified = name == 'type' or type_specified
+                private_visitor_body.extend(_get_vpi_xxx_visitor(type, vpi, card))
 
             elif key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
                 vpi = value.get('vpi')
                 card = value.get('card')
 
-                vpi_iterator[classname].append((vpi, card))
+                private_visitor_body.extend(_get_implementation(classname, vpi, card))
+                itr_required = True
 
         if not type_specified and (modeltype == 'obj_def'):
-            vpi_get_body[classname].append(('unsigned int', 'vpiType', '1'))
+            private_visitor_body.extend(_get_vpi_xxx_visitor('unsigned int', 'vpiType', '1'))
 
-    visitors = []
-    for model in models.values():
-        modeltype = model['type']
-        if modeltype in ['group_def', 'class_def']:
-            continue
+        if private_visitor_body:
+            if itr_required:
+                private_visitor_bodies.append(f'  vpiHandle itr;')
+            private_visitor_bodies.extend(private_visitor_body)
 
-        classname = model['name']
+        private_visitor_bodies.append(f'}}')
+        private_visitor_bodies.append('')
 
-        locals = []
-        remotes = []
-        baseclass = classname
-        while baseclass:
-            for type, vpi, card in vpi_get_str_body[baseclass]:
-                locals.extend(_get_vpi_str_visitor(type, vpi, card))
-
-            for type, vpi, card in vpi_get_body[baseclass]:
-                locals.extend(_get_vpi_xxx_visitor(type, vpi, card))
-
-            for vpi, card in vpi_iterator[baseclass]:
-                remotes.extend(_get_implementation(classname, vpi, card))
-
-            baseclass = models[baseclass]['extends']
-
-        if locals or remotes:
-            vpi_name = config.make_vpi_name(classname)
-            visitors.append(f'  if (objectType == {vpi_name}) {{')
-            visitors.extend(locals)
-            visitors.extend(remotes)
-            visitors.append( '    return;')
-            visitors.append( '  }')
+    visitors = [ f'  switch (objectType) {{' ] + sorted(visit_object_body) + [ f'  }}' ]
 
     # vpi_visitor.cpp
     with open(config.get_template_filepath('vpi_visitor.cpp'), 'r+t') as strm:
         file_content = strm.read()
 
     file_content = file_content.replace('<OBJECT_VISITORS>', '\n'.join(visitors))
+    file_content = file_content.replace('<PRIVATE_OBJECT_VISITORS>', '\n'.join(private_visitor_bodies))
     file_utils.set_content_if_changed(config.get_output_source_filepath('vpi_visitor.cpp'), file_content)
 
     return True

--- a/templates/class_header.h
+++ b/templates/class_header.h
@@ -51,7 +51,8 @@ public:
   <VIRTUAL> UHDM_OBJECT_TYPE UhdmType() const <OVERRIDE_OR_FINAL> { return uhdm<CLASSNAME>; }
 
 protected:
-  void DeepCopy(<CLASSNAME>* clone, Serializer* serializer, ElaboratorListener* elaborator, BaseClass* parent) const;
+  void DeepCopy(<CLASSNAME>* clone, Serializer* serializer,
+                ElaboratorListener* elaborator, BaseClass* parent) const;
 
 private:
 <MEMBERS>

--- a/templates/uhdm_types.h
+++ b/templates/uhdm_types.h
@@ -28,6 +28,7 @@
 
 #include <string>
 #include <uhdm/vpi_user.h>
+#include <uhdm/uhdm_vpi_user.h>
 
 namespace UHDM {
 class BaseClass;

--- a/templates/vpi_listener.cpp
+++ b/templates/vpi_listener.cpp
@@ -44,17 +44,15 @@
 using namespace UHDM;
 
 <VPI_LISTENERS>
-
-void UHDM::listen_any(vpiHandle object, VpiListener* listener, UHDM::VisitedContainer* visited) {
-  unsigned int type = ((const uhdm_handle*)object)->type;
+void UHDM::listen_any(vpiHandle handle, VpiListener* listener, UHDM::VisitedContainer* visited) {
+  unsigned int type = ((const uhdm_handle*)handle)->type;
   switch (type) {
 <VPI_ANY_LISTENERS>
-  default:
-    break;
+  default: break;
   }
 }
 
-void UHDM::listen_designs (const std::vector<vpiHandle>& designs, VpiListener* listener) {
+void UHDM::listen_designs(const std::vector<vpiHandle>& designs, VpiListener* listener) {
   for (auto design_h : designs) {
     UHDM::VisitedContainer visited;
     listen_design(design_h, listener, &visited);

--- a/templates/vpi_user.cpp
+++ b/templates/vpi_user.cpp
@@ -36,6 +36,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <uhdm/Serializer.h>
@@ -50,7 +51,7 @@ using namespace UHDM;
 
 UHDM::design* UhdmDesignFromVpiHandle(vpiHandle hdesign) {
   if (!hdesign) return nullptr;
-  UHDM::any* tmp = (UHDM::any*) ((uhdm_handle*)hdesign)->object;
+  UHDM::any* tmp = (UHDM::any*)((uhdm_handle*)hdesign)->object;
   if (tmp->UhdmType() == uhdmdesign)
     return (UHDM::design*)tmp;
   else
@@ -67,56 +68,46 @@ s_vpi_value* String2VpiValue(const std::string& s) {
   if ((pos = s.find("UINT:")) != std::string::npos) {
     val->format = vpiUIntVal;
     val->value.uint = std::strtoull(s.c_str() + pos + strlen("UINT:"), 0, 10);
-  }
-  else if ((pos = s.find("INT:")) != std::string::npos) {
+  } else if ((pos = s.find("INT:")) != std::string::npos) {
     val->format = vpiIntVal;
     val->value.integer = std::strtoll(s.c_str() + pos + strlen("INT:"), 0, 10);
-  }
-  else if ((pos = s.find("SCAL:")) != std::string::npos) {
+  } else if ((pos = s.find("SCAL:")) != std::string::npos) {
     val->format = vpiScalarVal;
-    const char *const parse_pos = s.c_str() + pos + strlen("SCAL:");
+    const char* const parse_pos = s.c_str() + pos + strlen("SCAL:");
     switch (parse_pos[0]) {
-    case 'Z': val->value.scalar = vpiZ; break;
-    case 'X': val->value.scalar = vpiX; break;
-    case 'H': val->value.scalar = vpiH; break;
-    case 'L': val->value.scalar = vpiL; break;
-      // Not really clear what the difference between X and DontCare is.
-      // Let's parse 'W'eak don't care as this one.
-    case 'W': val->value.scalar = vpiDontCare; break;
-    default:
-      if (strcasecmp(parse_pos, "DontCare") == 0) {
-        val->value.scalar = vpiDontCare;
-      }
-      else if (strcasecmp(parse_pos, "NoChange") == 0) {
-        val->value.scalar = vpiNoChange;
-      }
-      else {
-        val->value.scalar = atoi(parse_pos); // Maybe written numerically?
-      }
-      break;
+      case 'Z': val->value.scalar = vpiZ; break;
+      case 'X': val->value.scalar = vpiX; break;
+      case 'H': val->value.scalar = vpiH; break;
+      case 'L': val->value.scalar = vpiL; break;
+        // Not really clear what the difference between X and DontCare is.
+        // Let's parse 'W'eak don't care as this one.
+      case 'W': val->value.scalar = vpiDontCare; break;
+      default:
+        if (strcasecmp(parse_pos, "DontCare") == 0) {
+          val->value.scalar = vpiDontCare;
+        } else if (strcasecmp(parse_pos, "NoChange") == 0) {
+          val->value.scalar = vpiNoChange;
+        } else {
+          val->value.scalar = atoi(parse_pos);  // Maybe written numerically?
+        }
+        break;
     }
-  }
-  else if ((pos = s.find("BIN:")) != std::string::npos) {
+  } else if ((pos = s.find("BIN:")) != std::string::npos) {
     val->format = vpiBinStrVal;
     val->value.str = strdup(s.c_str() + pos + strlen("BIN:"));
-  }
-  else if ((pos = s.find("HEX:")) != std::string::npos) {
+  } else if ((pos = s.find("HEX:")) != std::string::npos) {
     val->format = vpiHexStrVal;
     val->value.str = strdup(s.c_str() + pos + strlen("HEX:"));
-  }
-  else if ((pos = s.find("OCT:")) != std::string::npos) {
+  } else if ((pos = s.find("OCT:")) != std::string::npos) {
     val->format = vpiOctStrVal;
     val->value.str = strdup(s.c_str() + pos + strlen("OCT:"));
-  }
-  else if ((pos = s.find("STRING:")) != std::string::npos) {
+  } else if ((pos = s.find("STRING:")) != std::string::npos) {
     val->format = vpiStringVal;
     val->value.str = strdup(s.c_str() + pos + strlen("STRING:"));
-  }
-  else if ((pos = s.find("REAL:")) != std::string::npos) {
+  } else if ((pos = s.find("REAL:")) != std::string::npos) {
     val->format = vpiRealVal;
     val->value.real = atof(s.c_str() + pos + strlen("REAL:"));
-  }
-  else if ((pos = s.find("DEC:")) != std::string::npos) {
+  } else if ((pos = s.find("DEC:")) != std::string::npos) {
     val->format = vpiDecStrVal;
     val->value.str = strdup(s.c_str() + pos + strlen("DEC:"));
   }
@@ -124,22 +115,20 @@ s_vpi_value* String2VpiValue(const std::string& s) {
   return val;
 }
 
-
 s_vpi_delay* String2VpiDelays(const std::string& s) {
   std::string scopy = s;
   s_vpi_delay* delay = new s_vpi_delay;
   delay->da = nullptr;
   if (strstr(scopy.c_str(), "#")) {
-    scopy.erase(0,1);
+    scopy.erase(0, 1);
     delay->da = new t_vpi_time;
     delay->no_of_delays = 1;
     delay->time_type = vpiScaledRealTime;
-    delay->da[0].low  = atoi(scopy.c_str());
+    delay->da[0].low = atoi(scopy.c_str());
     delay->da[0].type = vpiScaledRealTime;
   }
   return delay;
 }
-
 
 std::string VpiValue2String(const s_vpi_value* value) {
   static const std::string kIntPrefix("INT:");
@@ -154,271 +143,197 @@ std::string VpiValue2String(const s_vpi_value* value) {
 
   if (!value) return "";
   switch (value->format) {
-  case vpiIntVal: return kIntPrefix + std::to_string(value->value.integer);
-  case vpiUIntVal: return kUIntPrefix + std::to_string(value->value.uint);
-  case vpiScalarVal: {
-    switch (value->value.scalar) {
-    case vpi0: return "SCAL:0";
-    case vpi1: return "SCAL:1";
-    case vpiZ: return "SCAL:Z";
-    case vpiX: return "SCAL:X";
-    case vpiH: return "SCAL:H";
-    case vpiL: return "SCAL:L";
-    case vpiDontCare: return "SCAL:DontCare";
-    case vpiNoChange: return "SCAL:NoChange";
-    default:
-      // mmh, some unknown number.
-      return kScalPrefix + std::to_string(value->value.scalar);
+    case vpiIntVal: return kIntPrefix + std::to_string(value->value.integer);
+    case vpiUIntVal: return kUIntPrefix + std::to_string(value->value.uint);
+    case vpiScalarVal: {
+      switch (value->value.scalar) {
+        case vpi0: return "SCAL:0";
+        case vpi1: return "SCAL:1";
+        case vpiZ: return "SCAL:Z";
+        case vpiX: return "SCAL:X";
+        case vpiH: return "SCAL:H";
+        case vpiL: return "SCAL:L";
+        case vpiDontCare: return "SCAL:DontCare";
+        case vpiNoChange: return "SCAL:NoChange";
+        default:
+          // mmh, some unknown number.
+          return kScalPrefix + std::to_string(value->value.scalar);
+      }
     }
-  }
-  case vpiStringVal: return kStrPrefix + value->value.str;
-  case vpiHexStrVal: return kHexPrefix + value->value.str;
-  case vpiOctStrVal: return kOctPrefix + value->value.str;
-  case vpiBinStrVal: return kBinPrefix + value->value.str;
-  case vpiDecStrVal: return kDecPrefix + value->value.str;
-  case vpiRealVal:  return kRealPrefix + std::to_string(value->value.real);
+    case vpiStringVal: return kStrPrefix + value->value.str;
+    case vpiHexStrVal: return kHexPrefix + value->value.str;
+    case vpiOctStrVal: return kOctPrefix + value->value.str;
+    case vpiBinStrVal: return kBinPrefix + value->value.str;
+    case vpiDecStrVal: return kDecPrefix + value->value.str;
+    case vpiRealVal: return kRealPrefix + std::to_string(value->value.real);
   }
 
   return "";
 }
 
-
 std::string VpiDelay2String(const s_vpi_delay* delay) {
   std::string result;
-  if (delay == nullptr)
-    return result;
-  if (delay->da == nullptr)
-    return result;
+  if (delay == nullptr) return result;
+  if (delay->da == nullptr) return result;
   switch (delay->time_type) {
-  case vpiScaledRealTime: {
-    return std::string(std::string("#") + std::to_string(delay->da[0].low));
-    break;
-  }
-  default:
-    break;
+    case vpiScaledRealTime: {
+      return std::string(std::string("#") + std::to_string(delay->da[0].low));
+      break;
+    }
+    default:
+      break;
   }
   return result;
 }
 
-vpiHandle NewVpiHandle (const UHDM::BaseClass* object) {
-  return reinterpret_cast<vpiHandle>(new uhdm_handle(object->UhdmType(), object));
+vpiHandle NewVpiHandle(const UHDM::BaseClass* object) {
+  return reinterpret_cast<vpiHandle>(
+      new uhdm_handle(object->UhdmType(), object));
 }
 
-static vpiHandle NewHandle (UHDM_OBJECT_TYPE type, const void *object) {
+static vpiHandle NewHandle(UHDM_OBJECT_TYPE type, const void* object) {
   return reinterpret_cast<vpiHandle>(new uhdm_handle(type, object));
 }
 
-vpiHandle vpi_handle_by_index (vpiHandle object,
-                               PLI_INT32    indx) {
-  return 0;
-}
+vpiHandle vpi_handle_by_index(vpiHandle object, PLI_INT32 indx) { return 0; }
 
-vpiHandle vpi_handle_by_name (PLI_BYTE8    *name,
-                              vpiHandle    refHandle) {
-  const uhdm_handle* const handle = (const uhdm_handle*) refHandle;
-  const BaseClass* const object = (const BaseClass*) handle->object;
+vpiHandle vpi_handle_by_name(PLI_BYTE8* name, vpiHandle refHandle) {
+  const uhdm_handle* const handle = (const uhdm_handle*)refHandle;
+  const BaseClass* const object = (const BaseClass*)handle->object;
 <VPI_HANDLE_BY_NAME_BODY>
-  return 0;
 }
 
-vpiHandle vpi_handle (PLI_INT32 type,
-                      vpiHandle   refHandle) {
-  const uhdm_handle* const handle = (const uhdm_handle*) refHandle;
-  const BaseClass* const object = (const BaseClass*) handle->object;
+vpiHandle vpi_handle(PLI_INT32 type, vpiHandle refHandle) {
+  const uhdm_handle* const handle = (const uhdm_handle*)refHandle;
+  const BaseClass* const object = (const BaseClass*)handle->object;
 <VPI_HANDLE_BODY>
-  std::cout << "VPI ERROR: Bad usage of vpi_handle" << std::endl;
-  return 0;
 }
 
-vpiHandle vpi_handle_multi (PLI_INT32 type,
-                            vpiHandle   refHandle1,
-                            vpiHandle   refHandle2,
-                            ... ) {
+vpiHandle vpi_handle_multi(PLI_INT32 type, vpiHandle refHandle1,
+                           vpiHandle refHandle2, ...) {
   return 0;
 }
 
 /* for traversing relationships */
 
-vpiHandle vpi_iterate (PLI_INT32 type, vpiHandle refHandle) {
-  const uhdm_handle* const handle = (const uhdm_handle*) refHandle;
-  const BaseClass* const object = (const BaseClass*) handle->object;
+vpiHandle vpi_iterate(PLI_INT32 type, vpiHandle refHandle) {
+  const uhdm_handle* const handle = (const uhdm_handle*)refHandle;
+  const BaseClass* const object = (const BaseClass*)handle->object;
 <VPI_ITERATE_BODY>
-  std::cout << "VPI ERROR: Bad usage of vpi_iterate" << std::endl;
-  return 0;
 }
 
-vpiHandle vpi_scan (vpiHandle iterator) {
+vpiHandle vpi_scan(vpiHandle iterator) {
   if (!iterator) return 0;
-  uhdm_handle* handle = (uhdm_handle*) iterator;
-  const void* vect = handle->object;
-<VPI_SCAN_BODY>
-  return 0;
+  uhdm_handle* handle = (uhdm_handle*)iterator;
+  const std::vector<const BaseClass*>* vect = (const std::vector<const BaseClass*>*)handle->object;
+  if (handle->index < vect->size()) {
+    const BaseClass* const object = vect->at(handle->index);
+    uhdm_handle* h = new uhdm_handle(object->UhdmType(), object);
+    ++handle->index;
+    return (vpiHandle) h;
+  }
+  return nullptr;
 }
 
-PLI_INT32 vpi_free_object (vpiHandle object) {
+PLI_INT32 vpi_free_object(vpiHandle object) {
   return vpi_release_handle(object);
 }
 
-PLI_INT32 vpi_release_handle (vpiHandle object) {
-  delete (uhdm_handle*) object;
+PLI_INT32 vpi_release_handle(vpiHandle object) {
+  delete (uhdm_handle*)object;
   return 0;
 }
 
 /* for processing properties */
 
-PLI_INT32 vpi_get (PLI_INT32   property,
-                   vpiHandle   object) {
+PLI_INT32 vpi_get(PLI_INT32 property, vpiHandle object) {
   if (!object) {
-      std::cout << "VPI ERROR: Bad usage of vpi_get" << std::endl;
+    std::cout << "VPI ERROR: Bad usage of vpi_get" << std::endl;
     return 0;
   }
 
   // At this point, the implementation is exactly the same as for 64 bit,
   // but we truncate.
-  return (PLI_INT32) vpi_get64(property, object);
+  return (PLI_INT32)vpi_get64(property, object);
 }
 
-PLI_INT64 vpi_get64 (PLI_INT32 property,
-                     vpiHandle   object) {
+PLI_INT64 vpi_get64(PLI_INT32 property, vpiHandle object) {
   if (!object) {
-      std::cout << "VPI ERROR: Bad usage of vpi_get64" << std::endl;
+    std::cout << "VPI ERROR: Bad usage of vpi_get64" << std::endl;
     return 0;
   }
 
-  const uhdm_handle* const handle = (const uhdm_handle*) object;
-  const BaseClass*  const obj = (const BaseClass*) handle->object;
-
-  // Baseclass-handled properties; all the others still need to be handled
-  // separately, but this is a good start.
-  switch (property) {
-    case vpiLineNo: return obj->VpiLineNo();
-    case vpiColumnNo: return obj->VpiColumnNo();
-    case vpiEndLineNo: return obj->VpiEndLineNo();
-    case vpiEndColumnNo: return obj->VpiEndColumnNo();
-    case vpiType: return obj->VpiType();
-  }
-
-  // ... all other properties currently handled 'manually' for now
+  const uhdm_handle* const handle = (const uhdm_handle*)object;
+  const BaseClass* const obj = (const BaseClass*)handle->object;
 <VPI_GET_BODY>
-
-  return 0;
 }
 
-PLI_BYTE8 *vpi_get_str (PLI_INT32 property,
-                        vpiHandle   object) {
+PLI_BYTE8* vpi_get_str(PLI_INT32 property, vpiHandle object) {
   if (!object) {
     std::cout << "VPI ERROR: Bad usage of vpi_get_str" << std::endl;
     return 0;
   }
-  const uhdm_handle* const handle = (const uhdm_handle*) object;
-  const BaseClass*  const obj = (const BaseClass*) handle->object;
-
-  // Handle some easy cases first; these are handled in the BaseClass.
-  // TODO: add some specific property interfaces (VpiFullNameImplementor?)
-  // to access some other common properties.
-  switch (property) {
-    case vpiFile:
-      return (PLI_BYTE8*) (obj->VpiFile().empty()
-                           ? 0
-                           : obj->VpiFile().c_str());
-
-   case vpiName:
-     return (PLI_BYTE8*) (obj->VpiName().empty()
-                          ? 0
-                          : obj->VpiName().c_str());
-
-    case vpiDefName:
-      return (PLI_BYTE8*) (obj->VpiDefName().empty()
-                           ? 0
-                           : obj->VpiDefName().c_str());
-  }
-
-  // ... all other properties currently handled 'manually' for now
+  const uhdm_handle* const handle = (const uhdm_handle*)object;
+  const BaseClass* const obj = (const BaseClass*)handle->object;
 <VPI_GET_STR_BODY>
-
-  return 0;
 }
-
 
 /* delay processing */
 
-void vpi_get_delays (vpiHandle object,
-                     p_vpi_delay delay_p) {
+void vpi_get_delays(vpiHandle object, p_vpi_delay delay_p) {
+  delay_p->da = nullptr;
   if (!object) {
     std::cout << "VPI ERROR: Bad usage of vpi_get_delay" << std::endl;
+    return;
   }
-  const uhdm_handle* const handle = (const uhdm_handle*) object;
-  const BaseClass*  const obj = (const BaseClass*) handle->object;
-  delay_p->da = nullptr;
+  const uhdm_handle* const handle = (const uhdm_handle*)object;
+  const BaseClass* const obj = (const BaseClass*)handle->object;
 <VPI_GET_DELAY_BODY>
 }
 
-void vpi_put_delays (vpiHandle object,
-                     p_vpi_delay delay_p) {
-}
+void vpi_put_delays(vpiHandle object, p_vpi_delay delay_p) {}
 
 /* value processing */
 
-void vpi_get_value (vpiHandle vexpr,
-                    p_vpi_value value_p) {
+void vpi_get_value(vpiHandle vexpr, p_vpi_value value_p) {
+  value_p->format = 0;
   if (!vexpr) {
     std::cout << "VPI ERROR: Bad usage of vpi_get_value" << std::endl;
+    return;
   }
-  const uhdm_handle* const handle = (const uhdm_handle*) vexpr;
-  const BaseClass*  const obj = (const BaseClass*) handle->object;
-  value_p->format = 0;
+  const uhdm_handle* const handle = (const uhdm_handle*)vexpr;
+  const BaseClass* const obj = (const BaseClass*)handle->object;
 <VPI_GET_VALUE_BODY>
 }
 
-vpiHandle vpi_put_value (vpiHandle object,
-                         p_vpi_value value_p,
-                         p_vpi_time time_p,
-                         PLI_INT32 flags) {
+vpiHandle vpi_put_value(vpiHandle object, p_vpi_value value_p,
+                        p_vpi_time time_p, PLI_INT32 flags) {
   return 0;
 }
 
-void vpi_get_value_array (vpiHandle object,
-                          p_vpi_arrayvalue arrayvalue_p,
-                          PLI_INT32 *index_p,
-                          PLI_UINT32 num) {
-}
+void vpi_get_value_array(vpiHandle object, p_vpi_arrayvalue arrayvalue_p,
+                         PLI_INT32* index_p, PLI_UINT32 num) {}
 
-void vpi_put_value_array (vpiHandle object,
-                          p_vpi_arrayvalue arrayvalue_p,
-                          PLI_INT32 *index_p,
-                          PLI_UINT32 num) {
-}
+void vpi_put_value_array(vpiHandle object, p_vpi_arrayvalue arrayvalue_p,
+                         PLI_INT32* index_p, PLI_UINT32 num) {}
 
 /* time processing */
 
-void vpi_get_time(vpiHandle object,
-                  p_vpi_time time_p) {
-}
+void vpi_get_time(vpiHandle object, p_vpi_time time_p) {}
 
-
-PLI_INT32 vpi_get_data (PLI_INT32 id,
-                        PLI_BYTE8 *dataLoc,
-                        PLI_INT32 numOfBytes) {
+PLI_INT32 vpi_get_data(PLI_INT32 id, PLI_BYTE8* dataLoc, PLI_INT32 numOfBytes) {
   return 0;
 }
 
-PLI_INT32 vpi_put_data (PLI_INT32 id,
-                        PLI_BYTE8 *dataLoc,
-                        PLI_INT32 numOfBytes) {
+PLI_INT32 vpi_put_data(PLI_INT32 id, PLI_BYTE8* dataLoc, PLI_INT32 numOfBytes) {
   return 0;
 }
 
-void *vpi_get_userdata (vpiHandle obj) {
-  return 0;
-}
+void* vpi_get_userdata(vpiHandle obj) { return 0; }
 
-PLI_INT32 vpi_put_userdata (vpiHandle obj,
-                            void *userdata) {
-  return 0;
-}
+PLI_INT32 vpi_put_userdata(vpiHandle obj, void* userdata) { return 0; }
 
-vpiHandle vpi_handle_by_multi_index (vpiHandle obj,
-                                     PLI_INT32 num_index,
-                                     PLI_INT32 *index_array) {
+vpiHandle vpi_handle_by_multi_index(vpiHandle obj, PLI_INT32 num_index,
+                                    PLI_INT32* index_array) {
   return 0;
 }

--- a/templates/vpi_visitor.cpp
+++ b/templates/vpi_visitor.cpp
@@ -34,6 +34,8 @@
 #include <vector>
 
 static bool showIDs = false;
+static constexpr int kLevelIndent = 2;
+
 
 #ifdef STANDARD_VPI
 
@@ -423,49 +425,42 @@ static std::string visit_value(s_vpi_value* value) {
   if (value == nullptr)
     return "";
   switch (value->format) {
-  case vpiIntVal: {
-    return std::string(std::string("|INT:") + std::to_string(value->value.integer) + "\n");
-    break;
-  }
-  case vpiUIntVal: {
-    return std::string(std::string("|UINT:") + std::to_string(value->value.uint) + "\n");
-    break;
-  }
-  case vpiStringVal: {
-    const char* s = (const char*) value->value.str;
-    return std::string(std::string("|STRING:") + std::string(s) + "\n");
-    break;
-  }
-  case vpiBinStrVal: {
-    const char* s = (const char*) value->value.str;
-    return std::string(std::string("|BIN:") + std::string(s) + "\n");
-    break;
-  }
-  case vpiHexStrVal: {
-    const char* s = (const char*) value->value.str;
-    return std::string(std::string("|HEX:") + std::string(s) + "\n");
-    break;
-  }
-  case vpiOctStrVal: {
-    const char* s = (const char*) value->value.str;
-    return std::string(std::string("|OCT:") + std::string(s) + "\n");
-    break;
-  }
-  case vpiRealVal: {
-    return std::string(std::string("|REAL:") + std::to_string(value->value.real) + "\n");
-    break;
-  }
-  case vpiScalarVal: {
-    return std::string(std::string("|SCAL:") + std::to_string(value->value.scalar) + "\n");
-    break;
-  }
-  case vpiDecStrVal: {
-    const char* s = (const char*) value->value.str;
-    return std::string(std::string("|DEC:") + std::string(s) + "\n");
-    break;
-  }
-  default:
-    break;
+  case vpiIntVal:
+      return std::string("|INT:")
+          .append(std::to_string(value->value.integer))
+          .append("\n");
+  case vpiUIntVal:
+    return std::string("|UINT:")
+        .append(std::to_string(value->value.uint))
+        .append("\n");
+  case vpiStringVal:
+    return std::string("|STRING:")
+        .append((const char*)value->value.str)
+        .append("\n");
+  case vpiBinStrVal:
+    return std::string("|BIN:")
+        .append((const char*)value->value.str)
+        .append("\n");
+  case vpiHexStrVal:
+    return std::string("|HEX:")
+        .append((const char*)value->value.str)
+        .append("\n");
+  case vpiOctStrVal:
+    return std::string("|OCT:")
+        .append((const char*)value->value.str)
+        .append("\n");
+  case vpiRealVal:
+    return std::string("|REAL:")
+        .append(std::to_string(value->value.real))
+        .append("\n");
+  case vpiScalarVal:
+    return std::string("|SCAL:")
+        .append(std::to_string(value->value.scalar))
+        .append("\n");
+  case vpiDecStrVal:
+    return std::string("|DEC:")
+        .append((const char*)value->value.str)
+        .append("\n");
   }
   return "";
 }
@@ -474,12 +469,8 @@ static std::string visit_delays(s_vpi_delay* delay) {
   if (delay == nullptr)
     return "";
   switch (delay->time_type) {
-  case vpiScaledRealTime: {
-    return std::string(std::string("|#") + std::to_string(delay->da[0].low) + "\n");
-    break;
-  }
-  default:
-    break;
+  case vpiScaledRealTime:
+    return std::string("|#").append(std::to_string(delay->da[0].low)).append("\n");
   }
   return "";
 }
@@ -489,18 +480,17 @@ static std::ostream &stream_indent(std::ostream &out, int indent) {
   return out;
 }
 
-void visit_object (vpiHandle obj_h, int indent, const char *relation, VisitedContainer* visited, std::ostream& out, bool shallowVisit) {
+<PRIVATE_OBJECT_VISITORS>
+void visit_object(vpiHandle obj_h, int indent, const char *relation, VisitedContainer* visited, std::ostream& out, bool shallowVisit) {
   if (!obj_h)
     return;
 #ifdef STANDARD_VPI
 
-  static int kLevelIndent = 2;
   const bool alreadyVisited = visited->find(obj_h) != visited->end();
   visited->insert(obj_h);
 
 #else
 
-  static constexpr int kLevelIndent = 2;
   const uhdm_handle* const handle = (const uhdm_handle*) obj_h;
   const BaseClass* const object = (const BaseClass*) handle->object;
   const bool alreadyVisited = (visited->find(object) != visited->end());
@@ -516,11 +506,9 @@ void visit_object (vpiHandle obj_h, int indent, const char *relation, VisitedCon
     std::string hspaces;
     std::string rspaces;
     if (indent >= kLevelIndent) {
-      for (int i = 0; i < indent -2 ; i++) {
-        hspaces += " ";
-      }
-      rspaces = hspaces + "|";
-      hspaces += "\\_";
+      hspaces = std::string(indent - 2, ' ');
+      rspaces.assign(hspaces).append("|");
+      hspaces.append("\\_");
     }
 
     if (strlen(relation) != 0) {
@@ -608,7 +596,6 @@ void visit_object (vpiHandle obj_h, int indent, const char *relation, VisitedCon
   if (strcmp(relation, "vpiParent") == 0) {
     return;
   }
-  vpiHandle itr;
 <OBJECT_VISITORS>
 }
 
@@ -632,13 +619,11 @@ void vpi_show_ids(bool show) {
   showIDs = show;
 }
 
-static std::stringstream the_output;
-
 extern "C" {
   void vpi_decompiler (vpiHandle design) {
     std::vector<vpiHandle> designs;
     designs.push_back(design);
-    UHDM::visit_designs(designs, the_output);
-    std::cout << the_output.str().c_str() << std::endl;
+    UHDM::visit_designs(designs, std::cout);
+    std::cout << std::endl;
   }
 }

--- a/tests/vpi_listener_test.cpp
+++ b/tests/vpi_listener_test.cpp
@@ -119,11 +119,20 @@ TEST(VpiListenerTest, ProgramModule) {
 
   std::unique_ptr<MyVpiListener> listener(new MyVpiListener());
   listen_designs(design, listener.get());
+#if PYGEN_ENABLED
+  const std::vector<std::string> expected = {
+      "Module: /M1 parent: design1",
+      "Program: /PR1 parent: -",
+      "Module: u1/M2 parent: -",
+      "Module: u2/M3 parent: -",
+  };
+#else
   const std::vector<std::string> expected = {
       "Module: /M1 parent: design1",
       "Module: u1/M2 parent: -",
       "Module: u2/M3 parent: -",
       "Program: /PR1 parent: -",
   };
+#endif
   EXPECT_EQ(listener->collected(), expected);
 }


### PR DESCRIPTION
Modularization PAss 2

Take model class hierarchy into account when generating code for
vpi_listener, vpi_user and vpi_visitor. Also, the order of
listen/visit callbacks are in the same order as the model's
definition.

NOTE: This implementation changes the order of member processing.
Previous implementation used to visit/listen member of the most
concrete class before doing it for base. This implementation does
it in reverse i.e. the base classes are processed before the most
derived class.