### PR TITLE
Fixing allocation life-time issues

### DIFF
--- a/templates/BaseClass.h
+++ b/templates/BaseClass.h
@@ -228,6 +228,9 @@ namespace UHDM {
       objects_t objects_;
   };
 
+  typedef FactoryT<std::vector<BaseClass*>> VectorOfBaseClassFactory;
+  typedef FactoryT<std::vector<BaseClass*>> VectorOfanyFactory;
+
 }  // namespace UHDM
 
 UHDM_IMPLEMENT_RTTI_CAST_FUNCTIONS(any_cast, UHDM::BaseClass)

--- a/templates/Serializer.cpp
+++ b/templates/Serializer.cpp
@@ -91,6 +91,9 @@ std::map<std::string, unsigned long> Serializer::ObjectStats() const {
 
 void Serializer::Purge() {
   allIds_.clear();
+  anyVectMaker.Purge();
+  symbolMaker.Purge();
+  uhdm_handleMaker.Purge();
 <FACTORY_PURGE>
 }
 }  // namespace UHDM

--- a/templates/SymbolFactory.cpp
+++ b/templates/SymbolFactory.cpp
@@ -47,4 +47,10 @@ SymbolFactory::ID SymbolFactory::GetId(const std::string& symbol) const {
   return (found == symbol2IdMap_.end()) ? kBadId : found->second;
 }
 
+void SymbolFactory::Purge() {
+  Symbol2IdMap().swap(symbol2IdMap_);
+  Id2SymbolMap().swap(id2SymbolMap_);
+  idCounter_ = 0;
+}
+
 }  // namespace UHDM

--- a/templates/SymbolFactory.h
+++ b/templates/SymbolFactory.h
@@ -55,26 +55,15 @@ public:
   // Get symbol string identified by given ID or 0 (zero) if it doesn't exist
   ID GetId(const std::string& symbol) const;
 
+  // Remove all symbols
+  void Purge();
+
 private:
   ID idCounter_ = 0;
   Id2SymbolMap id2SymbolMap_;
   Symbol2IdMap symbol2IdMap_;
 };
 
-class VectorOfanyFactory {
-  friend Serializer;
-
-public:
-  std::vector<UHDM::any*>* Make() {
-    std::vector<UHDM::any*>* obj = new std::vector<UHDM::any*>();
-    objects_.push_back(obj);
-    return obj;
-  }
-
-private:
-  std::vector<std::vector<UHDM::any*>*> objects_;
-};
-
-};
+} // namespace UHDM
 
 #endif

--- a/templates/vpi_uhdm.h
+++ b/templates/vpi_uhdm.h
@@ -47,14 +47,18 @@ struct uhdm_handle {
 
 class uhdm_handleFactory {
   friend UHDM::Serializer;
-  public:
+
+ public:
   vpiHandle Make(UHDM::UHDM_OBJECT_TYPE type, const void* object) {
-    uhdm_handle* obj = new uhdm_handle(type, object);
-    objects_.push_back(obj);
-    return (vpiHandle) obj;
+    return (vpiHandle) new uhdm_handle(type, object);
   }
-  private:
-    std::vector<uhdm_handle*> objects_;
+
+  bool Erase(vpiHandle handle) {
+    delete (uhdm_handle*)handle;
+    return true;
+  }
+
+  void Purge() {}
 };
 
 /** Obtain a vpiHandle from a BaseClass (any) object */


### PR DESCRIPTION
Fixing allocation life-time issues
* Serializer::symbolMaker was never getting purged between Save &
  Restore. This is _not_ a leak, per se, but the recorded amount of
  memory used is significantly higher.
* uhdm_handle allocations are mismanaged. They could be allocated by
  Serializer::uhdm_handleMaker, and be recorded as part of it in a
  vector but this vector never gets emptied. The created instance are
  deleted using vp_release_handle. Current solution (stop tracking as
  part of the factory) is not optimal but fixes the consistently
  growing vector issue.
* Serializer::anyVectMaker was never getting emptied as part of
  Serializer::Purge call.