### PR TITLE
Upgrade VS2019 to VS2022

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,7 +195,7 @@ jobs:
 
     - name: Build & Test
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
 
         set CC=cl
         set CXX=cl


### PR DESCRIPTION
windows-latest on GHA now defaults to Window Server 2022 and doesn't have VS2019 preinstalled.