### PR TITLE
chipsalliance/Surelog#2540: Fixing windows build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,7 @@ jobs:
 
   msys2-gcc:
     name: msys2-gcc
-    runs-on: windows-latest
+    runs-on: windows-2022
     defaults:
       run:
         shell: msys2 {0}
@@ -169,7 +169,7 @@ jobs:
 
   windows-msvc:
     name: windows-cl
-    runs-on: windows-latest
+    runs-on: windows-2022
     defaults:
       run:
         shell: cmd
@@ -195,7 +195,7 @@ jobs:
 
     - name: Build & Test
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
 
         set CC=cl
         set CXX=cl


### PR DESCRIPTION
Issue: https://github.com/chipsalliance/Surelog/issues/2540

VS installation moved from "Program Files (x86)" to "Program Files"
Also, force use of 2022 server until the migration is officially
completed.

Consider this a temporary solution until the migration completes
on March 6th 2022.