### PR TITLE
Issue chipsalliance/UHDM#628: Reduce library size & improve build times

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,7 @@ jobs:
 
   msys2-gcc:
     name: msys2-gcc
-    runs-on: windows-latest
+    runs-on: windows-2022
     defaults:
       run:
         shell: msys2 {0}
@@ -169,7 +169,7 @@ jobs:
 
   windows-msvc:
     name: windows-cl
-    runs-on: windows-latest
+    runs-on: windows-2022
     defaults:
       run:
         shell: cmd
@@ -195,7 +195,7 @@ jobs:
 
     - name: Build & Test
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
 
         set CC=cl
         set CXX=cl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,12 +126,16 @@ set(uhdm-GENERATED_SRC
     ${GENDIR}/src/vpi_visitor.cpp
 )
 
-file(STRINGS "${PROJECT_SOURCE_DIR}/model/models.lst" LIST_OF_MODELS)
-foreach(MODEL_FILENAME ${LIST_OF_MODELS})
-  get_filename_component(MODEL_NAME ${MODEL_FILENAME} NAME_WE)
-  list(APPEND uhdm-GENERATED_SRC "${GENDIR}/src/${MODEL_NAME}.cpp")
-endforeach()
+# Apparently, compiling each file individually generates a huge
+# library file that is hard to work with. Use bulk-build as a workaround.
+#
+# file(STRINGS "${PROJECT_SOURCE_DIR}/model/models.lst" LIST_OF_MODELS)
+# foreach(MODEL_FILENAME ${LIST_OF_MODELS})
+#   get_filename_component(MODEL_NAME ${MODEL_FILENAME} NAME_WE)
+#   list(APPEND uhdm-GENERATED_SRC "${GENDIR}/src/${MODEL_NAME}.cpp")
+# endforeach()
 
+list(APPEND uhdm-GENERATED_SRC "${GENDIR}/src/classes.cpp")
 foreach(src_file ${uhdm-GENERATED_SRC})
   set_source_files_properties(${src_file} PROPERTIES GENERATED TRUE)
 endforeach(src_file ${uhdm-GENERATED_SRC})

--- a/scripts/capnp.py
+++ b/scripts/capnp.py
@@ -46,15 +46,6 @@ def generate(models):
         Classname = Classname_.replace('_', '')
 
         if modeltype != 'class_def':
-            individual_model_schemas[classname].append(('uhdmId', 'UInt64'))
-            individual_model_schemas[classname].append(('vpiParent', 'UInt64'))
-            individual_model_schemas[classname].append(('uhdmParentType', 'UInt64'))
-            individual_model_schemas[classname].append(('vpiFile', 'UInt64'))
-            individual_model_schemas[classname].append(('vpiLineNo', 'UInt32'))
-            individual_model_schemas[classname].append(('vpiEndLineNo', 'UInt32'))
-            individual_model_schemas[classname].append(('vpiColumnNo', 'UInt16'))
-            individual_model_schemas[classname].append(('vpiEndColumnNo', 'UInt16'))
-
             root_schema.append(f'  factory{Classname} @{root_schema_index} :List({Classname});')
             root_schema_index += 1
 
@@ -83,12 +74,20 @@ def generate(models):
             # Process the hierarchy tree top-down
             stack = []
             baseclass = classname
-            while (baseclass):
+            while baseclass:
                 stack.append(baseclass)
                 baseclass = models[baseclass]['extends']
 
-            capnpIndex = 0
             flattened_model_schemas.append(f'struct {Classname} {{')
+            flattened_model_schemas.append(f'  uhdmId @0 :UInt64;')
+            flattened_model_schemas.append(f'  vpiParent @1 :UInt64;')
+            flattened_model_schemas.append(f'  uhdmParentType @2 :UInt64;')
+            flattened_model_schemas.append(f'  vpiFile @3 :UInt64;')
+            flattened_model_schemas.append(f'  vpiLineNo @4 :UInt32;')
+            flattened_model_schemas.append(f'  vpiEndLineNo @5 :UInt32;')
+            flattened_model_schemas.append(f'  vpiColumnNo @6 :UInt16;')
+            flattened_model_schemas.append(f'  vpiEndColumnNo @7 :UInt16;')
+            capnpIndex = 8
 
             while stack:
                 for name, type in individual_model_schemas[stack.pop()]:

--- a/scripts/serializer.py
+++ b/scripts/serializer.py
@@ -6,8 +6,9 @@ import uhdm_types_h
 
 
 def generate(models):
-    factory_declarations = []
-    factory_methods = []
+    factory_data_members = []
+    factory_function_declarations = []
+    factory_function_implementations = []
     factory_purge = []
     factory_stats = []
     factory_object_type_map = []
@@ -34,8 +35,9 @@ def generate(models):
         baseclass = model.get('extends', 'BaseClass') or 'BaseClass'
 
         if modeltype != 'class_def':
-            factory_declarations.append(f'    {classname}Factory {classname}Maker;')
-            factory_methods.append(f'    {classname}* Make{Classname_}() {{ return Make<{classname}>(&{classname}Maker); }}')
+            factory_data_members.append(f'  {classname}Factory {classname}Maker;')
+            factory_function_declarations.append(f'  {classname}* Make{Classname_}();')
+            factory_function_implementations.append(f'{classname}* Serializer::Make{Classname_}() {{ return Make<{classname}>(&{classname}Maker); }}')
             factory_object_type_map.append(f'  case uhdm{classname} /* = {type_map["uhdm" + classname]} */: return {classname}Maker.objects_[index];')
 
             save_ids.append(f'  SetSaveId_(&{classname}Maker);')
@@ -47,8 +49,9 @@ def generate(models):
             factory_purge.append(f'  {classname}Maker.Purge();')
             factory_stats.append(f'  stats.insert(std::make_pair("{classname}", {classname}Maker.objects_.size()));')
 
-        factory_declarations.append(f'    VectorOf{classname}Factory {classname}VectMaker;')
-        factory_methods.append(f'    std::vector<{classname}*>* Make{Classname_}Vec() {{ return Make<{classname}>(&{classname}VectMaker); }}')
+        factory_data_members.append(f'  VectorOf{classname}Factory {classname}VectMaker;')
+        factory_function_declarations.append(f'  std::vector<{classname}*>* Make{Classname_}Vec();')
+        factory_function_implementations.append(f'std::vector<{classname}*>* Serializer::Make{Classname_}Vec() {{ return Make<{classname}>(&{classname}VectMaker); }}')
 
         saves_adapters.append(f'template<typename U>')
         saves_adapters.append(f'struct Serializer::AnySaveAdapter<{classname}, U> {{')
@@ -125,20 +128,21 @@ def generate(models):
                     saves_adapters.append(f'      ::capnp::List<{obj_key}>::Builder {Name}s = builder.init{Name}(obj->{Name_}()->size());')
                     saves_adapters.append(f'      for (unsigned int i = 0, n = obj->{Name_}()->size(); i < n; ++i) {{')
 
-                    restore_adapters.append(f'    if (reader.get{Name}().size() > 0) {{')
+                    restore_adapters.append(f'    if (unsigned int n = reader.get{Name}().size()) {{')
                     restore_adapters.append(f'      std::vector<{type}*>* vect = serializer->{type}VectMaker.Make();')
-                    restore_adapters.append(f'      for (unsigned int i = 0, n = reader.get{Name}().size(); i < n; ++i) {{')
+                    restore_adapters.append(f'      vect->reserve(n);')
+                    restore_adapters.append(f'      for (unsigned int i = 0; i < n; ++i) {{')
 
                     if key in ['class_ref', 'group_ref']:
                         saves_adapters.append(f'        ::ObjIndexType::Builder tmp = {Name}s[i];')
                         saves_adapters.append(f'        tmp.setIndex(serializer->GetId((*obj->{Name_}())[i]));')
                         saves_adapters.append(f'        tmp.setType(((BaseClass*)((*obj->{Name_}())[i]))->UhdmType());')
 
-                        restore_adapters.append(f'        vect->push_back(({type}*)serializer->GetObject(reader.get{Name}()[i].getType(), reader.get{Name}()[i].getIndex() - 1));')
+                        restore_adapters.append(f'        vect->emplace_back(({type}*)serializer->GetObject(reader.get{Name}()[i].getType(), reader.get{Name}()[i].getIndex() - 1));')
                     else:
                         saves_adapters.append(f'        {Name}s.set(i, serializer->GetId((*obj->{Name_}())[i]));')
 
-                        restore_adapters.append(f'        vect->push_back(serializer->{type}Maker.objects_[reader.get{Name}()[i] - 1]);')
+                        restore_adapters.append(f'        vect->emplace_back(serializer->{type}Maker.objects_[reader.get{Name}()[i] - 1]);')
 
                     saves_adapters.append('      }')
                     saves_adapters.append('    }')
@@ -161,22 +165,21 @@ def generate(models):
     ]
     uhdm_name_map.extend([ f'  case {name} /* = {id} */: return "{name[4:]}";' for name, id in uhdm_types_h.get_type_map(models).items() ])
     uhdm_name_map.append('  default: return "NO TYPE";')
-    uhdm_name_map.append('}')
+    uhdm_name_map.append('  }')
     uhdm_name_map.append('}')
 
     # Serializer.h
     with open(config.get_template_filepath('Serializer.h'), 'rt') as strm:
         file_content = strm.read()
 
-    file_content = file_content.replace('<FACTORIES>', '\n'.join(factory_declarations))
-    file_content = file_content.replace('<FACTORIES_METHODS>', '\n'.join(factory_methods))
+    file_content = file_content.replace('<FACTORY_DATA_MEMBERS>', '\n'.join(factory_data_members))
+    file_content = file_content.replace('<FACTORY_FUNCTION_DECLARATIONS>', '\n'.join(factory_function_declarations))
     file_utils.set_content_if_changed(config.get_output_header_filepath('Serializer.h'), file_content)
 
     # Serializer.cpp
     with open(config.get_template_filepath('Serializer.cpp'), 'rt') as strm:
         file_content = strm.read()
 
-    file_content = file_content.replace('<METHODS_CPP>', '') # Deprecated
     file_content = file_content.replace('<UHDM_NAME_MAP>', '\n'.join(uhdm_name_map))
     file_content = file_content.replace('<FACTORY_PURGE>', '\n'.join(factory_purge))
     file_content = file_content.replace('<FACTORY_STATS>', '\n'.join(factory_stats))
@@ -199,6 +202,7 @@ def generate(models):
     file_content = file_content.replace('<CAPNP_INIT_FACTORIES>', '\n'.join(restore_ids))
     file_content = file_content.replace('<CAPNP_RESTORE_FACTORIES>', '\n'.join(restore_objects))
     file_content = file_content.replace('<CAPNP_RESTORE_ADAPTERS>', '\n'.join(restore_adapters))
+    file_content = file_content.replace('<FACTORY_FUNCTION_IMPLEMENTATIONS>', '\n'.join(factory_function_implementations))
     file_utils.set_content_if_changed(config.get_output_source_filepath('Serializer_restore.cpp'), file_content)
 
     return True

--- a/scripts/uhdm_forward_decl_h.py
+++ b/scripts/uhdm_forward_decl_h.py
@@ -3,13 +3,26 @@ import file_utils
 
 
 def generate(models):
-    classnames = [ model['name'] for model in models.values() if model['type'] != 'group_def' ]
-    declarations = '\n'.join([f'class {classname};' for classname in sorted(classnames) if classname != 'BaseClass'])
+    class_declarations = []
+    factory_declarations = []
+    container_factory_declarations = []
+    for model in models.values():
+        model_type = model['type']
+        classname = model['name']
+
+        if model_type != 'group_def' and classname != 'BaseClass':
+            class_declarations.append(f'class {classname};')
+            container_factory_declarations.append(f'typedef FactoryT<std::vector<{classname} *>> VectorOf{classname}Factory;')
+
+            if model_type != 'class_def':
+                factory_declarations.append(f'typedef FactoryT<{classname}> {classname}Factory;')
 
     with open(config.get_template_filepath('uhdm_forward_decl.h'), 'rt') as strm:
         file_content = strm.read()
 
-    file_content = file_content.replace('<UHDM_FORWARD_DECL>', declarations)
+    file_content = file_content.replace('<UHDM_CLASSES_FORWARD_DECL>', '\n'.join(sorted(class_declarations)))
+    file_content = file_content.replace('<UHDM_FACTORIES_FORWARD_DECL>', '\n'.join(sorted(factory_declarations)))
+    file_content = file_content.replace('<UHDM_CONTAINER_FACTORIES_FORWARD_DECL>', '\n'.join(sorted(container_factory_declarations)))
     file_utils.set_content_if_changed(config.get_output_header_filepath('uhdm_forward_decl.h'), file_content)
     return True
 

--- a/templates/ElaboratorListener.cpp
+++ b/templates/ElaboratorListener.cpp
@@ -25,10 +25,12 @@
  */
 
 #include <uhdm/ElaboratorListener.h>
+
+#include <iostream>
+
 #include <uhdm/clone_tree.h>
 #include <uhdm/uhdm.h>
 
-// #include <uhdm/Serializer.h>
 
 namespace UHDM {
 

--- a/templates/ElaboratorListener.h
+++ b/templates/ElaboratorListener.h
@@ -24,9 +24,10 @@
  * Created on May 6, 2020, 10:03 PM
  */
 
+#ifndef UHDM_ELABORATORLISTENER_H
+#define UHDM_ELABORATORLISTENER_H
+
 #include <map>
-#include <stack>
-#include <iostream>
 
 #include <uhdm/VpiListener.h>
 
@@ -128,3 +129,5 @@ protected:
 };
 
 };
+
+#endif  // UHDM_ELABORATORLISTENER_H

--- a/templates/Serializer.cpp
+++ b/templates/Serializer.cpp
@@ -29,9 +29,7 @@
 #include <string>
 #include <vector>
 
-#include <uhdm/containers.h>
 #include <uhdm/uhdm.h>
-#include <uhdm/uhdm_types.h>
 
 #if defined(_MSC_VER)
   #pragma warning(push)
@@ -40,8 +38,8 @@
 
 namespace UHDM {
 
-void DefaultErrorHandler(ErrorType errType, const std::string& errorMsg, const any* object1, const any* object2) { 
-  std::cout << errorMsg << std::endl; 
+void DefaultErrorHandler(ErrorType errType, const std::string& errorMsg, const any* object1, const any* object2) {
+  std::cerr << errorMsg << std::endl;
 }
 
 void Serializer::SetId(const BaseClass* p, unsigned long id) {
@@ -68,8 +66,6 @@ std::string VpiTypeName(vpiHandle h) {
   BaseClass* obj = (BaseClass*) handle->object;
   return UhdmName(obj->UhdmType());
 }
-
-<METHODS_CPP>
 
 static constexpr unsigned int badIndex = -1;
 

--- a/templates/Serializer.h
+++ b/templates/Serializer.h
@@ -27,13 +27,17 @@
 #ifndef UHDM_SERIALIZER_H
 #define UHDM_SERIALIZER_H
 
+
+#include <functional>
+#include <iostream>
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
-#include <iostream>
-#include <functional>
-#include <uhdm/uhdm.h>
+#include <uhdm/containers.h>
+#include <uhdm/vpi_uhdm.h>
+#include <uhdm/SymbolFactory.h>
+
 
 namespace UHDM {
 enum ErrorType {
@@ -70,25 +74,16 @@ class Serializer {
   std::map<std::string, unsigned long> ObjectStats() const;
 
  private:
-  template <typename T, typename = typename std::enable_if<
-                            std::is_base_of<BaseClass, T>::value>::type>
-  T* Make(FactoryT<T>* const factory) {
-    T* const obj = factory->Make();
-    obj->SetSerializer(this);
-    obj->UhdmId(objId_++);
-    return obj;
-  }
+  template <typename T>
+  T* Make(FactoryT<T>* const factory);
 
-  template <typename T, typename = typename std::enable_if<
-                            std::is_base_of<BaseClass, T>::value>::type>
-  std::vector<T*>* Make(FactoryT<std::vector<T*>>* const factory) {
-    return factory->Make();
-  }
+  template <typename T>
+  std::vector<T*>* Make(FactoryT<std::vector<T*>>* const factory);
 
  public:
-  <FACTORIES_METHODS> std::vector<any*>* MakeAnyVec() {
-    return anyVectMaker.Make();
-  }
+<FACTORY_FUNCTION_DECLARATIONS>
+  std::vector<any*>* MakeAnyVec() { return anyVectMaker.Make(); }
+
   vpiHandle MakeUhdmHandle(UHDM_OBJECT_TYPE type, const void* object) {
     return uhdm_handleMaker.Make(type, object);
   }
@@ -96,9 +91,9 @@ class Serializer {
   VectorOfanyFactory anyVectMaker;
   SymbolFactory symbolMaker;
   uhdm_handleFactory uhdm_handleMaker;
-  <FACTORIES>
+<FACTORY_DATA_MEMBERS>
 
-      std::unordered_map<const BaseClass*, unsigned long>& AllObjects() {
+  std::unordered_map<const BaseClass*, unsigned long>& AllObjects() {
     return allIds_;
   }
 

--- a/templates/Serializer_restore.cpp
+++ b/templates/Serializer_restore.cpp
@@ -48,12 +48,26 @@
 #include <capnp/serialize-packed.h>
 
 #include "UHDM.capnp.h"
-#include <uhdm/containers.h>
 #include <uhdm/uhdm.h>
-#include <uhdm/uhdm_types.h>
 
 
 namespace UHDM {
+template <typename T>
+inline T* Serializer::Make(FactoryT<T>* const factory) {
+  T* const obj = factory->Make();
+  obj->SetSerializer(this);
+  obj->UhdmId(objId_++);
+  return obj;
+}
+
+template <typename T>
+inline std::vector<T*>* Serializer::Make(
+    FactoryT<std::vector<T*>>* const factory) {
+  return factory->Make();
+}
+
+<FACTORY_FUNCTION_IMPLEMENTATIONS>
+
 template<typename T, typename>
 void Serializer::SetRestoreId_(FactoryT<T>* const factory, unsigned long count) {
   for (unsigned int i = 0; i < count; ++i) {

--- a/templates/VpiListener.h
+++ b/templates/VpiListener.h
@@ -24,8 +24,8 @@
  * Created on December 14, 2019, 10:03 PM
  */
 
-#ifndef UHDM_VPILISTENER_CLASS_H
-#define UHDM_VPILISTENER_CLASS_H
+#ifndef UHDM_VPILISTENER_H
+#define UHDM_VPILISTENER_H
 
 #include <uhdm/uhdm_forward_decl.h>
 #include <uhdm/vpi_user.h>
@@ -36,7 +36,7 @@ public:
   // Use implicit constructor to initialize all members
   // VpiListener()
 
-  virtual ~VpiListener() {}
+  virtual ~VpiListener() = default;
 
 <VPI_LISTENER_METHODS>
 };

--- a/templates/VpiListenerTracer.h
+++ b/templates/VpiListenerTracer.h
@@ -24,8 +24,8 @@
  * Created on October 11, 2020, 9:00 PM
  */
 
-#ifndef UHDM_VPILISTENERTRACER_CLASS_H
-#define UHDM_VPILISTENERTRACER_CLASS_H
+#ifndef UHDM_VPILISTENERTRACER_H
+#define UHDM_VPILISTENERTRACER_H
 
 #include "VpiListener.h"
 

--- a/templates/class_source.cpp
+++ b/templates/class_source.cpp
@@ -24,8 +24,9 @@
  */
 
 #include <uhdm/<CLASSNAME>.h>
-#include <uhdm/ElaboratorListener.h>
-#include <uhdm/Serializer.h>
+
+<INCLUDES>
+
 
 namespace UHDM {
 <METHODS>

--- a/templates/clone_tree.h
+++ b/templates/clone_tree.h
@@ -25,9 +25,6 @@
 #ifndef UHDM_CLONE_TREE_H
 #define UHDM_CLONE_TREE_H
 
-#include <string>
-#include <vector>
-
 #include <uhdm/sv_vpi_user.h>
 
 namespace UHDM {

--- a/templates/containers.h
+++ b/templates/containers.h
@@ -27,7 +27,6 @@
 #define UHDM_CONTAINERS_H
 
 #include <vector>
-#include <unordered_map>
 #include <uhdm/uhdm_forward_decl.h>
 
 namespace UHDM {

--- a/templates/group_header.h
+++ b/templates/group_header.h
@@ -26,7 +26,7 @@
 #ifndef UHDM_<UPPER_GROUPNAME>_H
 #define UHDM_<UPPER_GROUPNAME>_H
 
-#include <uhdm/uhdm_forward_decl.h>
+#include <uhdm/containers.h>
 
 namespace UHDM {
 

--- a/templates/uhdm_forward_decl.h
+++ b/templates/uhdm_forward_decl.h
@@ -24,16 +24,23 @@
  * Created on May 06, 2020, 10:03 PM
  */
 
-#ifndef UHDM_FORWARD_DECL_CLASS_H
-#define UHDM_FORWARD_DECL_CLASS_H
+#ifndef UHDM_FORWARD_DECL_H
+#define UHDM_FORWARD_DECL_H
 
 #include <vector>
+
+#include <uhdm/BaseClass.h>
 
 namespace UHDM {
 class BaseClass;
 typedef BaseClass any;
-typedef std::vector<BaseClass*> VectorOfany;
-<UHDM_FORWARD_DECL>
+
+<UHDM_CLASSES_FORWARD_DECL>
+
+<UHDM_FACTORIES_FORWARD_DECL>
+
+typedef FactoryT<std::vector<BaseClass*>> VectorOfanyFactory;
+<UHDM_CONTAINER_FACTORIES_FORWARD_DECL>
 };
 
 

--- a/templates/vpi_uhdm.h
+++ b/templates/vpi_uhdm.h
@@ -27,9 +27,6 @@
 #ifndef VPI_UHDM_H
 #define VPI_UHDM_H
 
-#include <unordered_map>
-#include <vector>
-
 #include <uhdm/uhdm_types.h>
 
 namespace UHDM {

--- a/templates/vpi_visitor.h
+++ b/templates/vpi_visitor.h
@@ -23,6 +23,9 @@
  * Created on December 14, 2019, 10:03 PM
  */
 
+#ifndef UHDM_VPI_VISITOR_H
+#define UHDM_VPI_VISITOR_H
+
 #include <string>
 #include <vector>
 #include <set>
@@ -31,9 +34,6 @@
 
 #include <uhdm/BaseClass.h>
 #include <uhdm/uhdm_forward_decl.h>
-
-#ifndef UHDM_VPI_VISITOR_H
-#define UHDM_VPI_VISITOR_H
 
 namespace UHDM {
 


### PR DESCRIPTION
Issue chipsalliance/UHDM#628: Reduce library size & improve build times

* Removed uhdm.h include from headers
* Moved functions in Serializer header to implementation to avoid having to
  incldue uhdm.h
* Forward declare factories in uhdm_forward_decl.h
* Fixed an issue in capnp where fields weren't getting assigned the same id
  in the hierarchy
* Model classes now include the necessary headers instead of uhdm.h
* Removed unnecessary includes in header files
* Created a new file classes.cpp that includes all model class implementation
  files

Size down from 3.4GB to 210MB
```
-rw-r--r-- 1 runner docker   2434734 Feb 10 10:46 libgmockd.a
-rw-r--r-- 1 runner docker    514148 Feb 10 10:46 libgtest_maind.a
-rw-r--r-- 1 runner docker   5446672 Feb 10 10:46 libgtestd.a
-rw-r--r-- 1 runner docker 210474354 Feb 10 10:48 libuhdm.a
```