### PR TITLE
Improve install experience: system provide all the Python depdendencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,17 +13,11 @@ jobs:
         shell: bash
 
     steps:
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        architecture: x64
-
     - name: Install dependencies
       run: |
         sudo apt-get update -qq
-        sudo apt install -y g++-9 build-essential cmake
-
-        python -m pip install orderedmultidict
+        sudo apt install -y g++-9 build-essential cmake \
+                            python3 python3-orderedmultidict
 
     - name: Git pull
       uses: actions/checkout@v2

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,17 +3,13 @@
 
 ### Library uhdm.a
 
-
 ### Development Environment Required:
 
 * Linux (Ubuntu or Centos) or Windows, cmake 3.15 and GCC/VS supporting c++17
 
 * Please install the following package updates:
 
-   * sudo apt-get install build-essential cmake git tclsh
-
-* To generate the code, we need python orderedmultidict
-   * pip3 install orderedmultidict
+   * sudo apt-get install build-essential cmake git python3 python3-orderedmultidict
 
 * UHDM Source code
   * git clone https://github.com/alainmarcel/UHDM.git


### PR DESCRIPTION
This better documents what needs to be done. However, we it still would
be good to have a check in cmake to make sure that the orderedmultidict
is installed.

Signed-off-by: Henner Zeller <hzeller@google.com>