### PR TITLE
Reduce template specialization

### DIFF
--- a/templates/Serializer.h
+++ b/templates/Serializer.h
@@ -107,33 +107,11 @@ class Serializer {
                             std::is_base_of<BaseClass, T>::value>::type>
   void SetRestoreId_(FactoryT<T>* const factory, unsigned long count);
 
-  template <typename T, typename U,
-            typename = typename std::enable_if<
-                std::is_base_of<BaseClass, T>::value>::type>
-  struct AnySaveAdapter {};
-  template <typename, typename, typename>
-  friend struct AnySaveAdapter;
+  struct SaveAdapter;
+  friend struct SaveAdapter;
 
-  template <typename T, typename U,
-            typename = typename std::enable_if<
-                std::is_base_of<BaseClass, T>::value>::type>
-  struct VectorOfanySaveAdapter {};
-  template <typename, typename, typename>
-  friend struct VectorOfanySaveAdapter;
-
-  template <typename T, typename U,
-            typename = typename std::enable_if<
-                std::is_base_of<BaseClass, T>::value>::type>
-  struct AnyRestoreAdapter {};
-  template <typename, typename, typename>
-  friend struct AnyRestoreAdapter;
-
-  template <typename T, typename U,
-            typename = typename std::enable_if<
-                std::is_base_of<BaseClass, T>::value>::type>
-  struct VectorOfanyRestoreAdapter {};
-  template <typename, typename, typename>
-  friend struct VectorOfanyRestoreAdapter;
+  struct RestoreAdapter;
+  friend struct RestoreAdapter;
 
  private:
   BaseClass* GetObject(unsigned int objectType, unsigned int index);


### PR DESCRIPTION
Rework serialization to reduce template specialization and thus reduce generated binary size.
For release builds, this change reduces the binary sizes by ~20%.

Instead of dumping every field in the capnp schema for each class, subclasses carry only a pointer to the base schema. Thus, a class, say `attribute`, always loads data from a schema named `Attribute` and so no template specialization is required.

@alaindargelas @hzeller This is only a prototype of the change and for either of you to play around with if you find this worthwhile. If the change passes any/all checks, then I can clean up and create a PR for merge.