### PR TITLE
Remove listen_/enter/leave for class_def

### DIFF
--- a/scripts/VpiListener_h.py
+++ b/scripts/VpiListener_h.py
@@ -5,12 +5,12 @@ import file_utils
 def get_methods(models, enter, leave):
     methods = []
     for model in models.values():
-        if model['type'] != 'group_def':
+        if model['type'] not in ['class_def', 'group_def']:
             classname = model['name']
             Classname_ = classname[:1].upper() + classname[1:]
 
-            methods.append(f'    virtual void enter{Classname_}(const {classname}* object, const BaseClass* parent, vpiHandle handle, vpiHandle parentHandle) {{{enter}}}')
-            methods.append(f'    virtual void leave{Classname_}(const {classname}* object, const BaseClass* parent, vpiHandle handle, vpiHandle parentHandle) {{{leave}}}')
+            methods.append(f'  virtual void enter{Classname_}(const {classname}* object, const BaseClass* parent, vpiHandle handle, vpiHandle parentHandle) {{{enter}}}')
+            methods.append(f'  virtual void leave{Classname_}(const {classname}* object, const BaseClass* parent, vpiHandle handle, vpiHandle parentHandle) {{{leave}}}')
             methods.append('')
 
     return methods

--- a/scripts/vpi_listener.py
+++ b/scripts/vpi_listener.py
@@ -52,13 +52,13 @@ def generate(models):
         classname = model['name']
         Classname_ = classname[:1].upper() + classname[1:]
 
+        baseclass = model.get('extends')
+
         if modeltype != 'class_def':
             classnames.add(classname)
 
-        baseclass = model.get('extends')
-
-        declarations.append(f'void listen_{classname}(vpiHandle handle, VpiListener* listener);')
-        declarations.append(f'void listen_{classname}(vpiHandle handle, VpiListener* listener, VisitedContainer* visited);')
+            declarations.append(f'void listen_{classname}(vpiHandle handle, VpiListener* listener);')
+            declarations.append(f'void listen_{classname}(vpiHandle handle, VpiListener* listener, VisitedContainer* visited);')
 
         private_implementations.append(f'static void listen_{classname}_(const {classname}* object, const BaseClass* parent, vpiHandle handle, vpiHandle parentHandle, VpiListener* listener, VisitedContainer* visited) {{')
         if baseclass:
@@ -78,23 +78,24 @@ def generate(models):
         private_implementations.append( '}')
         private_implementations.append( '')
 
-        public_implementations.append(f'void UHDM::listen_{classname}(vpiHandle handle, VpiListener* listener, VisitedContainer* visited) {{')
-        public_implementations.append(f'  const {classname}* object = (const {classname}*) ((const uhdm_handle*)handle)->object;')
-        public_implementations.append( '  const BaseClass* parent = object->VpiParent();')
-        public_implementations.append( '  vpiHandle parentHandle = (parent != nullptr) ? NewVpiHandle(parent) : nullptr;')
-        public_implementations.append(f'  listener->enter{Classname_}(object, parent, handle, parentHandle);')
-        public_implementations.append( '  if (visited->insert(object).second) {')
-        public_implementations.append(f'    listen_{classname}_(object, parent, handle, parentHandle, listener, visited);')
-        public_implementations.append( '  }')
-        public_implementations.append(f'  listener->leave{Classname_}(object, parent, handle, parentHandle);')
-        public_implementations.append( '  vpi_release_handle(parentHandle);')
-        public_implementations.append(f'}}')
-        public_implementations.append( '')
-        public_implementations.append(f'void UHDM::listen_{classname}(vpiHandle handle, VpiListener* listener) {{')
-        public_implementations.append( '  VisitedContainer visited;')
-        public_implementations.append(f'  listen_{classname}(handle, listener, &visited);')
-        public_implementations.append(f'}}')
-        public_implementations.append( '')
+        if modeltype != 'class_def':
+            public_implementations.append(f'void UHDM::listen_{classname}(vpiHandle handle, VpiListener* listener, VisitedContainer* visited) {{')
+            public_implementations.append(f'  const {classname}* object = (const {classname}*) ((const uhdm_handle*)handle)->object;')
+            public_implementations.append( '  const BaseClass* parent = object->VpiParent();')
+            public_implementations.append( '  vpiHandle parentHandle = (parent != nullptr) ? NewVpiHandle(parent) : nullptr;')
+            public_implementations.append(f'  listener->enter{Classname_}(object, parent, handle, parentHandle);')
+            public_implementations.append( '  if (visited->insert(object).second) {')
+            public_implementations.append(f'    listen_{classname}_(object, parent, handle, parentHandle, listener, visited);')
+            public_implementations.append( '  }')
+            public_implementations.append(f'  listener->leave{Classname_}(object, parent, handle, parentHandle);')
+            public_implementations.append( '  vpi_release_handle(parentHandle);')
+            public_implementations.append(f'}}')
+            public_implementations.append( '')
+            public_implementations.append(f'void UHDM::listen_{classname}(vpiHandle handle, VpiListener* listener) {{')
+            public_implementations.append( '  VisitedContainer visited;')
+            public_implementations.append(f'  listen_{classname}(handle, listener, &visited);')
+            public_implementations.append(f'}}')
+            public_implementations.append( '')
 
    # vpi_listener.h
     with open(config.get_template_filepath('vpi_listener.h'), 'rt') as strm:

--- a/templates/ElaboratorListener.cpp
+++ b/templates/ElaboratorListener.cpp
@@ -25,12 +25,10 @@
  */
 
 #include <uhdm/ElaboratorListener.h>
-
-#include <iostream>
-
 #include <uhdm/clone_tree.h>
 #include <uhdm/uhdm.h>
 
+#include <iostream>
 
 namespace UHDM {
 
@@ -513,10 +511,141 @@ void ElaboratorListener::enterVariables(const variables* object,
   }
 }
 
-void ElaboratorListener::leaveVariables(const variables* object,
+void ElaboratorListener::enterRef_var(const ref_var* object,
+                                      const BaseClass* parent, vpiHandle handle,
+                                      vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterShort_real_var(const short_real_var* object,
+                                             const BaseClass* parent,
+                                             vpiHandle handle,
+                                             vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterReal_var(const real_var* object,
+                                       const BaseClass* parent,
+                                       vpiHandle handle,
+                                       vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterByte_var(const byte_var* object,
+                                       const BaseClass* parent,
+                                       vpiHandle handle,
+                                       vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterShort_int_var(const short_int_var* object,
+                                            const BaseClass* parent,
+                                            vpiHandle handle,
+                                            vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterInt_var(const int_var* object,
+                                      const BaseClass* parent, vpiHandle handle,
+                                      vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterLong_int_var(const long_int_var* object,
+                                           const BaseClass* parent,
+                                           vpiHandle handle,
+                                           vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterInteger_var(const integer_var* object,
+                                          const BaseClass* parent,
+                                          vpiHandle handle,
+                                          vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterTime_var(const time_var* object,
+                                       const BaseClass* parent,
+                                       vpiHandle handle,
+                                       vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterArray_var(const array_var* object,
                                         const BaseClass* parent,
                                         vpiHandle handle,
-                                        vpiHandle parentHandle) {}
+                                        vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterPacked_array_var(const packed_array_var* object,
+                                               const BaseClass* parent,
+                                               vpiHandle handle,
+                                               vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterBit_var(const bit_var* object,
+                                      const BaseClass* parent, vpiHandle handle,
+                                      vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterLogic_var(const logic_var* object,
+                                        const BaseClass* parent,
+                                        vpiHandle handle,
+                                        vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterStruct_var(const struct_var* object,
+                                         const BaseClass* parent,
+                                         vpiHandle handle,
+                                         vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterUnion_var(const union_var* object,
+                                        const BaseClass* parent,
+                                        vpiHandle handle,
+                                        vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterEnum_var(const enum_var* object,
+                                       const BaseClass* parent,
+                                       vpiHandle handle,
+                                       vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterString_var(const string_var* object,
+                                         const BaseClass* parent,
+                                         vpiHandle handle,
+                                         vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterChandle_var(const chandle_var* object,
+                                          const BaseClass* parent,
+                                          vpiHandle handle,
+                                          vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterVar_bit(const var_bit* object,
+                                      const BaseClass* parent, vpiHandle handle,
+                                      vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterClass_var(const class_var* object,
+                                        const BaseClass* parent,
+                                        vpiHandle handle,
+                                        vpiHandle parentHandle) {
+  enterVariables(object, parent, handle, parentHandle);
+}
 
 void ElaboratorListener::enterTask_func(const task_func* object,
                                         const BaseClass* parent,
@@ -549,6 +678,30 @@ void ElaboratorListener::leaveTask_func(const task_func* object,
                                         vpiHandle handle,
                                         vpiHandle parentHandle) {
   instStack_.pop_back();
+}
+
+void ElaboratorListener::enterFunction(const function* object,
+                                       const BaseClass* parent,
+                                       vpiHandle handle,
+                                       vpiHandle parentHandle) {
+  enterTask_func(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::leaveFunction(const function* object,
+                                       const BaseClass* parent,
+                                       vpiHandle handle,
+                                       vpiHandle parentHandle) {
+  leaveTask_func(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::enterTask(const task* object, const BaseClass* parent,
+                                   vpiHandle handle, vpiHandle parentHandle) {
+  enterTask_func(object, parent, handle, parentHandle);
+}
+
+void ElaboratorListener::leaveTask(const task* object, const BaseClass* parent,
+                                   vpiHandle handle, vpiHandle parentHandle) {
+  leaveTask_func(object, parent, handle, parentHandle);
 }
 
 void ElaboratorListener::enterGen_scope(const gen_scope* object,
@@ -606,4 +759,4 @@ void ElaboratorListener::leaveRef_obj(const ref_obj* object,
     ((ref_obj*)object)->Actual_group(bindAny(object->VpiName()));
 }
 
-} // namespace UHDM
+}  // namespace UHDM

--- a/templates/ElaboratorListener.h
+++ b/templates/ElaboratorListener.h
@@ -27,10 +27,9 @@
 #ifndef UHDM_ELABORATORLISTENER_H
 #define UHDM_ELABORATORLISTENER_H
 
-#include <map>
-
 #include <uhdm/VpiListener.h>
 
+#include <map>
 
 namespace UHDM {
 
@@ -40,9 +39,10 @@ class ElaboratorListener : public VpiListener {
   friend function;
   friend task;
   friend gen_scope_array;
-public:
 
-  ElaboratorListener (Serializer* serializer, bool debug = false) : serializer_(serializer), debug_(debug) {}
+ public:
+  ElaboratorListener(Serializer* serializer, bool debug = false)
+      : serializer_(serializer), debug_(debug) {}
   void uniquifyTypespec(bool uniquify) { uniquifyTypespec_ = uniquify; }
   bool uniquifyTypespec() { return uniquifyTypespec_; }
   void bindOnly(bool bindOnly) { clone_ = !bindOnly; }
@@ -63,58 +63,129 @@ public:
   // Bind to a function or task in the current scope
   any* bindTaskFunc(const std::string& name, const class_var* prefix = nullptr);
 
-  void scheduleTaskFuncBinding(tf_call* clone) { scheduledTfCallBinding_.push_back(clone); }
+  void scheduleTaskFuncBinding(tf_call* clone) {
+    scheduledTfCallBinding_.push_back(clone);
+  }
 
-protected:
+ protected:
   typedef std::map<std::string, const BaseClass*> ComponentMap;
 
   void leaveDesign(const design* object, const BaseClass* parent,
-                   vpiHandle handle, vpiHandle parentHandle) override;
+                   vpiHandle handle, vpiHandle parentHandle) final;
 
   void enterModule(const module* object, const BaseClass* parent,
-                   vpiHandle handle, vpiHandle parentHandle) override;
+                   vpiHandle handle, vpiHandle parentHandle) final;
 
   void leaveModule(const module* object, const BaseClass* parent,
-                   vpiHandle handle, vpiHandle parentHandle) override;
+                   vpiHandle handle, vpiHandle parentHandle) final;
 
   void enterPackage(const package* object, const BaseClass* parent,
-                    vpiHandle handle, vpiHandle parentHandle) override;
+                    vpiHandle handle, vpiHandle parentHandle) final;
 
   void leavePackage(const package* object, const BaseClass* parent,
-                    vpiHandle handle, vpiHandle parentHandle) override;
+                    vpiHandle handle, vpiHandle parentHandle) final;
 
   void enterClass_defn(const class_defn* object, const BaseClass* parent,
-                       vpiHandle handle, vpiHandle parentHandle) override;
+                       vpiHandle handle, vpiHandle parentHandle) final;
 
   void leaveClass_defn(const class_defn* object, const BaseClass* parent,
-                       vpiHandle handle, vpiHandle parentHandle) override;
-
-  void enterVariables(const variables* object, const BaseClass* parent,
-                   vpiHandle handle, vpiHandle parentHandle) override;
-
-  void leaveVariables(const variables* object, const BaseClass* parent,
-                   vpiHandle handle, vpiHandle parentHandle) override;
-
-
-  void enterTask_func(const task_func* object, const BaseClass* parent,
-                      vpiHandle handle, vpiHandle parentHandle) override;
-
-  void leaveTask_func(const task_func* object, const BaseClass* parent,
-                      vpiHandle handle, vpiHandle parentHandle) override;
+                       vpiHandle handle, vpiHandle parentHandle) final;
 
   void enterGen_scope(const gen_scope* object, const BaseClass* parent,
-                      vpiHandle handle, vpiHandle parentHandle) override;
+                      vpiHandle handle, vpiHandle parentHandle) final;
 
   void leaveGen_scope(const gen_scope* object, const BaseClass* parent,
-                      vpiHandle handle, vpiHandle parentHandle) override;
+                      vpiHandle handle, vpiHandle parentHandle) final;
 
   void leaveRef_obj(const ref_obj* object, const BaseClass* parent,
-                    vpiHandle handle, vpiHandle parentHandle) override;
+                    vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterRef_var(const ref_var* object, const BaseClass* parent,
+                    vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterShort_real_var(const short_real_var* object,
+                           const BaseClass* parent, vpiHandle handle,
+                           vpiHandle parentHandle) final;
+
+  void enterReal_var(const real_var* object, const BaseClass* parent,
+                     vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterByte_var(const byte_var* object, const BaseClass* parent,
+                     vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterShort_int_var(const short_int_var* object, const BaseClass* parent,
+                          vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterInt_var(const int_var* object, const BaseClass* parent,
+                    vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterLong_int_var(const long_int_var* object, const BaseClass* parent,
+                         vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterInteger_var(const integer_var* object, const BaseClass* parent,
+                        vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterTime_var(const time_var* object, const BaseClass* parent,
+                     vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterArray_var(const array_var* object, const BaseClass* parent,
+                      vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterPacked_array_var(const packed_array_var* object,
+                             const BaseClass* parent, vpiHandle handle,
+                             vpiHandle parentHandle) final;
+
+  void enterBit_var(const bit_var* object, const BaseClass* parent,
+                    vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterLogic_var(const logic_var* object, const BaseClass* parent,
+                      vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterStruct_var(const struct_var* object, const BaseClass* parent,
+                       vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterUnion_var(const union_var* object, const BaseClass* parent,
+                      vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterEnum_var(const enum_var* object, const BaseClass* parent,
+                     vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterString_var(const string_var* object, const BaseClass* parent,
+                       vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterChandle_var(const chandle_var* object, const BaseClass* parent,
+                        vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterVar_bit(const var_bit* object, const BaseClass* parent,
+                  vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterClass_var(const class_var* object, const BaseClass* parent,
+                      vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterFunction(const function* object, const BaseClass* parent,
+                     vpiHandle handle, vpiHandle parentHandle) final;
+  void leaveFunction(const function* object, const BaseClass* parent,
+                     vpiHandle handle, vpiHandle parentHandle) final;
+
+  void enterTask(const task* object, const BaseClass* parent, vpiHandle handle,
+                 vpiHandle parentHandle) final;
+  void leaveTask(const task* object, const BaseClass* parent, vpiHandle handle,
+                 vpiHandle parentHandle) final;
 
  private:
+  void enterVariables(const variables* object, const BaseClass* parent,
+                      vpiHandle handle, vpiHandle parentHandle);
+
+  void enterTask_func(const task_func* object, const BaseClass* parent,
+                      vpiHandle handle, vpiHandle parentHandle);
+
+  void leaveTask_func(const task_func* object, const BaseClass* parent,
+                      vpiHandle handle, vpiHandle parentHandle);
 
   // Instance context stack
-  typedef std::vector<std::pair<const BaseClass*, std::tuple<ComponentMap, ComponentMap, ComponentMap>>> InstStack;
+  typedef std::vector<std::pair<
+      const BaseClass*, std::tuple<ComponentMap, ComponentMap, ComponentMap>>>
+      InstStack;
   InstStack instStack_;
 
   // Flat list of components (modules, udps, interfaces)
@@ -128,6 +199,6 @@ protected:
   std::vector<tf_call*> scheduledTfCallBinding_;
 };
 
-};
+};  // namespace UHDM
 
 #endif  // UHDM_ELABORATORLISTENER_H

--- a/templates/ExprEval.cpp
+++ b/templates/ExprEval.cpp
@@ -102,8 +102,8 @@ bool ExprEval::isFullySpecified(const UHDM::typespec *tps) {
 void tokenizeMulti(std::string_view str, std::string_view separator,
                    std::vector<std::string> &result) {
   std::string tmp;
-  const unsigned int sepSize = separator.size();
-  const unsigned int stringSize = str.size();
+  const unsigned int sepSize = static_cast<unsigned int>(separator.size());
+  const unsigned int stringSize = static_cast<unsigned int>(str.size());
   for (unsigned int i = 0; i < stringSize; i++) {
     bool isSeparator = true;
     for (unsigned int j = 0; j < sepSize; j++) {
@@ -356,7 +356,7 @@ long double ExprEval::get_double(bool &invalidValue, const UHDM::expr *expr) {
         break;
       }
       default: {
-        result = get_value(invalidValue, expr);
+        result = static_cast<long double>(get_value(invalidValue, expr));
         break;
       }
     }
@@ -752,7 +752,7 @@ uint64_t ExprEval::size(const any *typespec, bool &invalidValue,
         UHDM::VectorOftypespec_member *members = sts->Members();
         if (members) {
           for (UHDM::typespec_member *member : *members) {
-            unsigned int max =
+            uint64_t max =
                 size(member->Typespec(), invalidValue, inst, pexpr, full);
             if (max > bits) bits = max;
           }
@@ -1045,16 +1045,16 @@ expr *ExprEval::reduceBitSelect(expr *op, unsigned int index_val,
         if (ranges) {
           range *r = ranges->at(0);
           bool invalidValue = false;
-          lr = get_value(invalidValue, r->Left_expr());
-          rr = get_value(invalidValue, r->Right_expr());
+          lr = static_cast<unsigned short>(get_value(invalidValue, r->Left_expr()));
+          rr = static_cast<unsigned short>(get_value(invalidValue, r->Right_expr()));
         }
       }
     }
-    c->VpiSize(wordSize);
+    c->VpiSize(static_cast<int>(wordSize));
     if (index_val < binary.size()) {
       // TODO: If range does not start at 0
       if (lr >= rr) {
-        index_val = binary.size() - ((index_val + 1) * wordSize);
+        index_val = static_cast<unsigned int>(binary.size() - ((index_val + 1) * wordSize));
       }
       std::string v;
       for (unsigned int i = 0; i < wordSize; i++) {
@@ -1812,7 +1812,7 @@ expr *ExprEval::reduceExpr(const any *result, bool &invalidValue,
               if (invalidValue) break;
               uint64_t res = val & 1;
               for (int i = 1; i < cst->VpiSize(); i++) {
-                res = res & ((val & (1 << i)) >> i);
+                res = res & ((val & (1ULL << i)) >> i);
               }
               UHDM::constant *c = s.MakeConstant();
               c->VpiValue("UINT:" + std::to_string(res));
@@ -1831,7 +1831,7 @@ expr *ExprEval::reduceExpr(const any *result, bool &invalidValue,
               if (invalidValue) break;
               uint64_t res = val & 1;
               for (unsigned int i = 1; i < 32; i++) {
-                res = res & ((val & (1 << i)) >> i);
+                res = res & ((val & (1ULL << i)) >> i);
               }
               res = !res;
               UHDM::constant *c = s.MakeConstant();
@@ -1851,7 +1851,7 @@ expr *ExprEval::reduceExpr(const any *result, bool &invalidValue,
               if (invalidValue) break;
               uint64_t res = val & 1;
               for (unsigned int i = 1; i < 32; i++) {
-                res = res | ((val & (1 << i)) >> i);
+                res = res | ((val & (1ULL << i)) >> i);
               }
               UHDM::constant *c = s.MakeConstant();
               c->VpiValue("UINT:" + std::to_string(res));
@@ -1870,7 +1870,7 @@ expr *ExprEval::reduceExpr(const any *result, bool &invalidValue,
               if (invalidValue) break;
               uint64_t res = val & 1;
               for (unsigned int i = 1; i < 64; i++) {
-                res = res | ((val & (1 << i)) >> i);
+                res = res | ((val & (1ULL << i)) >> i);
               }
               res = !res;
               UHDM::constant *c = s.MakeConstant();
@@ -1890,7 +1890,7 @@ expr *ExprEval::reduceExpr(const any *result, bool &invalidValue,
               if (invalidValue) break;
               uint64_t res = val & 1;
               for (unsigned int i = 1; i < 64; i++) {
-                res = res ^ ((val & (1 << i)) >> i);
+                res = res ^ ((val & (1ULL << i)) >> i);
               }
               UHDM::constant *c = s.MakeConstant();
               c->VpiValue("UINT:" + std::to_string(res));
@@ -1909,7 +1909,7 @@ expr *ExprEval::reduceExpr(const any *result, bool &invalidValue,
               if (invalidValue) break;
               uint64_t res = val & 1;
               for (unsigned int i = 1; i < 64; i++) {
-                res = res ^ ((val & (1 << i)) >> i);
+                res = res ^ ((val & (1ULL << i)) >> i);
               }
               res = !res;
               UHDM::constant *c = s.MakeConstant();
@@ -1983,7 +1983,7 @@ expr *ExprEval::reduceExpr(const any *result, bool &invalidValue,
               int64_t val1 = get_value(invalidValueI, expr1);
               int64_t val = 0;
               if ((invalidValue == false) && (invalidValueI == false)) {
-                val = pow(val0, val1);
+                val = static_cast<int64_t>(std::pow<int64_t>(val0, val1));
                 UHDM::constant *c = s.MakeConstant();
                 c->VpiValue("INT:" + std::to_string(val));
                 c->VpiDecompile(std::to_string(val));
@@ -2171,7 +2171,7 @@ expr *ExprEval::reduceExpr(const any *result, bool &invalidValue,
                 c->VpiDecompile(std::to_string(res));
                 c->VpiConstType(vpiUIntConst);
               }
-              c->VpiSize(n * width);
+              c->VpiSize(static_cast<int>(n * width));
               // Word size
               if (width) {
                 int_typespec *ts = s.MakeInt_typespec();
@@ -2306,7 +2306,7 @@ expr *ExprEval::reduceExpr(const any *result, bool &invalidValue,
             if (c1) {
               if (stringVal) {
                 c1->VpiValue("STRING:" + cval);
-                c1->VpiSize(cval.size() * 8);
+                c1->VpiSize(static_cast<int>(cval.size() * 8));
                 c1->VpiConstType(vpiStringConst);
               } else {
                  if (cval.size() > UHDM_MAX_BIT_WIDTH) {
@@ -2375,7 +2375,7 @@ expr *ExprEval::reduceExpr(const any *result, bool &invalidValue,
                     ((uint64_t)((uint64_t)1 << cast_to)) - ((uint64_t)1);
                 uint64_t res = val0 & mask;
                 c->VpiValue("UINT:" + std::to_string(res));
-                c->VpiSize(cast_to);
+                c->VpiSize(static_cast<int>(cast_to));
                 c->VpiConstType(vpiUIntConst);
                 result = c;
               } else if (ttps == uhdmenum_typespec) {
@@ -2514,10 +2514,10 @@ expr *ExprEval::reduceExpr(const any *result, bool &invalidValue,
             }
             if (object) result = object;
           } else if (opType == vpiMultiConcatOp) {
-            result = reduceBitSelect(op, index_val, invalidValue, inst, pexpr);
+            result = reduceBitSelect(op, static_cast<unsigned int>(index_val), invalidValue, inst, pexpr);
           }
         } else if (otype == uhdmconstant) {
-          result = reduceBitSelect((constant *)object, index_val, invalidValue,
+          result = reduceBitSelect((constant *)object, static_cast<unsigned int>(index_val), invalidValue,
                                    inst, pexpr);
         }
       }
@@ -2553,7 +2553,7 @@ expr *ExprEval::reduceExpr(const any *result, bool &invalidValue,
       UHDM::constant *c = s.MakeConstant();
       c->VpiValue("BIN:" + sub);
       c->VpiDecompile(sub);
-      c->VpiSize(sub.size());
+      c->VpiSize(static_cast<int>(sub.size()));
       c->VpiConstType(vpiBinaryConst);
       result = c;
     }

--- a/templates/SynthSubset.cpp
+++ b/templates/SynthSubset.cpp
@@ -160,11 +160,6 @@ void SynthSubset::leaveThread_obj(const thread_obj* object,
   reportError(object);
 }
 
-void SynthSubset::leaveWaits(const waits* object, const BaseClass* parent,
-                             vpiHandle handle, vpiHandle parentHandle) {
-  reportError(object);
-}
-
 void SynthSubset::leaveWait_stmt(const wait_stmt* object,
                                  const BaseClass* parent, vpiHandle handle,
                                  vpiHandle parentHandle) {
@@ -180,11 +175,6 @@ void SynthSubset::leaveWait_fork(const wait_fork* object,
 void SynthSubset::leaveOrdered_wait(const ordered_wait* object,
                                     const BaseClass* parent, vpiHandle handle,
                                     vpiHandle parentHandle) {
-  reportError(object);
-}
-
-void SynthSubset::leaveDisables(const disables* object, const BaseClass* parent,
-                                vpiHandle handle, vpiHandle parentHandle) {
   reportError(object);
 }
 
@@ -542,8 +532,9 @@ void SynthSubset::leaveUser_systf(const user_systf* object,
   reportError(object);
 }
 
-void SynthSubset::leaveTf_call(const tf_call* object, const BaseClass* parent,
-                               vpiHandle handle, vpiHandle parentHandle) {
+void SynthSubset::leaveTask_call(const task_call* object,
+                                 const BaseClass* parent, vpiHandle handle,
+                                 vpiHandle parentHandle) {
   reportError(object);
 }
 
@@ -558,13 +549,6 @@ void SynthSubset::leaveMethod_task_call(const method_task_call* object,
                                         const BaseClass* parent,
                                         vpiHandle handle,
                                         vpiHandle parentHandle) {
-  reportError(object);
-}
-
-void SynthSubset::leaveConstraint_expr(const constraint_expr* object,
-                                       const BaseClass* parent,
-                                       vpiHandle handle,
-                                       vpiHandle parentHandle) {
   reportError(object);
 }
 

--- a/templates/SynthSubset.h
+++ b/templates/SynthSubset.h
@@ -66,9 +66,6 @@ class SynthSubset : public VpiListener {
   void leaveThread_obj(const thread_obj* object, const BaseClass* parent,
                        vpiHandle handle, vpiHandle parentHandle) override;
 
-  void leaveWaits(const waits* object, const BaseClass* parent,
-                  vpiHandle handle, vpiHandle parentHandle) override;
-
   void leaveWait_stmt(const wait_stmt* object, const BaseClass* parent,
                       vpiHandle handle, vpiHandle parentHandle) override;
 
@@ -77,9 +74,6 @@ class SynthSubset : public VpiListener {
 
   void leaveOrdered_wait(const ordered_wait* object, const BaseClass* parent,
                          vpiHandle handle, vpiHandle parentHandle) override;
-
-  void leaveDisables(const disables* object, const BaseClass* parent,
-                     vpiHandle handle, vpiHandle parentHandle) override;
 
   void leaveDisable(const disable* object, const BaseClass* parent,
                     vpiHandle handle, vpiHandle parentHandle) override;
@@ -270,7 +264,7 @@ class SynthSubset : public VpiListener {
   void leaveUser_systf(const user_systf* object, const BaseClass* parent,
                        vpiHandle handle, vpiHandle parentHandle) override;
 
-  void leaveTf_call(const tf_call* object, const BaseClass* parent,
+  void leaveTask_call(const task_call* object, const BaseClass* parent,
                     vpiHandle handle, vpiHandle parentHandle) override;
 
   void leaveMethod_func_call(const method_func_call* object,
@@ -280,10 +274,6 @@ class SynthSubset : public VpiListener {
   void leaveMethod_task_call(const method_task_call* object,
                              const BaseClass* parent, vpiHandle handle,
                              vpiHandle parentHandle) override;
-
-  void leaveConstraint_expr(const constraint_expr* object,
-                            const BaseClass* parent, vpiHandle handle,
-                            vpiHandle parentHandle) override;
 
   void leaveConstraint_ordering(const constraint_ordering* object,
                                 const BaseClass* parent, vpiHandle handle,


### PR DESCRIPTION
Remove listen_/enter/leave for class_def

Remove public API and enter/leave listener callbacks for class_def
models.

These methods give the false impression that those callbacks will
be called while walking the design hierarchy. The callbacks were
meant to be called iff the specific listen_<class_def> API was
invoked. Not worth the ambiguity.

P.S. This has infact caused a bug in ElaboratorListener & SynthSubset
implementations where enter/leave functions were implemented for
class_def but those functions will never be called.

Also, fixed a few build warnings in ExprEval

P.S. This is a potentially breaking change since it modifies the public
VpiListener.h file and removes a few publicly available listen_xxx
APIs.

