### PR TITLE
vpi_visitor & vpi_listener logic update

### DIFF
--- a/scripts/classes.py
+++ b/scripts/classes.py
@@ -428,7 +428,7 @@ def _get_GetByVpiType_implementation(model):
         content.append(f'  switch (type) {{')
 
     if modeltype == 'obj_def':
-        content.append( '  case vpiParent: return std::make_tuple(vpiParent_, static_cast<UHDM_OBJECT_TYPE>(0), nullptr);')
+        content.append( '    case vpiParent: return std::make_tuple(vpiParent_, static_cast<UHDM_OBJECT_TYPE>(0), nullptr);')
 
     if case_bodies:
         for vpi in sorted(case_bodies.keys()):

--- a/scripts/vpi_listener.py
+++ b/scripts/vpi_listener.py
@@ -5,7 +5,7 @@ import file_utils
 def _get_listeners(classname, vpi, type, card):
     listeners = []
 
-    if vpi in [ 'vpiParent', 'vpiInstance', 'vpiExtends' ]:
+    if vpi in ['vpiParent', 'vpiInstance', 'vpiProgram', 'vpiPackage', 'vpiUdp']:
         return listeners # To prevent infinite loops in visitors as these relations are pointing upward in the tree
 
     elif card == '1':

--- a/templates/ElaboratorListener.cpp
+++ b/templates/ElaboratorListener.cpp
@@ -235,6 +235,8 @@ void ElaboratorListener::enterClass_defn(const class_defn* object,
                                          const BaseClass* parent,
                                          vpiHandle handle,
                                          vpiHandle parentHandle) {
+  if (!visited_.insert(object).second) return;
+
   class_defn* cl = (class_defn*)object;
 
   // Collect instance elaborated nets
@@ -276,7 +278,9 @@ void ElaboratorListener::leaveClass_defn(const class_defn* object,
                                          const BaseClass* parent,
                                          vpiHandle handle,
                                          vpiHandle parentHandle) {
-  instStack_.pop_back();
+  if (!instStack_.empty() && (instStack_.back().first == object)) {
+    instStack_.pop_back();
+  }
 }
 
 // Hardcoded implementations

--- a/templates/ElaboratorListener.h
+++ b/templates/ElaboratorListener.h
@@ -30,6 +30,8 @@
 #include <uhdm/VpiListener.h>
 
 #include <map>
+#include <unordered_set>
+#include <vector>
 
 namespace UHDM {
 
@@ -181,6 +183,9 @@ class ElaboratorListener : public VpiListener {
 
   void leaveTask_func(const task_func* object, const BaseClass* parent,
                       vpiHandle handle, vpiHandle parentHandle);
+
+  typedef std::unordered_set<const UHDM::any*> VisitedSet;
+  VisitedSet visited_;
 
   // Instance context stack
   typedef std::vector<std::pair<

--- a/templates/ExprEval.cpp
+++ b/templates/ExprEval.cpp
@@ -117,12 +117,12 @@ void tokenizeMulti(std::string_view str, std::string_view separator,
     if (isSeparator) {
       i = i + sepSize - 1;
       result.push_back(tmp);
-      tmp = "";
+      tmp.clear();
       if (i == (str.size() - 1)) result.push_back(tmp);
     } else if (i == (str.size() - 1)) {
       tmp += str[i];
       result.push_back(tmp);
-      tmp = "";
+      tmp.clear();
     } else {
       tmp += str[i];
     }
@@ -1595,7 +1595,7 @@ any *ExprEval::hierarchicalSelector(std::vector<std::string> &select_path,
             uint64_t res = iv & mask;
             res = res >> (from);
             cons->VpiValue("UINT:" + std::to_string(res));
-            cons->VpiSize(width);
+            cons->VpiSize(static_cast<int>(width));
             return cons;
           } else {
             from += size(member, invalidValue, inst, pexpr, true);
@@ -1609,8 +1609,8 @@ any *ExprEval::hierarchicalSelector(std::vector<std::string> &select_path,
   if (elemName.find('[') != std::string::npos) {
     std::string indexName = ltrim(elemName, '[');
     indexName = rtrim(elemName, ']');
-    selectIndex = std::strtoull(indexName.c_str(), nullptr, 10);
-    elemName = "";
+    selectIndex = static_cast<int>(std::strtoull(indexName.c_str(), nullptr, 10));
+    elemName.clear();
     if (operation *oper = any_cast<operation *>(object)) {
       int opType = oper->VpiOpType();
       if (opType == vpiAssignmentPatternOp) {

--- a/templates/vpi_visitor.cpp
+++ b/templates/vpi_visitor.cpp
@@ -593,9 +593,6 @@ void visit_object(vpiHandle obj_h, int indent, const char *relation, VisitedCont
   if (alreadyVisited || shallowVisit) {
     return;
   }
-  if (strcmp(relation, "vpiParent") == 0) {
-    return;
-  }
 <OBJECT_VISITORS>
 }
 


### PR DESCRIPTION
vpi_visitor & vpi_listener logic update

* vpi_listener
** vpiExtends cannot be safely ignored since there could be only a
   single reference to it. Ignoring would mean there is never a
   entry/leave call for it.
** Avoid entry/leave for vpiProgram, vpiPackage, and vpiUdp when
   referred as a member reference from other objects.

* vpi_visitor
** Show vpiParent in the output for bit_select & part_select
** Never use shallow for ref_obj - without the vpiActual the reference
   itself is pointless
** Similar update for vpiInstance, vpiModule, vpiInterface, vpiUse,
   vpiProgram, vpiClassDefn, vpiPackage, and vpiUdp.
** Attempt to show all the information at the outer level but shallow
   in inner level of the hierarchy (basically, flattenning the tree a
   bit so it's easier to visually parse).