### PR TITLE
Speeding up UHDM deserialization

### DIFF
--- a/templates/Serializer.cpp
+++ b/templates/Serializer.cpp
@@ -47,7 +47,7 @@ void Serializer::SetId(const BaseClass* p, unsigned long id) {
 }
 
 unsigned long Serializer::GetId(const BaseClass* p) {
-  std::unordered_map<const BaseClass*, unsigned long>::iterator itr = allIds_.find(p);
+  std::map<const BaseClass*, unsigned long>::iterator itr = allIds_.find(p);
   if (itr == allIds_.end()) {
     unsigned long tmp = incrId_;
     allIds_.insert(std::make_pair(p, incrId_));

--- a/templates/Serializer.h
+++ b/templates/Serializer.h
@@ -102,7 +102,7 @@ class Serializer {
   uhdm_handleFactory uhdm_handleMaker;
 <FACTORY_DATA_MEMBERS>
 
-  const std::unordered_map<const BaseClass*, unsigned long>& AllObjects() const {
+  const std::map<const BaseClass*, unsigned long>& AllObjects() const {
     return allIds_;
   }
 
@@ -125,7 +125,7 @@ class Serializer {
   BaseClass* GetObject(unsigned int objectType, unsigned int index);
   void SetId(const BaseClass* p, unsigned long id);
   unsigned long GetId(const BaseClass* p);
-  std::unordered_map<const BaseClass*, unsigned long> allIds_;
+  std::map<const BaseClass*, unsigned long> allIds_;
   unsigned long incrId_;  // Capnp id
   unsigned long objId_;   // ID for property annotations
 


### PR DESCRIPTION
During initialization the setID function consumes a lot of cycles hashing the BaseClass pointer.

This change reduces the uhdm read time by 22%.