### PR TITLE
Adding {enter|leave}Any callbacks

### DIFF
--- a/templates/UhdmListener.cpp
+++ b/templates/UhdmListener.cpp
@@ -58,10 +58,15 @@ bool UhdmListener::didVisitAll(const Serializer& serializer) const {
 <UHDM_PRIVATE_LISTEN_IMPLEMENTATIONS>
 <UHDM_PUBLIC_LISTEN_IMPLEMENTATIONS>
 void UhdmListener::listenAny(const any* const object) {
+  const bool revisiting = visited.find(object) != visited.end();
+  if (!revisiting) enterAny(object);
+
   switch (object->UhdmType()) {
 <UHDM_LISTENANY_IMPLEMENTATION>
   default: break;
   }
+
+  if (!revisiting) leaveAny(object);
 }
 
 } // namespace UHDM

--- a/templates/UhdmListener.h
+++ b/templates/UhdmListener.h
@@ -82,7 +82,10 @@ public:
 
   void listenAny(const any *const object);
 <UHDM_PUBLIC_LISTEN_DECLARATIONS>
-  
+
+  virtual void enterAny(const any* const object) {}
+  virtual void leaveAny(const any* const object) {}
+
 <UHDM_ENTER_LEAVE_DECLARATIONS>
 <UHDM_ENTER_LEAVE_VECTOR_DECLARATIONS>
 private:


### PR DESCRIPTION
Adding {enter|leave}Any callbacks to allow subclasses to implement
a single function instead of every possible function. This callback
is useful for implementing pre-processing listeners (like collecting
all objects in model hierarchy).