### PR TITLE
Be consistent with inclusion file quoting.

### DIFF
--- a/tests/symbol_factory_test.cpp
+++ b/tests/symbol_factory_test.cpp
@@ -14,13 +14,13 @@
  limitations under the License.
 */
 
-#include <uhdm/SymbolFactory.h>
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
 #include <string>
 #include <string_view>
 #include <vector>
+
+#include "uhdm/SymbolFactory.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace UHDM {
 namespace {


### PR DESCRIPTION
The other tests in this directory use quote (") instead
of angle bracket (<) for inclusion of gtest.h and gmock.h.

Be consistent and do the same in symbol_factory_test.cpp.