### PR TITLE
Gen scope to support task_func

### DIFF
--- a/model/gen_scope.yaml
+++ b/model/gen_scope.yaml
@@ -118,3 +118,8 @@
     vpi: vpiClockingBlock
     type: clocking_block
     card: any
+  - class_ref: task_func
+    name: task func
+    vpi: vpiTaskFunc
+    type: task_func
+    card: any


### PR DESCRIPTION
The VPI Standard has a bug, gen_scope do allow to have in-scope function declaration, all simulators support it.
Adding that property.