### PR TITLE
Update to the way callstack is maintained in UdhmListener

### DIFF
--- a/scripts/UhdmListener.py
+++ b/scripts/UhdmListener.py
@@ -86,13 +86,13 @@ def generate(models):
             classnames.add(classname)
 
             public_implementations.append(f'void UhdmListener::listen{Classname_}(const {classname}* const object) {{')
+            public_implementations.append( '  callstack.push_back(object);')
             public_implementations.append(f'  enter{Classname_}(object);')
             public_implementations.append( '  if (visited.insert(object).second) {')
-            public_implementations.append( '    callstack.push_back(object);')
             public_implementations.append(f'    listen{Classname_}_(object);')
-            public_implementations.append( '    callstack.pop_back();')
             public_implementations.append( '  }')
             public_implementations.append(f'  leave{Classname_}(object);')
+            public_implementations.append( '  callstack.pop_back();')
             public_implementations.append(f'}}')
             public_implementations.append( '')
 


### PR DESCRIPTION
Update to the way callstack is maintained in UdhmListener

In the previous implementation, the callstack was updated only when any
of the members of object would receive enter/leave callbacks. That logic
introduces problems for cases where additional listenXXX calls are made
from within the enter/leave callbacks. The callbacks never see the
callstack being updated. As an update, update the callstack before and
after the enter/leave callbacks respectively. The side-effect of this
change is that the top of the callstack will always be the object for
which the enter/leave callback is being invoked. So, to check the
immediate context, the enter/leave callbacks have to check the
penultimate entry on the callstack.

This change is required to implement logic, like Linter, where the order
of visits is controlled by the sub-class implementation, rather than
depending purely on the logic of UhdmListener.