### PR TITLE
Resolving some ref_obj parenting issues

### DIFF
--- a/scripts/vpi_visitor_cpp.py
+++ b/scripts/vpi_visitor_cpp.py
@@ -9,10 +9,7 @@ def _get_implementation(classname, vpi, card):
     if card == '1':
         shallow_visit = 'false'
 
-        if (vpi == 'vpiParent') and ('_select' not in classname):
-            return content
-
-        if vpi in ['vpiInstance', 'vpiModule', 'vpiInterface', 'vpiUse', 'vpiProgram', 'vpiClassDefn', 'vpiPackage', 'vpiUdp']:
+        if vpi in ['vpiParent', 'vpiInstance', 'vpiModule', 'vpiInterface', 'vpiUse', 'vpiProgram', 'vpiClassDefn', 'vpiPackage', 'vpiUdp']:
             # Prevent walking upwards and makes the UHDM output cleaner
             # Prevent loop in Standard VPI
             shallow_visit = 'true'


### PR DESCRIPTION
Resolving some ref_obj parenting issues

* Show ref_obj's parent in UHDM output as this is critical piece of
  information for this specific model. Current logic does not suffice
  because it uses the parent's name and more often than not the name is
  empty.
* Objects in elaborated model where pointing into the non-elaborated side
  as parent.