### PR TITLE
Issue chipsalliance/Surelog#2985: Remove 'parent' in uhdm output

### DIFF
--- a/templates/vpi_visitor.cpp
+++ b/templates/vpi_visitor.cpp
@@ -576,19 +576,6 @@ void visit_object(vpiHandle obj_h, int indent, const char *relation, VisitedCont
         }
       }
     }
-    if (vpiHandle par = vpi_handle(vpiParent, obj_h)) {
-      if (const char* parentName = vpi_get_str(vpiFullName, par)) {
-        out << ", parent:" << parentName;
-      } else if (const char* parentName = vpi_get_str(vpiName, par)) {
-        out << ", parent:" << parentName;
-      }
-      if (showIDs) {
-        const uhdm_handle* const phandle = (const uhdm_handle*) par;
-        const BaseClass* const pobject = (const BaseClass*) phandle->object;
-        out << ", parID:" << pobject->UhdmId();
-      }
-      vpi_free_object(par);
-    }
     out << "\n";
   }
 


### PR DESCRIPTION
Issue chipsalliance/Surelog#2985: Remove 'parent' in uhdm output

The information is now available as an independent field in the hierarchy which includes the id information as well.