### PR TITLE
Issue chipsalliance/Surelog#3012 Recent vpiParent change makes debugging difficult

### DIFF
--- a/scripts/vpi_visitor_cpp.py
+++ b/scripts/vpi_visitor_cpp.py
@@ -22,6 +22,10 @@ def _get_implementation(classname, vpi, card):
             # Prevent stepping inside tasks while processing calls (task_call, method_task_call) to them
             shallow_visit = 'true'
 
+        if classname in ['ref_obj']:
+            # Ref_obj are always printed shallow
+            shallow_visit = 'true'
+
         content.append(f'  if (vpiHandle itr = vpi_handle({vpi}, obj_h)) {{')
         content.append(f'    visit_object(itr, indent + kLevelIndent, "{vpi}", visited, out, {shallow_visit});')
         content.append( '    release_handle(itr);')


### PR DESCRIPTION
Issue chipsalliance/Surelog#3012 Recent vpiParent change makes
debugging difficult

vpiParent visitation was meant to be shallow except for ref_obj. But
that exception causes ripple down the stream because vpiActual still
ends up being non-shallow. Ensure that the entire ref_obj visitation is
shallow.