### PR TITLE
Removed BaseClass::UhdmParentType

### DIFF
--- a/scripts/capnp.py
+++ b/scripts/capnp.py
@@ -34,13 +34,12 @@ def generate(models):
     model_schemas = [
       'struct Any {',
       '  uhdmId @0 :UInt64;',
-      '  vpiParent @1 :UInt64;',
-      '  uhdmParentType @2 :UInt64;',
-      '  vpiFile @3 :UInt64;',
-      '  vpiLineNo @4 :UInt32;',
-      '  vpiEndLineNo @5 :UInt32;',
-      '  vpiColumnNo @6 :UInt16;',
-      '  vpiEndColumnNo @7 :UInt16;',
+      '  vpiParent @1 :ObjIndexType;',
+      '  vpiFile @2 :UInt64;',
+      '  vpiLineNo @3 :UInt32;',
+      '  vpiEndLineNo @4 :UInt32;',
+      '  vpiColumnNo @5 :UInt16;',
+      '  vpiEndColumnNo @6 :UInt16;',
       '}',
       ''
     ]

--- a/scripts/classes.py
+++ b/scripts/classes.py
@@ -16,7 +16,7 @@ def _get_declarations(classname, type, vpi, card, real_type=''):
 
     final = ''
     virtual = ''
-    if vpi in ['vpiParent', 'uhdmParentType', 'uhdmType', 'vpiLineNo', 'vpiColumnNo', 'vpiEndLineNo', 'vpiEndColumnNo', 'vpiFile', 'vpiName', 'vpiDefName', 'uhdmId']:
+    if vpi in ['vpiParent', 'uhdmType', 'vpiLineNo', 'vpiColumnNo', 'vpiEndLineNo', 'vpiEndColumnNo', 'vpiFile', 'vpiName', 'vpiDefName', 'uhdmId']:
         final = ' final'
         virtual = 'virtual '
 
@@ -43,10 +43,7 @@ def _get_declarations(classname, type, vpi, card, real_type=''):
             content.append(f'  {virtual}const std::string& {Vpi_}() const{final};')
         else:
             content.append(f'  {virtual}{const}{type}{pointer} {Vpi_}() const{final} {{ return {vpi}_; }}')
-            if vpi == 'vpiParent':
-                content.append(f'  virtual bool {Vpi_}({type}{pointer} data) final {{ {check}{vpi}_ = data; uhdmParentType_ = (data != nullptr) ? data->UhdmType() : 0; return true; }}')
-            else:
-                content.append(f'  {virtual}bool {Vpi_}({type}{pointer} data){final} {{ {check}{vpi}_ = data; return true; }}')
+            content.append(f'  {virtual}bool {Vpi_}({type}{pointer} data){final} {{ {check}{vpi}_ = data; return true; }}')
     elif card == 'any':
         content.append(f'  VectorOf{type}* {Vpi_}() const {{ return {vpi}_; }}')
         content.append(f'  bool {Vpi_}(VectorOf{type}* data) {{ {check}{vpi}_ = data; return true; }}')
@@ -704,12 +701,6 @@ def _generate_one_class(model, models, templates):
         data_members.extend(_get_data_member('BaseClass', 'vpiParent', '1'))
         declarations.extend(_get_declarations(classname, 'BaseClass', 'vpiParent', '1'))
         func_body, func_includes = _get_implementations(classname, 'BaseClass', 'vpiParent', '1')
-        implementations.extend(func_body)
-        includes.update(func_includes)
-
-        data_members.extend(_get_data_member('unsigned int', 'uhdmParentType', '1'))
-        declarations.extend(_get_declarations(classname, 'unsigned int', 'uhdmParentType', '1'))
-        func_body, func_includes = _get_implementations(classname, 'unsigned int', 'uhdmParentType', '1')
         implementations.extend(func_body)
         includes.update(func_includes)
 

--- a/templates/BaseClass.h
+++ b/templates/BaseClass.h
@@ -74,10 +74,6 @@ namespace UHDM {
 
     virtual bool VpiParent(BaseClass* data) = 0;
 
-    virtual unsigned int UhdmParentType() const = 0;
-
-    virtual bool UhdmParentType(unsigned int data) = 0;
-
     virtual std::filesystem::path VpiFile() const = 0;
     virtual SymbolFactory::ID VpiFileId() const = 0;
 

--- a/templates/Serializer.cpp
+++ b/templates/Serializer.cpp
@@ -94,6 +94,6 @@ void Serializer::Purge() {
 }
 }  // namespace UHDM
 
-#if (defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__))
+#if defined(_MSC_VER)
   #pragma warning(pop)
 #endif

--- a/templates/Serializer_restore.cpp
+++ b/templates/Serializer_restore.cpp
@@ -76,8 +76,7 @@ inline void Serializer::SetRestoreId_(FactoryT<T>* const factory, unsigned long 
 
 struct Serializer::RestoreAdapter {
   void operator()(Any::Reader reader, Serializer *const serializer, BaseClass *const obj) const {
-    obj->UhdmParentType(reader.getUhdmParentType());
-    obj->VpiParent(serializer->GetObject(reader.getUhdmParentType(), reader.getVpiParent() - 1));
+    obj->VpiParent(serializer->GetObject(reader.getVpiParent().getType(), reader.getVpiParent().getIndex() - 1));
     obj->VpiFile(std::filesystem::path(serializer->symbolMaker.GetSymbol(reader.getVpiFile())));
     obj->VpiLineNo(reader.getVpiLineNo());
     obj->VpiColumnNo(reader.getVpiColumnNo());
@@ -124,8 +123,8 @@ const std::vector<vpiHandle> Serializer::Restore(const std::string& file) {
   close(fileid);
   return designs;
 }
+}  // namespace UHDM
 
 #if defined(_MSC_VER)
   #pragma warning(pop)
 #endif
-}  // namespace UHDM

--- a/templates/Serializer_save.cpp
+++ b/templates/Serializer_save.cpp
@@ -65,8 +65,11 @@ void Serializer::SetSaveId_(FactoryT<T> *const factory) {
 
 struct Serializer::SaveAdapter {
   void operator()(const BaseClass *const obj, Serializer *const serializer, Any::Builder builder) const {
-    builder.setVpiParent(serializer->GetId(obj->VpiParent()));
-    builder.setUhdmParentType(obj->UhdmParentType());
+    if (obj->VpiParent() != nullptr) {
+      ::ObjIndexType::Builder vpiParentBuilder = builder.getVpiParent();
+      vpiParentBuilder.setIndex(serializer->GetId(obj->VpiParent()));
+      vpiParentBuilder.setType(obj->VpiParent()->UhdmType());
+    }
     builder.setVpiFile(obj->GetSerializer()->symbolMaker.Make(obj->VpiFile().string()));
     builder.setVpiLineNo(obj->VpiLineNo());
     builder.setVpiColumnNo(obj->VpiColumnNo());
@@ -119,8 +122,8 @@ void Serializer::Save(const std::string& file) {
   writePackedMessageToFd(fileid, message);
   close(fileid);
 }
+}  // namespace UHDM
 
 #if defined(_MSC_VER)
   #pragma warning(pop)
 #endif
-}  // namespace UHDM


### PR DESCRIPTION
Removed BaseClass::UhdmParentType

For some unknown reason (probably historical remnant) the
BaseClass::vpiParent is stored differently in the cache compared to all
other references to BaseClass. BaseClass::vpiParent used
BaseClass::vpiParentType and index for caching, and other BaseClass
references used ObjectIndex as setup in capnp.

Removing the former approach to generalize how all references are
stored for consistency. Fixed up Serializer Save/Restore accordingly.