### PR TITLE
Add more non-synthesizable objects to SynthSubset visitor

### DIFF
--- a/templates/SynthSubset.cpp
+++ b/templates/SynthSubset.cpp
@@ -160,6 +160,18 @@ void SynthSubset::leaveThread_obj(const thread_obj* object,
   reportError(object);
 }
 
+void SynthSubset::leaveFork_stmt(const fork_stmt* object,
+                                 const BaseClass* parent, vpiHandle handle,
+                                 vpiHandle parentHandle) {
+  reportError(object);
+}
+
+void SynthSubset::leaveNamed_fork(const named_fork* object,
+                                  const BaseClass* parent, vpiHandle handle,
+                                  vpiHandle parentHandle) {
+  reportError(object);
+}
+
 void SynthSubset::leaveWait_stmt(const wait_stmt* object,
                                  const BaseClass* parent, vpiHandle handle,
                                  vpiHandle parentHandle) {
@@ -423,9 +435,21 @@ void SynthSubset::leaveTime_net(const time_net* object, const BaseClass* parent,
   reportError(object);
 }
 
+void SynthSubset::leaveEvent_stmt(const event_stmt* object,
+                                  const BaseClass* parent, vpiHandle handle,
+                                  vpiHandle parentHandle) {
+  reportError(object);
+}
+
 void SynthSubset::leaveNamed_event(const named_event* object,
                                    const BaseClass* parent, vpiHandle handle,
                                    vpiHandle parentHandle) {
+  reportError(object);
+}
+
+void SynthSubset::leaveEvent_typespec(const event_typespec* object,
+                                      const BaseClass* parent, vpiHandle handle,
+                                      vpiHandle parentHandle) {
   reportError(object);
 }
 

--- a/templates/SynthSubset.h
+++ b/templates/SynthSubset.h
@@ -66,6 +66,12 @@ class SynthSubset : public VpiListener {
   void leaveThread_obj(const thread_obj* object, const BaseClass* parent,
                        vpiHandle handle, vpiHandle parentHandle) override;
 
+  void leaveFork_stmt(const fork_stmt* object, const BaseClass* parent,
+                      vpiHandle handle, vpiHandle parentHandle) override;
+
+  void leaveNamed_fork(const named_fork* object, const BaseClass* parent,
+                       vpiHandle handle, vpiHandle parentHandle) override;
+
   void leaveWait_stmt(const wait_stmt* object, const BaseClass* parent,
                       vpiHandle handle, vpiHandle parentHandle) override;
 
@@ -211,8 +217,16 @@ class SynthSubset : public VpiListener {
   void leaveTime_net(const time_net* object, const BaseClass* parent,
                      vpiHandle handle, vpiHandle parentHandle) override;
 
+  void leaveEvent_stmt(const event_stmt* object, const BaseClass* parent,
+                       vpiHandle handle, vpiHandle parentHandle) override;
+
   void leaveNamed_event(const named_event* object, const BaseClass* parent,
                         vpiHandle handle, vpiHandle parentHandle) override;
+
+  void leaveEvent_typespec(const event_typespec* object,
+                           const BaseClass* parent, vpiHandle handle,
+                           vpiHandle parentHandle) override;
+
 
   void leaveClass_typespec(const class_typespec* object,
                            const BaseClass* parent, vpiHandle handle,


### PR DESCRIPTION
With this change, these constructs:
* `fork_stmt`
* `named_fork`
* `named_event`
* `event_typespec`

will be treated as non-synthesizable.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>