### PR TITLE
AllIds in Serializer: use canonical insert; make typedef

### DIFF
--- a/templates/Serializer.cpp
+++ b/templates/Serializer.cpp
@@ -43,19 +43,15 @@ void DefaultErrorHandler(ErrorType errType, const std::string& errorMsg, const a
 }
 
 void Serializer::SetId(const BaseClass* p, unsigned long id) {
-  allIds_.insert(std::make_pair(p, id));
+  allIds_.emplace(p, id);
 }
 
 unsigned long Serializer::GetId(const BaseClass* p) {
-  std::map<const BaseClass*, unsigned long>::iterator itr = allIds_.find(p);
-  if (itr == allIds_.end()) {
-    unsigned long tmp = incrId_;
-    allIds_.insert(std::make_pair(p, incrId_));
-    incrId_++;
-    return tmp;
-  } else {
-    return (*itr).second;
+  auto inserted = allIds_.emplace(p, incrId_);
+  if (inserted.second) {
+    ++incrId_;
   }
+  return inserted.first->second;
 }
 
 <UHDM_NAME_MAP>

--- a/templates/Serializer.h
+++ b/templates/Serializer.h
@@ -74,6 +74,8 @@ class FactoryT;
 
 class Serializer {
  public:
+  using IdMap = std::map<const BaseClass*, unsigned long>;
+
   Serializer() : incrId_(0), objId_(0), errorHandler(DefaultErrorHandler) {
     symbolMaker.Make("");
   }
@@ -104,7 +106,7 @@ class Serializer {
   uhdm_handleFactory uhdm_handleMaker;
 <FACTORY_DATA_MEMBERS>
 
-  const std::map<const BaseClass*, unsigned long>& AllObjects() const {
+  const IdMap& AllObjects() const {
     return allIds_;
   }
 
@@ -127,7 +129,7 @@ class Serializer {
   BaseClass* GetObject(unsigned int objectType, unsigned int index);
   void SetId(const BaseClass* p, unsigned long id);
   unsigned long GetId(const BaseClass* p);
-  std::map<const BaseClass*, unsigned long> allIds_;
+  IdMap allIds_;
   unsigned long incrId_;  // Capnp id
   unsigned long objId_;   // ID for property annotations
 


### PR DESCRIPTION
o Use canonical map insert/emplace in which we don't find()
  and then do the same thing again on insert, but do it in
  one go.
o Make the map used for the ID storage a typedef to improve
  readability (also makes it easier to replace in one place).

Signed-off-by: Henner Zeller <h.zeller@acm.org>