### PR TITLE
chipsalliance/Surelog#2962: Flush often

### DIFF
--- a/templates/vpi_visitor.cpp
+++ b/templates/vpi_visitor.cpp
@@ -577,14 +577,17 @@ void visit_object(vpiHandle obj_h, int indent, const char *relation, VisitedCont
 
 // Public interface
 void visit_designs(const std::vector<vpiHandle>& designs, std::ostream &out) {
+  out << std::unitbuf;
   for (auto design : designs) {
     VisitedContainer visited;
     visit_object(design, 0, "", &visited, out);
   }
+  out << std::nounitbuf;
 }
 
 std::string visit_designs(const std::vector<vpiHandle>& designs) {
   std::stringstream out;
+  out << std::unitbuf;
   visit_designs(designs, out);
   return out.str();
 }


### PR DESCRIPTION
chipsalliance/Surelog#2962: Flush often

With large designs, visitation logic can end up buffering too much with
no progress reported on screen. Switching to flush often. This also
helps with keeping the memory requirement down for large designs.