### PR TITLE
Use a std::deque instead of a std::vector to keep track of allocated objects

### DIFF
--- a/templates/BaseClass.h
+++ b/templates/BaseClass.h
@@ -27,6 +27,7 @@
 #ifndef UHDM_BASE_CLASS_H
 #define UHDM_BASE_CLASS_H
 
+#include <deque>
 #include <filesystem>
 #include <set>
 #include <string_view>
@@ -147,7 +148,12 @@ namespace UHDM {
   template<typename T>
   class FactoryT final {
     friend Serializer;
-    typedef std::vector<T *> objects_t;
+    // TODO: make this an arena: iinstead of pointers, store the
+    // objects directly with placement-new'ed object using emplace_back()
+    // One less indirection and a lot less overhead.
+    // (dqque guarantees pointer stability; however, we'd need to
+    // do something special in Erase() - can't re-arrange).
+    typedef std::deque<T *> objects_t;
 
     public:
       T* Make() {

--- a/templates/Serializer_restore.cpp
+++ b/templates/Serializer_restore.cpp
@@ -88,7 +88,7 @@ struct Serializer::RestoreAdapter {
 <CAPNP_RESTORE_ADAPTERS>
 
   template<typename T, typename U, typename = typename std::enable_if<std::is_base_of<BaseClass, T>::value>::type>
-  void operator()(typename ::capnp::List<U>::Reader reader, Serializer *serializer, std::vector<T*> &objects) const {
+  void operator()(typename ::capnp::List<U>::Reader reader, Serializer *serializer, typename FactoryT<T>::objects_t &objects) const {
     unsigned long index = 0;
     for (typename U::Reader obj : reader)
       operator()(obj, serializer, objects[index++]);

--- a/templates/Serializer_save.cpp
+++ b/templates/Serializer_save.cpp
@@ -81,7 +81,7 @@ struct Serializer::SaveAdapter {
 <CAPNP_SAVE_ADAPTERS>
 
   template<typename T, typename U, typename = typename std::enable_if<std::is_base_of<BaseClass, T>::value>::type>
-  void operator()(const std::vector<T*> &objects, Serializer *serializer, typename ::capnp::List<U>::Builder builder) const {
+  void operator()(const typename FactoryT<T>::objects_t &objects, Serializer *serializer, typename ::capnp::List<U>::Builder builder) const {
     unsigned long index = 0;
     for (const T* obj : objects)
       operator()(obj, serializer, builder[index++]);


### PR DESCRIPTION
The FactoryT does not have a need to keep the list contiguously in
memory, so we can use deque, avoiding unnecessary re-allocs.

This allows the memory allocator to not worry about providing many large contiguous regions, which could contribute to an improved situation for https://github.com/chipsalliance/Surelog/issues/2962