### PR TITLE
Let the stream handle its own flushing. Only use method returning string in tests 

### DIFF
--- a/templates/vpi_visitor.cpp
+++ b/templates/vpi_visitor.cpp
@@ -576,19 +576,10 @@ void visit_object(vpiHandle obj_h, int indent, const char *relation, VisitedCont
 
 // Public interface
 void visit_designs(const std::vector<vpiHandle>& designs, std::ostream &out) {
-  out << std::unitbuf;
   for (auto design : designs) {
     VisitedContainer visited;
     visit_object(design, 0, "", &visited, out);
   }
-  out << std::nounitbuf;
-}
-
-std::string visit_designs(const std::vector<vpiHandle>& designs) {
-  std::stringstream out;
-  out << std::unitbuf;
-  visit_designs(designs, out);
-  return out.str();
 }
 
 };

--- a/templates/vpi_visitor.h
+++ b/templates/vpi_visitor.h
@@ -43,9 +43,6 @@ void visit_object (vpiHandle obj_h, int indent, const char *relation, VisitedCon
 // Visit designs, dump to given stream.
 void visit_designs (const std::vector<vpiHandle>& designs, std::ostream &out);
 
-// Visit designs, return string representation.
-std::string visit_designs (const std::vector<vpiHandle>& designs);
-
 // For debug use in GDB
 std::string decompile(UHDM::any* handle);
 

--- a/tests/classes_test.cpp
+++ b/tests/classes_test.cpp
@@ -7,6 +7,8 @@
 #include "uhdm/VpiListener.h"
 #include "uhdm/vpi_visitor.h"
 
+#include "test_util.h"
+
 using namespace UHDM;
 
 static std::vector<vpiHandle> build_designs(Serializer* s) {
@@ -104,13 +106,13 @@ static std::vector<vpiHandle> build_designs(Serializer* s) {
 TEST(ClassesTest, DesignSaveRestoreRoundtrip) {
   Serializer serializer;
   const std::vector<vpiHandle>& designs = build_designs(&serializer);
-  const std::string before = visit_designs(designs);
+  const std::string before = designs_to_string(designs);
 
   const std::string filename = testing::TempDir() + "/classes_test.uhdm";
   serializer.Save(filename);
 
   const std::vector<vpiHandle>& restoredDesigns = serializer.Restore(filename);
-  const std::string restored = visit_designs(restoredDesigns);
+  const std::string restored = designs_to_string(restoredDesigns);
 
   EXPECT_EQ(before, restored);
 
@@ -119,6 +121,6 @@ TEST(ClassesTest, DesignSaveRestoreRoundtrip) {
   listener->listenDesigns(restoredDesigns);
   delete listener;
 
-  const std::string elaborated = visit_designs(restoredDesigns);
+  const std::string elaborated = designs_to_string(restoredDesigns);
   EXPECT_NE(restored, elaborated);  // Elaboration should've done _something_
 }

--- a/tests/error-handler_test.cpp
+++ b/tests/error-handler_test.cpp
@@ -5,6 +5,8 @@
 #include "uhdm/uhdm.h"
 #include "uhdm/vpi_visitor.h"
 
+#include "test_util.h"
+
 using namespace UHDM;
 using testing::HasSubstr;
 
@@ -107,7 +109,7 @@ TEST(ErrorHandlerTest, ErrorHandlerIsCalled) {
   serializer.SetErrorHandler(MyErrorHandler);
 
   issuedError = false;
-  const std::string before = visit_designs(build_designs(&serializer));
+  const std::string before = designs_to_string(build_designs(&serializer));
 
   EXPECT_TRUE(issuedError);  // Issue in design.
   EXPECT_THAT(last_msg, HasSubstr("adding wrong object type"));
@@ -121,7 +123,7 @@ TEST(ErrorHandlerTest, ErrorHandlerIsCalled) {
   // Save/restore will not contain the errornous part.
   issuedError = false;
   std::vector<vpiHandle> restoredDesigns = serializer.Restore(filename);
-  const std::string restored = visit_designs(restoredDesigns);
+  const std::string restored = designs_to_string(restoredDesigns);
   EXPECT_FALSE(issuedError);
 
   EXPECT_EQ(before, restored);

--- a/tests/expr_reduce_test.cpp
+++ b/tests/expr_reduce_test.cpp
@@ -34,6 +34,8 @@
 #include "uhdm/vpi_visitor.h"
 #include "uhdm/ExprEval.h"
 
+#include "test_util.h"
+
 using namespace UHDM;
 
 //-------------------------------------------
@@ -94,7 +96,7 @@ std::vector<vpiHandle> build_designs(Serializer* s) {
 TEST(FullElabTest, ElaborationRoundtrip) {
   Serializer serializer;
   const std::vector<vpiHandle>& designs = build_designs(&serializer);
-  const std::string before = visit_designs(designs);
+  const std::string before = designs_to_string(designs);
 
   bool elaborated = false;
   for (auto design : designs) {

--- a/tests/full_elab_test.cpp
+++ b/tests/full_elab_test.cpp
@@ -34,6 +34,8 @@
 #include "uhdm/VpiListener.h"
 #include "uhdm/vpi_visitor.h"
 
+#include "test_util.h"
+
 using namespace UHDM;
 
 //-------------------------------------------
@@ -188,7 +190,7 @@ std::string dumpStats(const Serializer& serializer) {
 TEST(FullElabTest, ElaborationRoundtrip) {
   Serializer serializer;
   const std::vector<vpiHandle>& designs = build_designs(&serializer);
-  const std::string before = visit_designs(designs);
+  const std::string before = designs_to_string(designs);
 
   bool elaborated = false;
   for (auto design : designs) {
@@ -216,6 +218,6 @@ TEST(FullElabTest, ElaborationRoundtrip) {
 
   // TODO: this needs more fine-grained object-level inspection.
 
-  const std::string after = visit_designs(designs);
+  const std::string after = designs_to_string(designs);
   EXPECT_NE(before, after);  // We expect the elaboration to have some impact :)
 }

--- a/tests/garbage_collect_test.cpp
+++ b/tests/garbage_collect_test.cpp
@@ -6,6 +6,8 @@
 #include "uhdm/uhdm.h"
 #include "uhdm/vpi_visitor.h"
 
+#include "test_util.h"
+
 using namespace UHDM;
 
 static std::vector<vpiHandle> build_designs(Serializer* s) {
@@ -38,7 +40,7 @@ static std::vector<vpiHandle> build_designs(Serializer* s) {
 TEST(GarbageCollectTest, NoLeakExpectation) {
   Serializer serializer;
   const std::vector<vpiHandle>& designs = build_designs(&serializer);
-  const std::string before = visit_designs(designs);
+  const std::string before = designs_to_string(designs);
 
   const std::string filename = testing::TempDir() + "/gc_test.uhdm";
   serializer.Save(filename);
@@ -47,7 +49,7 @@ TEST(GarbageCollectTest, NoLeakExpectation) {
   }
 
   const std::vector<vpiHandle>& restoredDesigns = serializer.Restore(filename);
-  const std::string restored = visit_designs(restoredDesigns);
+  const std::string restored = designs_to_string(restoredDesigns);
 
   std::string decompiled;
   for (auto objIndexPair : serializer.AllObjects()) {

--- a/tests/listener_elab_test.cpp
+++ b/tests/listener_elab_test.cpp
@@ -37,6 +37,8 @@
 #include "uhdm/uhdm_forward_decl.h"
 #include "uhdm/vpi_visitor.h"
 
+#include "test_util.h"
+
 using namespace UHDM;
 
 //-------------------------------------------
@@ -364,7 +366,7 @@ TEST(ListenerElabTest, RoundTrip) {
   const std::vector<vpiHandle>& designs = build_designs(&serializer);
   std::string orig;
   orig += "DUMP Design content:\n";
-  orig += visit_designs(designs);
+  orig += designs_to_string(designs);
   std::cout << orig;
   bool elaborated = false;
   for (auto design : designs) {
@@ -376,7 +378,7 @@ TEST(ListenerElabTest, RoundTrip) {
     listener->listenDesigns(designs);
     delete listener;
   }
-  std::string post_elab1 = visit_designs(designs);
+  std::string post_elab1 = designs_to_string(designs);
   for (auto design : designs) {
     elaborated = vpi_get(vpiElaborated, design) || elaborated;
   }
@@ -388,6 +390,6 @@ TEST(ListenerElabTest, RoundTrip) {
     listener->listenDesigns(designs);
     delete listener;
   }
-  std::string post_elab2 = visit_designs(designs);
+  std::string post_elab2 = designs_to_string(designs);
   EXPECT_EQ(post_elab1, post_elab2);
 }

--- a/tests/module-port_test.cpp
+++ b/tests/module-port_test.cpp
@@ -6,6 +6,8 @@
 #include "uhdm/uhdm.h"
 #include "uhdm/vpi_visitor.h"
 
+#include "test_util.h"
+
 using namespace UHDM;
 
 // TODO: These tests are 'too big', i.e. they don't test a particular aspect
@@ -136,12 +138,12 @@ TEST(Serialization, SerializeModulePortDesign_e2e) {
   Serializer serializer;
   const std::vector<vpiHandle>& designs = buildModulePortDesign(&serializer);
 
-  const std::string orig = visit_designs(designs);
+  const std::string orig = designs_to_string(designs);
 
   const std::string filename = testing::TempDir() + "/serialize-roundrip.uhdm";
   serializer.Save(filename);
 
   const std::vector<vpiHandle>& restoredDesigns = serializer.Restore(filename);
-  const std::string restored = visit_designs(restoredDesigns);
+  const std::string restored = designs_to_string(restoredDesigns);
   EXPECT_EQ(orig, restored);
 }

--- a/tests/process_test.cpp
+++ b/tests/process_test.cpp
@@ -4,9 +4,9 @@
 #include "uhdm/uhdm.h"
 #include "uhdm/vpi_visitor.h"
 
-using namespace UHDM;
+#include "test_util.h"
 
-#include "uhdm/vpi_visitor.h"
+using namespace UHDM;
 
 // This builds a simple design:
 // module m1;
@@ -86,13 +86,13 @@ static std::vector<vpiHandle> buildSimpleAlawysDesign(Serializer* s) {
 
 TEST(SerializationProcess, ProcessSerialization) {
   Serializer serializer;
-  const std::string orig = visit_designs(buildSimpleAlawysDesign(&serializer));
+  const std::string orig = designs_to_string(buildSimpleAlawysDesign(&serializer));
 
   const std::string filename = testing::TempDir() + "/surelog_process.uhdm";
   serializer.Save(filename);
 
   const std::vector<vpiHandle> restoredDesigns = serializer.Restore(filename);
-  const std::string restored = visit_designs(restoredDesigns);
+  const std::string restored = designs_to_string(restoredDesigns);
   EXPECT_EQ(orig, restored);
 }
 

--- a/tests/statement_test.cpp
+++ b/tests/statement_test.cpp
@@ -6,6 +6,8 @@
 #include "uhdm/uhdm.h"
 #include "uhdm/vpi_visitor.h"
 
+#include "test_util.h"
+
 using namespace UHDM;
 
 // TODO: These tests are 'too big', i.e. they don't test a particular aspect
@@ -101,12 +103,12 @@ TEST(Serialization, SerializeStatementDesign_e2e) {
   Serializer serializer;
   const std::vector<vpiHandle>& designs = buildStatementDesign(&serializer);
 
-  const std::string orig = visit_designs(designs);
+  const std::string orig = designs_to_string(designs);
 
   const std::string filename = testing::TempDir() + "/serialize-roundrip.uhdm";
   serializer.Save(filename);
 
   const std::vector<vpiHandle>& restoredDesigns = serializer.Restore(filename);
-  const std::string restored = visit_designs(restoredDesigns);
+  const std::string restored = designs_to_string(restoredDesigns);
   EXPECT_EQ(orig, restored);
 }

--- a/tests/test_util.h
+++ b/tests/test_util.h
@@ -1,0 +1,29 @@
+/*
+ (c) 2022 The UHDM authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+#ifndef UHDM_TEST_UTIL_H
+#define UHDM_TEST_UTIL_H
+
+#include <sstream>
+#include "uhdm/vpi_visitor.h"
+
+inline std::string designs_to_string(const std::vector<vpiHandle>& designs) {
+  std::stringstream out;
+  UHDM::visit_designs(designs, out);
+  return out.str();
+}
+
+#endif  // UHDM_TEST_UTIL_H

--- a/tests/tf_call_test.cpp
+++ b/tests/tf_call_test.cpp
@@ -4,9 +4,9 @@
 #include "uhdm/uhdm.h"
 #include "uhdm/vpi_visitor.h"
 
-using namespace UHDM;
+#include "test_util.h"
 
-#include "uhdm/vpi_visitor.h"
+using namespace UHDM;
 
 static std::vector<vpiHandle> build_tfCallDesign(Serializer* s) {
   std::vector<vpiHandle> designs;
@@ -71,11 +71,11 @@ static std::vector<vpiHandle> build_tfCallDesign(Serializer* s) {
 
 TEST(Serialization, TFCallDesign) {
   Serializer serializer;
-  const std::string orig = visit_designs(build_tfCallDesign(&serializer));
+  const std::string orig = designs_to_string(build_tfCallDesign(&serializer));
   const std::string filename = testing::TempDir() + "/surelog_tf_call.uhdm";
   serializer.Save(filename);
 
   std::vector<vpiHandle> restoredDesigns = serializer.Restore(filename);
-  const std::string restored = visit_designs(restoredDesigns);
+  const std::string restored = designs_to_string(restoredDesigns);
   EXPECT_EQ(orig, restored);
 }

--- a/util/uhdm-dump.cpp
+++ b/util/uhdm-dump.cpp
@@ -127,8 +127,9 @@ int main(int argc, char **argv) {
   visit_designs(restoredDesigns, std::cout);
 
   if (!goldenFile.empty()) {
-    const std::string restored = visit_designs(restoredDesigns);
-    if (!CompareContentWithFile(restored, goldenFile, verbose)) {
+    std::stringstream restored;
+    visit_designs(restoredDesigns, restored);
+    if (!CompareContentWithFile(restored.str(), goldenFile, verbose)) {
       return 2;
     }
   }


### PR DESCRIPTION

 * Changing the flushing on each output creates a huge slowdown
   and leaves the user with no choice. If the caller would like to
   have that behavior, it should be done outside of this function.
 * As looking at Surelog shows, the visitor that returns the string is
   mis-used 100% of the time. Let's not provide that rope.
 * Add the convenience function that retunrs a string in the
   test_utils.h for local use in the unit tests.

Context:
  https://github.com/chipsalliance/UHDM/pull/743
  https://github.com/chipsalliance/Surelog/issues/2962
