### PR TITLE
Fix more places that overzealously flush the stream.

### DIFF
--- a/scripts/vpi_visitor_cpp.py
+++ b/scripts/vpi_visitor_cpp.py
@@ -62,10 +62,10 @@ def _get_vpi_xxx_visitor(type, vpi, card):
     elif (card == '1') and (vpi not in ['vpiType', 'vpiFile', 'vpiLineNo', 'vpiColumnNo', 'vpiEndLineNo', 'vpiEndColumnNo']):
         if type == 'string':
             content.append(f'  if (const char* s = vpi_get_str({vpi}, obj_h))')
-            content.append(f'    stream_indent(out, indent) << "|{vpi}:" << s << std::endl;')
+            content.append(f'    stream_indent(out, indent) << "|{vpi}:" << s << "\\n";') # no std::endl, avoid flush
         else:
             content.append(f'  if (const int n = vpi_get({vpi}, obj_h))')
-            content.append(f'    stream_indent(out, indent) << "|{vpi}:" << n << std::endl;')
+            content.append(f'    stream_indent(out, indent) << "|{vpi}:" << n << "\\n";') # no std::endl, avoid flush
     return content
 
 

--- a/util/uhdm-dump.cpp
+++ b/util/uhdm-dump.cpp
@@ -83,6 +83,8 @@ static int usage(const char *progname) {
 }
 
 int main(int argc, char **argv) {
+  std::ios::sync_with_stdio(false);
+
   bool elab = false;
   bool verbose = false;
   std::string uhdmFile;


### PR DESCRIPTION
Using std::endl will flush the stream with each line which is
definitely not what we want when dumping out a large design.

This speeds up uhdm-dump significantly.

Signed-off-by: Henner Zeller <h.zeller@acm.org>