### PR TITLE
Using std::deque<> as an allocation space for factories.

### DIFF
--- a/templates/Serializer.h
+++ b/templates/Serializer.h
@@ -37,6 +37,7 @@
 #include <uhdm/containers.h>
 #include <uhdm/vpi_uhdm.h>
 #include <uhdm/SymbolFactory.h>
+#include <uhdm/uhdm.h>
 
 #define UHDM_MAX_BIT_WIDTH 1024*1024
 

--- a/templates/uhdm_forward_decl.h
+++ b/templates/uhdm_forward_decl.h
@@ -36,11 +36,6 @@ class BaseClass;
 typedef BaseClass any;
 
 <UHDM_CLASSES_FORWARD_DECL>
-
-<UHDM_FACTORIES_FORWARD_DECL>
-
-typedef FactoryT<std::vector<BaseClass*>> VectorOfanyFactory;
-<UHDM_CONTAINER_FACTORIES_FORWARD_DECL>
 };
 
 


### PR DESCRIPTION
This allows to have pre-sized buffers and easily de-allocated objects.
Since malloc allocators already do something similar, this is not
creating huge saving (about 70 MiB RAM saving for Rsd, 5-10% CPU time)

This particular implementation will increase the compile time by
a lot as we need to pull in all the classes from uhdm/uhdm.h (as
we need to know the size in the factory), so it would need some
refinement (e.g. some PIMPL-style) to be usable.

So leaving it here as draft if someone wants to experiment with
it.