### PR TITLE
Make VpiListenerTracer.h be self-contained.

### DIFF
--- a/templates/VpiListenerTracer.h
+++ b/templates/VpiListenerTracer.h
@@ -29,6 +29,8 @@
 
 #include "VpiListener.h"
 
+#include "uhdm/uhdm.h"  // Needed to know how to access VPI line/column
+
 #include <ostream>
 #include <string>
 

--- a/tests/vpi_listener_test.cpp
+++ b/tests/vpi_listener_test.cpp
@@ -1,18 +1,23 @@
 // -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
 
-#include "uhdm/VpiListener.h"
-
 #include <iostream>
 #include <memory>
 #include <stack>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "uhdm/uhdm.h"
+
+// uhdm
 #include "uhdm/VpiListener.h"
+#include "uhdm/VpiListenerTracer.h"
+
+// We include this last to make sure that the headers above don't accidentally
+// depend on any class defined here
+#include "uhdm/uhdm.h"
 
 using namespace UHDM;
 using testing::ElementsAre;
+using testing::HasSubstr;
 
 class MyVpiListener : public VpiListener {
  protected:
@@ -124,4 +129,14 @@ TEST(VpiListenerTest, ProgramModule) {
       "Module: u2/M3 parent: -",
   };
   EXPECT_EQ(listener->collected(), expected);
+}
+
+TEST(UhdmListenerTracerTest, ProgramModule) {
+  Serializer serializer;
+  const std::vector<vpiHandle>& design = buildModuleProg(&serializer);
+
+  std::stringstream out;
+  std::unique_ptr<VpiListenerTracer> listener(new VpiListenerTracer(out));
+  listener->listenDesigns(design);
+  EXPECT_THAT(out.str(), HasSubstr("enterDesign: [0,0:0,0]"));
 }


### PR DESCRIPTION
The header relied on forward declared classes, but since it actually
accesses members (VpiLineNo() etc.), it needs a full declaration of
these.