### PR TITLE
Issue chipsalliance/Surelog#3077 - Include gates and udps in non-elaborated tree

### DIFF
--- a/scripts/classes.py
+++ b/scripts/classes.py
@@ -232,6 +232,11 @@ def _get_DeepClone_implementation(model, models):
                     content.append(f'  clone->{method}(elaborator->bindAny(VpiName()));')
                     content.append(f'  if (!clone->{method}()) clone->{method}((any*) {method}());')
 
+                elif classname == 'udp' and method == 'Udp_defn':
+                    includes.add('ElaboratorListener')
+                    content.append(f'  clone->{method}((udp_defn*) elaborator->bindAny(VpiDefName()));')
+                    content.append(f'  if (!clone->{method}()) clone->{method}((udp_defn*) {method}());')
+
                 elif method in ['Task', 'Function']:
                     prefix = 'nullptr'
                     includes.add(method.lower())


### PR DESCRIPTION
Issue chipsalliance/Surelog#3077 - Include gates and udps in non-elaborated tree

Don't clone udp_defn. Bind any existing cloned one or use the one from
source i.e. one that is being cloned.