### PR TITLE
Handle CI subcommand failures correctly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -210,6 +210,9 @@ jobs:
         where python && python --version
 
         make release
+        if %errorlevel% neq 0 exit /b %errorlevel%
         make test
+        if %errorlevel% neq 0 exit /b %errorlevel%
         make install
+        if %errorlevel% neq 0 exit /b %errorlevel%
         make test_install


### PR DESCRIPTION
Handle CI subcommand failures correctly

Unlike bash, Windows scripts don't fail if one of the subcommand in the
batch fails. Result from each such command has to explicitly be checked
and bubbled up appropriately.