### PR TITLE
Update to callback logic in UhdmListener

### DIFF
--- a/tests/uhdm_listener_test.cpp
+++ b/tests/uhdm_listener_test.cpp
@@ -16,21 +16,25 @@ using testing::ElementsAre;
 class MyUhdmListener : public UhdmListener {
  protected:
   void enterModule(const module* object) override {
+    if (visited.find(object) != visited.end()) return;
     CollectLine("Module", object);
     stack_.push(object);
   }
 
   void leaveModule(const module* object) override {
+    if (visited.find(object) != visited.end()) return;
     ASSERT_EQ(stack_.top(), object);
     stack_.pop();
   }
 
   void enterProgram(const program* object) override {
+    if (visited.find(object) != visited.end()) return;
     CollectLine("Program", object);
     stack_.push(object);
   }
 
   void leaveProgram(const program* object) override {
+    if (visited.find(object) != visited.end()) return;
     ASSERT_EQ(stack_.top(), object);
     stack_.pop();
   }


### PR DESCRIPTION
Update to callback logic in UhdmListener

In previous implementation, specific vpiXXX listen invocations were
skipped. This has been found to be a problem since there are cases where
there is only one such edge in the tree and that is being skipped.

Instead, let the client code deal with duplicate callbacks. The visit
container will track all objects that are already stepped-in to avoid
infinite recursion.