### PR TITLE
Revert 82fd37f01e508fb839cb1c02b519bf15d825dd8e: Use filesystem where applicable

### DIFF
--- a/scripts/serializer.py
+++ b/scripts/serializer.py
@@ -73,10 +73,7 @@ def generate(models):
                 Vpi_ = vpi[:1].upper() + vpi[1:]
                 Vpi = Vpi_.replace('_', '')
 
-                if vpi in ['vpiFile', 'vpiDefFile']:
-                    saves_adapters.append(f'    builder.set{Vpi}(serializer->symbolMaker.Make(obj->{Vpi_}().string()));')
-                    restore_adapters.append(f'    obj->{Vpi_}(serializer->symbolMaker.GetSymbol(reader.get{Vpi}()));')
-                elif type in ['string', 'value', 'delay']:
+                if type in ['string', 'value', 'delay']:
                     saves_adapters.append(f'    builder.set{Vpi}(serializer->symbolMaker.Make(obj->{Vpi_}()));')
                     restore_adapters.append(f'    obj->{Vpi_}(serializer->symbolMaker.GetSymbol(reader.get{Vpi}()));')
                 else:

--- a/templates/BaseClass.cpp
+++ b/templates/BaseClass.cpp
@@ -50,9 +50,8 @@ BaseClass::vpi_property_value_t BaseClass::GetVpiPropertyValue(
     case vpiType:
       return vpi_property_value_t(VpiType());
     case vpiFile: {
-      SymbolFactory::ID fileId = VpiFileId();
-      if (fileId != SymbolFactory::getBadId()) {
-        const std::string& file = serializer_->symbolMaker.GetSymbol(fileId);
+      const std::string& file = VpiFile();
+      if (!file.empty()) {
         return vpi_property_value_t(file.c_str());
       }
     } break;

--- a/templates/BaseClass.h
+++ b/templates/BaseClass.h
@@ -28,8 +28,8 @@
 #define UHDM_BASE_CLASS_H
 
 #include <deque>
-#include <filesystem>
 #include <set>
+#include <string>
 #include <string_view>
 #include <tuple>
 #include <variant>
@@ -75,10 +75,9 @@ namespace UHDM {
 
     virtual bool VpiParent(BaseClass* data) = 0;
 
-    virtual std::filesystem::path VpiFile() const = 0;
-    virtual SymbolFactory::ID VpiFileId() const = 0;
+    virtual const std::string& VpiFile() const = 0;
 
-    virtual bool VpiFile(const std::filesystem::path& data) = 0;
+    virtual bool VpiFile(const std::string& data) = 0;
 
     virtual int VpiLineNo() const final { return vpiLineNo_; }
 

--- a/templates/Serializer.cpp
+++ b/templates/Serializer.cpp
@@ -24,6 +24,7 @@
  */
 #include <uhdm/Serializer.h>
 
+#include <algorithm>
 #include <iomanip>
 #include <iostream>
 #include <map>
@@ -97,7 +98,7 @@ void Serializer::PrintStats(std::ostream& strm,
     if (count > 0) {
       // The longest model name is
       // "enum_struct_union_packed_array_typespec_group"
-      strm << std::setw(48) << std::left << name << std::setw(4) << std::right
+      strm << std::setw(48) << std::left << name << std::setw(8) << std::right
            << count << std::endl;
     }
   }

--- a/templates/Serializer.h
+++ b/templates/Serializer.h
@@ -28,6 +28,7 @@
 #define UHDM_SERIALIZER_H
 
 
+#include <filesystem>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -82,11 +83,11 @@ class Serializer {
   }
   ~Serializer();
 
-  void Save(const std::string& file);
+  void Save(const std::filesystem::path& filepath);
   void Purge();
   void SetErrorHandler(ErrorHandler handler) { errorHandler = handler; }
   ErrorHandler GetErrorHandler() { return errorHandler; }
-  const std::vector<vpiHandle> Restore(const std::string& file);
+  const std::vector<vpiHandle> Restore(const std::filesystem::path& filepath);
   std::map<std::string, unsigned long> ObjectStats() const;
   void PrintStats(std::ostream& strm, std::string_view infoText) const;
 

--- a/templates/Serializer_restore.cpp
+++ b/templates/Serializer_restore.cpp
@@ -76,7 +76,7 @@ inline void Serializer::SetRestoreId_(FactoryT<T>* const factory, unsigned long 
 struct Serializer::RestoreAdapter {
   void operator()(Any::Reader reader, Serializer *const serializer, BaseClass *const obj) const {
     obj->VpiParent(serializer->GetObject(reader.getVpiParent().getType(), reader.getVpiParent().getIndex() - 1));
-    obj->VpiFile(std::filesystem::path(serializer->symbolMaker.GetSymbol(reader.getVpiFile())));
+    obj->VpiFile(serializer->symbolMaker.GetSymbol(reader.getVpiFile()));
     obj->VpiLineNo(reader.getVpiLineNo());
     obj->VpiColumnNo(reader.getVpiColumnNo());
     obj->VpiEndLineNo(reader.getVpiEndLineNo());
@@ -94,9 +94,10 @@ struct Serializer::RestoreAdapter {
   }
 };
 
-const std::vector<vpiHandle> Serializer::Restore(const std::string& file) {
+const std::vector<vpiHandle> Serializer::Restore(const std::filesystem::path& filepath) {
   Purge();
   std::vector<vpiHandle> designs;
+  const std::string file = filepath.string();
   int fileid = open(file.c_str(), O_RDONLY | O_BINARY);
   ::capnp::ReaderOptions options;
   options.traversalLimitInWords = ULLONG_MAX;

--- a/templates/Serializer_save.cpp
+++ b/templates/Serializer_save.cpp
@@ -69,7 +69,7 @@ struct Serializer::SaveAdapter {
       vpiParentBuilder.setIndex(serializer->GetId(obj->VpiParent()));
       vpiParentBuilder.setType(obj->VpiParent()->UhdmType());
     }
-    builder.setVpiFile(obj->GetSerializer()->symbolMaker.Make(obj->VpiFile().string()));
+    builder.setVpiFile(obj->GetSerializer()->symbolMaker.Make(obj->VpiFile()));
     builder.setVpiLineNo(obj->VpiLineNo());
     builder.setVpiColumnNo(obj->VpiColumnNo());
     builder.setVpiEndLineNo(obj->VpiEndLineNo());
@@ -87,11 +87,12 @@ struct Serializer::SaveAdapter {
   }
 };
 
-void Serializer::Save(const std::string& file) {
+void Serializer::Save(const std::filesystem::path& filepath) {
   unsigned long index = 0;
 
 <CAPNP_ID>
 
+  const std::string file = filepath.string();
   const int fileid = open(file.c_str(), O_CREAT | O_WRONLY | O_BINARY, S_IRWXU);
   ::capnp::MallocMessageBuilder message;
   UhdmRoot::Builder cap_root = message.initRoot<UhdmRoot>();


### PR DESCRIPTION
Revert 82fd37f01e508fb839cb1c02b519bf15d825dd8e: Use filesystem where applicable

VpiFile is back to string as it doesn't necessarily always represent a legal filesystem path. Widening the scope of what this represents from a specific local filesystem path to cover scenarios like UNC paths and generic resource ids.
