### PR TITLE
The generated UHDM.capnp.h is in generated/src, point -I to it.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ target_include_directories(uhdm SYSTEM PUBLIC
   $<INSTALL_INTERFACE:include>)
 target_include_directories(uhdm PRIVATE
   ${PROJECT_SOURCE_DIR}/third_party/capnproto/c++/src
-  ${PROJECT_SOURCE_DIR}/third_party/UHDM/src)
+  ${GENDIR}/src)
 target_compile_definitions(uhdm
   PUBLIC PLI_DLLISPEC=
   PUBLIC PLI_DLLESPEC=)


### PR DESCRIPTION
The UDHM.capnp.h is included without path in the UHDM.capnp.c++ implementationa as well as in our serializers.
Add that to the needed include path. Currently it only works if we consider an implicit -I.

Also remove include to third_party/UDHM/src, which looks like some copy-paste issue from somewhere else ?