### PR TITLE
Make sure that test-files written are unique between tests.

### DIFF
--- a/tests/module-port_test.cpp
+++ b/tests/module-port_test.cpp
@@ -140,7 +140,8 @@ TEST(Serialization, SerializeModulePortDesign_e2e) {
 
   const std::string orig = designs_to_string(designs);
 
-  const std::string filename = testing::TempDir() + "/serialize-roundrip.uhdm";
+  const std::string filename =
+      testing::TempDir() + "/serialize-module-port-roundrip.uhdm";
   serializer.Save(filename);
 
   const std::vector<vpiHandle>& restoredDesigns = serializer.Restore(filename);

--- a/tests/statement_test.cpp
+++ b/tests/statement_test.cpp
@@ -105,7 +105,8 @@ TEST(Serialization, SerializeStatementDesign_e2e) {
 
   const std::string orig = designs_to_string(designs);
 
-  const std::string filename = testing::TempDir() + "/serialize-roundrip.uhdm";
+  const std::string filename =
+      testing::TempDir() + "/serialize-statement-roundrip.uhdm";
   serializer.Save(filename);
 
   const std::vector<vpiHandle>& restoredDesigns = serializer.Restore(filename);


### PR DESCRIPTION
If testing::TempDir() is the same for all tests (likely), this otherwise can result in collisions if tests are run in parallel.
