### PR TITLE
Accept std::string_view as argument instead of std::string&

### DIFF
--- a/templates/BaseClass.h
+++ b/templates/BaseClass.h
@@ -77,7 +77,7 @@ namespace UHDM {
 
     virtual const std::string& VpiFile() const = 0;
 
-    virtual bool VpiFile(const std::string& data) = 0;
+    virtual bool VpiFile(std::string_view data) = 0;
 
     virtual int VpiLineNo() const final { return vpiLineNo_; }
 

--- a/templates/ExprEval.cpp
+++ b/templates/ExprEval.cpp
@@ -696,14 +696,14 @@ expr *ExprEval::flattenPatternAssignments(Serializer &s, const typespec *tps,
               c->VpiValue("UINT:" + std::to_string(uval));
               c->VpiDecompile(std::to_string(uval));
               c->VpiConstType(vpiUIntConst);
-              c->VpiSize(size);
+              c->VpiSize(static_cast<int>(size));
             } else if (uval == 0) {
               uint64_t size = ExprEval::size(fieldTypes[index], invalidValue,
                                          nullptr, exp, true, true);
               c->VpiValue("UINT:" + std::to_string(uval));
               c->VpiDecompile(std::to_string(uval));
               c->VpiConstType(vpiUIntConst);
-              c->VpiSize(size);
+              c->VpiSize(static_cast<int>(size));
             }
           }
         }


### PR DESCRIPTION
Accept std::string_view as argument instead of std::string&. Also, 
* check for invalid value post reduction before using it.
* fixed a few warning messages.