### PR TITLE
Include vpiDefLineNo & vpiRefXXX in ignore list for uhdm compare

### DIFF
--- a/scripts/classes.py
+++ b/scripts/classes.py
@@ -530,11 +530,17 @@ def _get_Compare_implementation(model):
         'uhdmId',
         'uhdmType',
         'vpiColumnNo',
+        'vpiDefLineNo',
         'vpiEndColumnNo',
         'vpiEndLineNo',
         'vpiFile',
         'vpiFullName',
         'vpiLineNo',
+        'vpiRefColumnNo',
+        'vpiRefEndColumnNo',
+        'vpiRefEndLineNo',
+        'vpiRefFile',
+        'vpiRefLineNo',
     ]
 
     classname = model['name']


### PR DESCRIPTION
Include vpiDefLineNo & vpiRefXXX in ignore list for uhdm compare

Differences in these variable don't make the UHDM tree logically different.