### PR TITLE
Swap out std::strtoxxxx in favor of std::from_chars for portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ set(uhdm-GENERATED_SRC
     ${GENDIR}/src/clone_tree.cpp
     ${GENDIR}/src/ElaboratorListener.cpp
     ${GENDIR}/src/ExprEval.cpp
+    ${GENDIR}/src/NumUtils.cpp
     ${GENDIR}/src/Serializer.cpp
     ${GENDIR}/src/Serializer_restore.cpp
     ${GENDIR}/src/Serializer_save.cpp

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -122,6 +122,8 @@ def _main():
             config.get_template_filepath('ElaboratorListener.h'): config.get_output_header_filepath('ElaboratorListener.h'),
             config.get_template_filepath('ExprEval.h'): config.get_output_header_filepath('ExprEval.h'),
             config.get_template_filepath('ExprEval.cpp'): config.get_output_source_filepath('ExprEval.cpp'),
+            config.get_template_filepath('NumUtils.h'): config.get_output_header_filepath('NumUtils.h'),
+            config.get_template_filepath('NumUtils.cpp'): config.get_output_source_filepath('NumUtils.cpp'),
             config.get_template_filepath('UhdmLint.h'): config.get_output_header_filepath('UhdmLint.h'),
             config.get_template_filepath('UhdmLint.cpp'): config.get_output_source_filepath('UhdmLint.cpp'),
             config.get_template_filepath('UhdmAdjuster.h'): config.get_output_header_filepath('UhdmAdjuster.h'),

--- a/templates/NumUtils.cpp
+++ b/templates/NumUtils.cpp
@@ -1,0 +1,185 @@
+/*
+ Copyright 2019 Alain Dargelas
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/*
+ * File:   NumUtils.cpp
+ * Author: alain
+ *
+ * Created on December 29, 2020, 10:43 PM
+ */
+
+#include <uhdm/NumUtils.h>
+#include <string.h>
+
+#include <algorithm>
+#include <bitset>
+#include <iostream>
+#include <locale>
+#include <regex>
+#include <sstream>
+
+namespace UHDM {
+
+std::string NumUtils::hexToBin(std::string_view s) {
+  std::string out;
+  out.reserve(s.length() * 4);
+  for (auto i : s) {
+    uint8_t n;
+    if ((i <= '9') && (i >= '0'))
+      n = i - '0';
+    else
+      n = 10 + i - 'A';
+    for (int8_t j = 3; j >= 0; --j) out.push_back((n & (1 << j)) ? '1' : '0');
+  }
+  size_t pos = out.find('1');
+  if (pos == std::string::npos)
+    out.clear();
+  else
+    out = out.substr(pos);
+  return out;
+}
+
+std::string NumUtils::binToHex(std::string_view s) {
+  std::string out;
+  out.reserve((s.length() + 3) / 4);
+  for (unsigned int i = 0; i < s.size(); i += 4) {
+    int8_t n = 0;
+    for (unsigned int j = i; j < i + 4; ++j) {
+      n <<= 1;
+      if (s[j] == '1') n |= 1;
+    }
+
+    if (n <= 9)
+      out.push_back('0' + n);
+    else
+      out.push_back('A' + n - 10);
+  }
+  return out;
+}
+
+std::string NumUtils::toBinary(int size, uint64_t val) {
+  int constexpr bitFieldSize = 100;
+  std::string tmp = std::bitset<bitFieldSize>(val).to_string();
+  if (size <= 0) {
+    for (unsigned int i = 0; i < bitFieldSize; i++) {
+      if (tmp[i] == '1') {
+        size = bitFieldSize - i;
+        break;
+      }
+    }
+  }
+  std::string result;
+  result.reserve(bitFieldSize - size + 1);
+  for (unsigned int i = bitFieldSize - size; i < bitFieldSize; i++)
+    result += tmp[i];
+  return result;
+}
+
+uint64_t NumUtils::getMask(uint64_t wide) {
+  uint64_t mask = 0;
+  uint64_t sizeInBits = sizeof(mask) * 8;
+  mask = (wide >= sizeInBits)
+             ? ((uint64_t)-1)
+             : ((uint64_t)((uint64_t)(((uint64_t)1) << ((uint64_t)wide))) -
+                (uint64_t)1);
+  return mask;
+}
+
+/*
+ * So, unfortunately not all c++17 implemenetations actually provide
+ * a std::from_chars() for floating point numbers; available only >= g++-11
+ * for instance.
+ *
+ * So here we use the c++ detection pattern to determine if that function
+ * is available, otherwise fall back to slower best-effort implementation that
+ * copies it to a nul-terminated buffer, then calls the old strtof(), strotd()
+ * functions.
+ */
+template <typename T, typename = void>
+struct from_chars_available : std::false_type {};
+template <typename T>
+struct from_chars_available<
+    T, std::void_t<decltype(std::from_chars(
+           std::declval<const char *>(), std::declval<const char *>(),
+           std::declval<T &>()))>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool from_chars_available_v = from_chars_available<T>::value;
+
+// Copy everything that looks like a number into output iterator.
+static void CopyNumberTo(const char *in_begin, const char *in_end,
+                         char *out_begin, const char *out_end) {
+  const char *src = in_begin;
+  char *dst = out_begin;
+  const char *extra_allowed = "+-.e";
+  bool have_point = false;
+  out_end -= 1;  // Allow space for 0 termination.
+  while ((src < in_end) && (isdigit(*src) || strchr(extra_allowed, *src)) &&
+         (dst < out_end)) {
+    // The sign is only allowed in the first character of the buffer
+    if (((*src == '+') || (*src == '-')) && (dst != out_begin)) break;
+    // only allow one decimal point
+    if (*src == '.') {
+      if (have_point)
+        break;
+      else
+        have_point = true;
+    }
+    *dst++ = *src++;
+  }
+  *dst = '\0';
+}
+
+template <typename T, T (*strto_fallback_fun)(const char *, char **)>
+static const char *strToIeee(std::string_view s, T *result) {
+  // Need to skip whitespace first to not use up our buffer for that.
+  while (!s.empty() && isspace(s.front())) s.remove_prefix(1);
+  if constexpr (from_chars_available_v<T>) {
+    if (!s.empty() && (s.front() == '+')) s.remove_prefix(1);
+    if (s.empty()) return nullptr;
+    auto success = std::from_chars(s.data(), s.data() + s.size(), *result);
+    return (success.ec == std::errc()) ? success.ptr : nullptr;
+  }
+
+  if (s.empty()) return nullptr;
+
+  // Fallback in case std::from_chars() does not exist for this type. Here,
+  // we just call the corresponding C-function, but first have to copy
+  // the number to a local buffer, as that one requires \0-termination.
+  char buffer[64] = {'\0'};
+
+  CopyNumberTo(s.data(), s.data() + s.size(), buffer, buffer + sizeof(buffer));
+  char *endptr = nullptr;
+  *result = strto_fallback_fun(buffer, &endptr);
+  if (endptr == buffer) return nullptr;  // Error.
+
+  // Now, convert our offset back relative to the original string.
+  return s.data() + (endptr - buffer);
+}
+
+const char *NumUtils::parseFloat(std::string_view s, float *result) {
+  return strToIeee<float, strtof>(s, result);
+}
+
+const char *NumUtils::parseDouble(std::string_view s, double *result) {
+  return strToIeee<double, strtod>(s, result);
+}
+
+const char *NumUtils::parseLongDouble(std::string_view s, long double *result) {
+  return strToIeee<long double, strtold>(s, result);
+}
+
+}  // namespace UHDM

--- a/templates/NumUtils.h
+++ b/templates/NumUtils.h
@@ -1,0 +1,193 @@
+/*
+ Copyright 2020 Alain Dargelas
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/*
+ * File:   NumUtils.h
+ * Author: alain
+ *
+ * Created on Dec 29, 2020, 10:43 PM
+ */
+
+#ifndef UHDM_NUMUTILS_H
+#define UHDM_NUMUTILS_H
+#pragma once
+
+#include <cctype>
+#include <charconv>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace UHDM {
+class NumUtils final {
+ private:
+  // These functions parse a number from a std::string_view into "result".
+  // Returns the end of the number on success, nullptr otherwise.
+  // So this can be used in a simple boolean context for success testing, but
+  // as well in parsing context where advancing to the next position after the
+  // number is needed.
+  // All these functions require to check the return value to verify that
+  // parsing worked.
+
+  // Parse any number type with std::from_chars
+  template <typename number_type>
+  static const char* strToNum(std::string_view s, int32_t base,
+                              number_type* result) {
+    while (!s.empty() && std::isspace((int32_t)s.front())) s.remove_prefix(1);
+    if (!s.empty() && (s.front() == '+')) s.remove_prefix(1);
+    if (s.empty()) return nullptr;
+    auto success =
+        std::from_chars(s.data(), s.data() + s.size(), *result, base);
+    return (success.ec == std::errc()) ? success.ptr : nullptr;
+  }
+
+  template <typename sint_type, typename uint_type, typename result_type>
+  static const char* strToInt(std::string_view s, int32_t base,
+                              result_type* result) {
+    // std::from_chars can't deal with leading spaces or plus, so remove them.
+    while (!s.empty() && std::isspace((int32_t)s.front())) s.remove_prefix(1);
+    if (!s.empty() && (s.front() == '+')) s.remove_prefix(1);
+    if (s.empty()) return nullptr;
+    std::from_chars_result parse_result;
+    // Try parsing as signed first
+    sint_type sn = 0;
+    parse_result = std::from_chars(s.data(), s.data() + s.size(), sn, base);
+    if (parse_result.ec == std::errc()) {
+      *result = static_cast<result_type>(sn);
+      return parse_result.ptr;
+    }
+
+    // If the number surely isn't -ve, try parsing as unsigned
+    if ((s.front() != '-') &&
+        (parse_result.ec == std::errc::result_out_of_range)) {
+      uint_type un = 0;
+      parse_result = std::from_chars(s.data(), s.data() + s.size(), un, base);
+      if (parse_result.ec == std::errc()) {
+        *result = static_cast<result_type>(un);
+        return parse_result.ptr;
+      }
+    }
+
+    return nullptr;
+  }
+
+ public:
+  static std::string hexToBin(std::string_view s);
+
+  static std::string binToHex(std::string_view s);
+
+  static std::string toBinary(int size, uint64_t val);
+
+  static uint64_t getMask(uint64_t wide);
+
+  // Parse int values.
+  // Returns the pointer to one char after the parsed value or nullptr on
+  // failure.
+
+  // Parse integer of the given size (int32_t, uint32_t, int64_t, uint64_t),
+  // but be lenient in the sign interpretation.
+  // The full signed negative range and positive unsigned range for the integer
+  // of that size is allowed. The final value is cast to the signed or unsigned
+  // potentially flipping the sign (but we're leniently allowing that).
+  template <typename result_type>
+  [[nodiscard]] inline static const char* parseIntLenient(std::string_view s,
+                                                          result_type* result) {
+    if constexpr (sizeof(result_type) == 4) {
+      return strToInt<int32_t, uint32_t, result_type>(s, 10, result);
+    } else {
+      return strToInt<int64_t, uint64_t, result_type>(s, 10, result);
+    }
+  }
+
+  // Parse signed int32, stricly matching its range
+  [[nodiscard]] inline static const char* parseInt32(std::string_view s,
+                                                     int32_t* result) {
+    return strToNum(s, 10, result);
+  }
+  // Parse uint32, stricly matching its range; no negative numbers
+  [[nodiscard]] inline static const char* parseUint32(std::string_view s,
+                                                      uint32_t* result) {
+    return strToNum(s, 10, result);
+  }
+
+  // Parse signed int64, stricly matching its range; no negative numbers
+  [[nodiscard]] inline static const char* parseInt64(std::string_view s,
+                                                     int64_t* result) {
+    return strToNum(s, 10, result);
+  }
+  // Parse uint64, stricly matching its range; no negative numbers
+  [[nodiscard]] inline static const char* parseUint64(std::string_view s,
+                                                      uint64_t* result) {
+    return strToNum(s, 10, result);
+  }
+
+  template <typename result_type>
+  [[nodiscard]] inline static const char* parseBinary(std::string_view s,
+                                                      result_type* result) {
+    if constexpr (sizeof(result_type) == 4) {
+      return strToInt<int32_t, uint32_t, result_type>(s, 2, result);
+    } else {
+      return strToInt<int64_t, uint64_t, result_type>(s, 2, result);
+    }
+  }
+
+  template <typename result_type>
+  [[nodiscard]] inline static const char* parseOctal(std::string_view s,
+                                                     result_type* result) {
+    if constexpr (sizeof(result_type) == 4) {
+      return strToInt<int32_t, uint32_t, result_type>(s, 8, result);
+    } else {
+      return strToInt<int64_t, uint64_t, result_type>(s, 8, result);
+    }
+  }
+
+  template <typename result_type>
+  [[nodiscard]] inline static const char* parseHex(std::string_view s,
+                                                   result_type* result) {
+    if constexpr (sizeof(result_type) == 4) {
+      return strToInt<int32_t, uint32_t, result_type>(s, 16, result);
+    } else {
+      return strToInt<int64_t, uint64_t, result_type>(s, 16, result);
+    }
+  }
+
+  // Parse float value.
+  // Returns the pointer to one char after the parsed value or nullptr on
+  // failure.
+  [[nodiscard]] static const char* parseFloat(std::string_view s,
+                                              float* result);
+
+  // Parse double value.
+  // Returns the pointer to one char after the parsed value or nullptr on
+  // failure.
+  [[nodiscard]] static const char* parseDouble(std::string_view s,
+                                               double* result);
+
+  // Parse long double value.
+  // Returns the pointer to one char after the parsed value or nullptr on
+  // failure.
+  [[nodiscard]] static const char* parseLongDouble(std::string_view s,
+                                                   long double* result);
+
+ private:
+  NumUtils() = delete;
+  NumUtils(const NumUtils& orig) = delete;
+  ~NumUtils() = delete;
+};
+
+};  // namespace UHDM
+
+#endif /* UHDM_NUMUTILS_H */

--- a/templates/UhdmLint.cpp
+++ b/templates/UhdmLint.cpp
@@ -122,7 +122,7 @@ void UhdmLint::checkMultiContAssign(
       for (auto operand : *op->Operands()) {
         if (operand->UhdmType() == uhdmconstant) {
           constant* c = (constant*)operand;
-          if (strstr(c->VpiValue().c_str(), "z")) {
+          if (c->VpiValue().find('z') != std::string::npos) {
             triStatedOp = true;
             break;
           }
@@ -158,7 +158,7 @@ void UhdmLint::checkMultiContAssign(
             for (auto operand : *op->Operands()) {
               if (operand->UhdmType() == uhdmconstant) {
                 constant* c = (constant*)operand;
-                if (strstr(c->VpiValue().c_str(), "z")) {
+                if (c->VpiValue().find('z') != std::string::npos) {
                   triStatedOp = true;
                   break;
                 }

--- a/templates/vpi_uhdm.h
+++ b/templates/vpi_uhdm.h
@@ -29,6 +29,9 @@
 
 #include <uhdm/uhdm_types.h>
 
+#include <string>
+#include <string_view>
+
 namespace UHDM {
   class Serializer;
   class design;
@@ -61,9 +64,9 @@ class uhdm_handleFactory {
 /** Obtain a vpiHandle from a BaseClass (any) object */
 vpiHandle NewVpiHandle (const UHDM::BaseClass* object);
 
-s_vpi_value* String2VpiValue(const std::string& s);
+s_vpi_value* String2VpiValue(std::string_view sv);
 
-s_vpi_delay* String2VpiDelays(const std::string& s);
+s_vpi_delay* String2VpiDelays(std::string_view sv);
 
 std::string VpiValue2String(const s_vpi_value* value);
 

--- a/tests/vpi_value_conversion_test.cpp
+++ b/tests/vpi_value_conversion_test.cpp
@@ -56,8 +56,11 @@ TEST(VpiValue, ParseValueFindPrefix) {
   // With Whitespace in front.
   EXPECT_EQ(ParseAndRegenerateString("  INT:42"), "INT:42");
 
-  // .. or even other garbage in front.
-  EXPECT_EQ(ParseAndRegenerateString("unrelated stuff:43 INT:42"), "INT:42");
+  // .. or with whitespace at end.
+  EXPECT_EQ(ParseAndRegenerateString("INT:42  "), "INT:42");
+
+  // .. or at both ends.
+  EXPECT_EQ(ParseAndRegenerateString("  INT:42  "), "INT:42");
 }
 
 TEST(VpiValue, ParseScalarValue) {


### PR DESCRIPTION
Swap out std::strtoxxxx in favor of std::from_chars for portability

* Implemented NumUtils to contain all number related utility functions
* Remove use of posix functions like strdup, strstr & strcasecmp (replace with custom implementation as there are no equivalent in C++)
* Some of the vpi functions now accept std::string_view instead of std::string

Known Issues:
Number parsing errors are largely ignored, to keep the behavior the same as previous implementation. Accounting for parse errors results in regression test failures. Will need to revisit these individually as a follow up.