### PR TITLE
Issue #831: Fix compile issues on MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,10 @@ else()
   )
 endif()
 
+if (WIN32)
+  add_compile_definitions(WIN32_LEAN_AND_MEAN)
+endif()
+
 # All the files the generator depends on.
 file(GLOB yaml_SRC ${PROJECT_SOURCE_DIR}/model/*.yaml)
 file(GLOB templates_SRC ${PROJECT_SOURCE_DIR}/templates/*.h

--- a/include/sv_vpi_user.h
+++ b/include/sv_vpi_user.h
@@ -33,7 +33,7 @@ extern "C" {
 
 /****************************** OBJECT TYPES ******************************/
 #define vpiPackage                            600
-#define vpiInterface                          601
+#define vpiInterfaceInst                      601
 #define vpiProgram                            602
 #define vpiInterfaceArray                     603
 #define vpiProgramArray                       604

--- a/include/vpi_user.h
+++ b/include/vpi_user.h
@@ -151,7 +151,7 @@ typedef PLI_UINT32 *vpiHandle;
 #define vpiMemory             29   /* behavioral memory */
 #define vpiMemoryWord         30   /* single word of memory */
 #define vpiModPath            31   /* module path for path delays */
-#define vpiModule             32   /* module instance */
+#define vpiModuleInst         32   /* module instance */
 #define vpiNamedBegin         33   /* named block statement */
 #define vpiNamedEvent         34   /* event variable */
 #define vpiNamedFork          35   /* named fork-join block */

--- a/model/actual_group.yaml
+++ b/model/actual_group.yaml
@@ -16,7 +16,7 @@
 # Parameters, enum_const, io_decl are not in the actual group in the Standard, we add them to the group for binding convenience
  
 - group_def: actual_group
-  - obj_ref: interface
+  - obj_ref: interface_inst
   - obj_ref: interface_array
   - obj_ref: modport
   - class_ref: nets

--- a/model/design.yaml
+++ b/model/design.yaml
@@ -50,8 +50,8 @@
     vpi: uhdmallClasses
     card: any
   - class: allInterfaces
-    type: interface
-    vpi_obj: vpiInterface
+    type: interface_inst
+    vpi_obj: vpiInterfaceInst
     vpi: uhdmallInterfaces
     card: any
   - class: allUdps
@@ -65,8 +65,8 @@
     vpi: uhdmallPrograms
     card: any
   - class: allModules
-    type: module
-    vpi_obj: vpiModule
+    type: module_inst
+    vpi_obj: vpiModuleInst
     vpi: uhdmallModules
     card: any
   - class_ref: typespecs
@@ -94,7 +94,7 @@
     type: param_assign
     card: any
   - class: topModules
-    type: module
-    vpi_obj: vpiModule
+    type: module_inst
+    vpi_obj: vpiModuleInst
     vpi: uhdmtopModules
     card: any

--- a/model/gen_scope.yaml
+++ b/model/gen_scope.yaml
@@ -58,8 +58,8 @@
     card: any
   - obj_ref: modules
     name: modules
-    vpi: vpiModule
-    type: module
+    vpi: vpiModuleInst
+    type: module_inst
     card: any
   - obj_ref: module_arrays
     name: module array
@@ -102,8 +102,8 @@
     card: any
   - obj_ref: interfaces
     name: interface
-    vpi: vpiInterface
-    type: interface
+    vpi: vpiInterfaceInst
+    type: interface_inst
     card: any
   - obj_ref: interface_arrays
     vpi: vpiInterfaceArray

--- a/model/instance.yaml
+++ b/model/instance.yaml
@@ -138,8 +138,8 @@
     card: any
   - obj_ref: module
     name: module
-    vpi: vpiModule
-    type: module
+    vpi: vpiModuleInst
+    type: module_inst
     card: 1
   - class_ref: instance
     name: instance

--- a/model/instance_array.yaml
+++ b/model/instance_array.yaml
@@ -57,8 +57,8 @@
     card: any
   - obj_ref: modules
     name: modules
-    vpi: vpiModule
-    type: module
+    vpi: vpiModuleInst
+    type: module_inst
     card: any
   - class_ref: elem_typespec
     name: elem typespec

--- a/model/interf_prog_mod_group.yaml
+++ b/model/interf_prog_mod_group.yaml
@@ -15,7 +15,6 @@
 # Universal Hardware Data Model (UHDM) "interface program module group" formal description
  
 - group_def: interf_prog_mod_group
-  - obj_ref: module
+  - obj_ref: module_inst
   - obj_ref: program
-  - obj_ref: interface
- 
+  - obj_ref: interface_inst

--- a/model/interface_inst.yaml
+++ b/model/interface_inst.yaml
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Universal Hardware Data Model (UHDM) "interface" formal description
+# Universal Hardware Data Model (UHDM) "interface_inst" formal description
  
-- obj_def: interface
+- obj_def: interface_inst
   - extends: instance
   - property: index
     name: index
@@ -22,7 +22,7 @@
     type: int
     card: 1
   - property: type
-    name: vpiInterface
+    name: vpiInterfaceInst
     vpi: vpiType
     type: unsigned int
     card: 1
@@ -72,8 +72,8 @@
     card: any  
   - obj_ref: interfaces
     name: interface
-    vpi: vpiInterface
-    type: interface
+    vpi: vpiInterfaceInst
+    type: interface_inst
     card: any
   - obj_ref: interface_arrays
     vpi: vpiInterfaceArray

--- a/model/models.lst
+++ b/model/models.lst
@@ -203,10 +203,10 @@ class_defn.yaml
 class_obj.yaml
 class_var.yaml
 instance.yaml
-interface.yaml
+interface_inst.yaml
 program.yaml
 package.yaml
-module.yaml
+module_inst.yaml
 checker_decl.yaml
 checker_inst.yaml
 short_real_typespec.yaml

--- a/model/modport.yaml
+++ b/model/modport.yaml
@@ -27,6 +27,6 @@
     card: any
   - obj_ref: interface
     name: interface
-    vpi: vpiInterface
-    type: interface
+    vpi: vpiInterfaceInst
+    type: interface_inst
     card: 1

--- a/model/module_inst.yaml
+++ b/model/module_inst.yaml
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Universal Hardware Data Model (UHDM) "module" formal description
+# Universal Hardware Data Model (UHDM) "module_inst" formal description
  
-- obj_def: module
+- obj_def: module_inst
   - extends: instance
   - property: index
     name: index
@@ -22,7 +22,7 @@
     type: int
     card: 1
   - property: type
-    name: vpiModule
+    name: vpiModuleInst
     vpi: vpiType
     type: unsigned int
     card: 1
@@ -68,8 +68,8 @@
     card: any
   - obj_ref: interfaces
     name: interface
-    vpi: vpiInterface
-    type: interface
+    vpi: vpiInterfaceInst
+    type: interface_inst
     card: any
   - obj_ref: interface_arrays
     vpi: vpiInterfaceArray
@@ -83,8 +83,8 @@
     card: any
   - obj_ref: modules
     name: modules
-    vpi: vpiModule
-    type: module
+    vpi: vpiModuleInst
+    type: module_inst
     card: any
   - obj_ref: module_arrays
     name: module array

--- a/model/nets.yaml
+++ b/model/nets.yaml
@@ -158,6 +158,6 @@
     card: 1
   - obj_ref: module
     name: module
-    vpi: vpiModule
-    type: module
+    vpi: vpiModuleInst
+    type: module_inst
     card: 1

--- a/model/ports.yaml
+++ b/model/ports.yaml
@@ -82,6 +82,6 @@
     card: 1
   - obj_ref: module
     name: module
-    vpi: vpiModule
-    type: module
+    vpi: vpiModuleInst
+    type: module_inst
     card: 1

--- a/model/process_stmt.yaml
+++ b/model/process_stmt.yaml
@@ -22,8 +22,8 @@
     card: 1
   - obj_ref: module
     name: module
-    vpi: vpiModule
-    type: module
+    vpi: vpiModuleInst
+    type: module_inst
     card: 1
   - obj_ref: attributes
     name: attributes

--- a/model/program.yaml
+++ b/model/program.yaml
@@ -38,8 +38,8 @@
     card: 1
   - obj_ref: interfaces
     name: interface
-    vpi: vpiInterface
-    type: interface
+    vpi: vpiInterfaceInst
+    type: interface_inst
     card: any
   - group_ref: expr_dist
     name: expr distribution

--- a/model/tchk.yaml
+++ b/model/tchk.yaml
@@ -17,8 +17,8 @@
 - obj_def: tchk
   - obj_ref: module
     name: module
-    type: module
-    vpi: vpiModule
+    type: module_inst
+    vpi: vpiModuleInst
     card: 1
   - class_ref: expr
     name: expr

--- a/model/test.yaml
+++ b/model/test.yaml
@@ -27,12 +27,12 @@
     vpi: vpiTopModule
     card: 1
   - obj_ref: modules
-    vpi: vpiModule
-    type: module
+    vpi: vpiModuleInst
+    type: module_inst
     card: any
 
 - obj_def: design
   - class: uhdmAllModules
-    type: module
-    vpi_obj: vpiModule
+    type: module_inst
+    vpi_obj: vpiModuleInst
     card: any

--- a/model/variables.yaml
+++ b/model/variables.yaml
@@ -118,8 +118,8 @@
     card: 1
   - obj_ref: module
     name: module
-    vpi: vpiModule
-    type: module
+    vpi: vpiModuleInst
+    type: module_inst
     card: 1
   - class_ref: instance
     name: instance

--- a/scripts/ElaboratorListener_cpp.py
+++ b/scripts/ElaboratorListener_cpp.py
@@ -188,8 +188,8 @@ def _generate_class_listeners(models):
 
 
 def generate(models):
-    module_listeners = _generate_module_listeners(models, 'module')
-    interface_listeners = _generate_module_listeners(models, 'interface')
+    module_listeners = _generate_module_listeners(models, 'module_inst')
+    interface_listeners = _generate_module_listeners(models, 'interface_inst')
     class_listeners = _generate_class_listeners(models)
 
     with open(config.get_template_filepath('ElaboratorListener.cpp'), 'rt') as strm:

--- a/scripts/VpiListener.py
+++ b/scripts/VpiListener.py
@@ -6,8 +6,8 @@ def _get_listeners(classname, vpi, type, card):
     listeners = []
 
     if card == '1':
-        # upward vpiModule, vpiInterface relation (when card == 1, pointing to the parent object) creates loops in visitors
-        if vpi in ['vpiParent', 'vpiInstance', 'vpiModule', 'vpiInterface', 'vpiUse', 'vpiProgram', 'vpiClassDefn', 'vpiPackage', 'vpiUdp']:
+        # upward vpiModuleInst, vpiInterfaceInst relation (when card == 1, pointing to the parent object) creates loops in visitors
+        if vpi in ['vpiParent', 'vpiInstance', 'vpiModuleInst', 'vpiInterfaceInst', 'vpiUse', 'vpiProgram', 'vpiClassDefn', 'vpiPackage', 'vpiUdp']:
             return listeners
 
         if 'func_call' in classname and vpi == 'vpiFunction':

--- a/scripts/classes.py
+++ b/scripts/classes.py
@@ -288,8 +288,8 @@ def _get_DeepClone_implementation(model, models):
                     content.append( '    clone->Instance(inst);')
 
                 elif method == 'Module':
-                    includes.add('module')
-                    content.append(f'  if (auto obj = {method}()) clone->{method}((module*) obj);')
+                    includes.add('module_inst')
+                    content.append(f'  if (auto obj = {method}()) clone->{method}((module_inst*) obj);')
 
                 elif method == 'Typespec':
                     includes.add('typespec')

--- a/scripts/vpi_visitor_cpp.py
+++ b/scripts/vpi_visitor_cpp.py
@@ -9,7 +9,7 @@ def _get_implementation(classname, vpi, card):
     if card == '1':
         shallow_visit = 'false'
 
-        if vpi in ['vpiParent', 'vpiInstance', 'vpiModule', 'vpiInterface', 'vpiUse', 'vpiProgram', 'vpiClassDefn', 'vpiPackage', 'vpiUdp']:
+        if vpi in ['vpiParent', 'vpiInstance', 'vpiModuleInst', 'vpiInterfaceInst', 'vpiUse', 'vpiProgram', 'vpiClassDefn', 'vpiPackage', 'vpiUdp']:
             # Prevent walking upwards and makes the UHDM output cleaner
             # Prevent loop in Standard VPI
             shallow_visit = 'true'

--- a/templates/ElaboratorListener.cpp
+++ b/templates/ElaboratorListener.cpp
@@ -145,14 +145,14 @@ static std::string& ltrim(std::string& str, char c) {
   return str;
 }
 
-void ElaboratorListener::enterModule(const module* object, vpiHandle handle) {
+void ElaboratorListener::enterModule_inst(const module_inst* object, vpiHandle handle) {
   bool topLevelModule = object->VpiTopModule();
   const std::string& instName = object->VpiName();
   const std::string& defName = object->VpiDefName();
   bool flatModule =
       (instName == "") && ((object->VpiParent() == 0) ||
                            ((object->VpiParent() != 0) &&
-                            (object->VpiParent()->VpiType() != vpiModule)));
+                            (object->VpiParent()->VpiType() != vpiModuleInst)));
   // false when it is a module in a hierachy tree
   if (debug_)
     std::cout << "Module: " << defName << " (" << instName
@@ -188,7 +188,7 @@ void ElaboratorListener::enterModule(const module* object, vpiHandle handle) {
     }
 
     if (object->Interfaces()) {
-      for (interface* inter : *object->Interfaces()) {
+      for (interface_inst* inter : *object->Interfaces()) {
         netMap.emplace(inter->VpiName(), inter);
       }
     }
@@ -295,8 +295,8 @@ void ElaboratorListener::enterModule(const module* object, vpiHandle handle) {
       const BaseClass* comp = (*itrDef).second;
       int compType = comp->VpiType();
       switch (compType) {
-        case vpiModule: {
-          module* defMod = (module*)comp;
+        case vpiModuleInst: {
+          module_inst* defMod = (module_inst*)comp;
           if (defMod->Typespecs()) {
             for (typespec* tps : *defMod->Typespecs()) {
               if (tps->UhdmType() == uhdmenum_typespec) {
@@ -326,7 +326,7 @@ void ElaboratorListener::enterModule(const module* object, vpiHandle handle) {
     modMap.emplace(modName, object);
 
     if (object->Modules()) {
-      for (module* mod : *object->Modules()) {
+      for (module_inst* mod : *object->Modules()) {
         modMap.emplace(mod->VpiName(), mod);
       }
     }
@@ -356,19 +356,19 @@ void ElaboratorListener::enterModule(const module* object, vpiHandle handle) {
                             std::make_tuple(netMap, paramMap, funcMap, modMap));
   }
   if (muteErrors_ == false) {
-    elabModule(object, handle);
+    elabModule_inst(object, handle);
   }
 }
 
-void ElaboratorListener::elabModule(const module* object, vpiHandle handle) {
-  module* inst = const_cast<module*>(object);
+void ElaboratorListener::elabModule_inst(const module_inst* object, vpiHandle handle) {
+  module_inst* inst = const_cast<module_inst*>(object);
   bool topLevelModule = object->VpiTopModule();
   const std::string& instName = object->VpiName();
   const std::string& defName = object->VpiDefName();
   bool flatModule =
       (instName == "") && ((object->VpiParent() == 0) ||
                            ((object->VpiParent() != 0) &&
-                            (object->VpiParent()->VpiType() != vpiModule)));
+                            (object->VpiParent()->VpiType() != vpiModuleInst)));
   // false when it is a module in a hierachy tree
   if (debug_)
     std::cout << "Module: " << defName << " (" << instName
@@ -391,8 +391,8 @@ void ElaboratorListener::elabModule(const module* object, vpiHandle handle) {
       const BaseClass* comp = (*itrDef).second;
       int compType = comp->VpiType();
       switch (compType) {
-        case vpiModule: {
-          module* defMod = (module*)comp;
+        case vpiModuleInst: {
+          module_inst* defMod = (module_inst*)comp;
           if (clone_) {
             <MODULE_ELABORATOR_LISTENER>
           }
@@ -405,7 +405,7 @@ void ElaboratorListener::elabModule(const module* object, vpiHandle handle) {
   }
 }
 
-void ElaboratorListener::leaveModule(const module* object, vpiHandle handle) {
+void ElaboratorListener::leaveModule_inst(const module_inst* object, vpiHandle handle) {
   bindScheduledTaskFunc();
   if (inHierarchy_ && !instStack_.empty() && (instStack_.back().first == object)) {
     instStack_.pop_back();
@@ -577,14 +577,14 @@ void ElaboratorListener::leaveClass_defn(const class_defn* object,
   }
 }
 
-void ElaboratorListener::enterInterface(const interface* object,
-                                        vpiHandle handle) {
+void ElaboratorListener::enterInterface_inst(const interface_inst* object,
+                                             vpiHandle handle) {
   const std::string& instName = object->VpiName();
   const std::string& defName = object->VpiDefName();
   bool flatModule =
       (instName == "") && ((object->VpiParent() == 0) ||
                            ((object->VpiParent() != 0) &&
-                            (object->VpiParent()->VpiType() != vpiModule)));
+                            (object->VpiParent()->VpiType() != vpiModuleInst)));
   // false when it is an interface in a hierachy tree
   if (debug_)
     std::cout << "Module: " << defName << " (" << instName
@@ -624,7 +624,7 @@ void ElaboratorListener::enterInterface(const interface* object,
     }
 
     if (object->Interfaces()) {
-      for (interface* inter : *object->Interfaces()) {
+      for (interface_inst* inter : *object->Interfaces()) {
         netMap.emplace(inter->VpiName(), inter);
       }
     }
@@ -690,8 +690,8 @@ void ElaboratorListener::enterInterface(const interface* object,
       const BaseClass* comp = (*itrDef).second;
       int compType = comp->VpiType();
       switch (compType) {
-        case vpiModule: {
-          module* defMod = (module*)comp;
+        case vpiModuleInst: {
+          module_inst* defMod = (module_inst*)comp;
           if (defMod->Typespecs()) {
             for (typespec* tps : *defMod->Typespecs()) {
               if (tps->UhdmType() == uhdmenum_typespec) {
@@ -739,7 +739,7 @@ void ElaboratorListener::enterInterface(const interface* object,
       const BaseClass* comp = (*itrDef).second;
       int compType = comp->VpiType();
       switch (compType) {
-        case vpiInterface: {
+        case vpiInterfaceInst: {
           //  interface* defMod = (interface*)comp;
           if (clone_) {
             // Don't activate yet  <INTERFACE//regexp
@@ -756,8 +756,8 @@ void ElaboratorListener::enterInterface(const interface* object,
   }
 }
 
-void ElaboratorListener::leaveInterface(const interface* object,
-                                        vpiHandle handle) {
+void ElaboratorListener::leaveInterface_inst(const interface_inst* object,
+                                             vpiHandle handle) {
   bindScheduledTaskFunc();
   if (!instStack_.empty() && (instStack_.back().first == object)) {
     instStack_.pop_back();

--- a/templates/ElaboratorListener.h
+++ b/templates/ElaboratorListener.h
@@ -78,12 +78,12 @@ class ElaboratorListener final : public VpiListener {
 
   void leaveDesign(const design* object, vpiHandle handle) final;
 
-  void enterModule(const module* object, vpiHandle handle) final;
-  void elabModule(const module* object, vpiHandle handle);
-  void leaveModule(const module* object, vpiHandle handle) final;
+  void enterModule_inst(const module_inst* object, vpiHandle handle) final;
+  void elabModule_inst(const module_inst* object, vpiHandle handle);
+  void leaveModule_inst(const module_inst* object, vpiHandle handle) final;
 
-  void enterInterface(const interface* object, vpiHandle handle) final;
-  void leaveInterface(const interface* object, vpiHandle handle) final;
+  void enterInterface_inst(const interface_inst* object, vpiHandle handle) final;
+  void leaveInterface_inst(const interface_inst* object, vpiHandle handle) final;
 
   void enterPackage(const package* object, vpiHandle handle) final;
   void leavePackage(const package* object, vpiHandle handle) final;

--- a/templates/ExprEval.cpp
+++ b/templates/ExprEval.cpp
@@ -4174,7 +4174,7 @@ expr *ExprEval::evalFunc(UHDM::function *func, std::vector<any *> *args,
   const std::string name = func->VpiName();
   // set internal scope stack
   Scopes scopes;
-  module *scope = s.MakeModule();
+  module_inst *scope = s.MakeModule_inst();
   scope->VpiParent((any *)inst);
   if (const instance *pack = func->Instance()) {
     scope->Task_funcs(pack->Task_funcs());

--- a/templates/UhdmAdjuster.cpp
+++ b/templates/UhdmAdjuster.cpp
@@ -75,7 +75,7 @@ const any* UhdmAdjuster::resize(const any* object, int maxsize, bool is_overall_
   } else if (type == uhdmlogic_net) {
     const any* parent = result->VpiParent();
     if (parent && (parent->UhdmType() == uhdmmodule)) {
-      module* mod = (module*)parent;
+      module_inst* mod = (module_inst*)parent;
       if (mod->Cont_assigns()) {
         for (cont_assign* cass : *mod->Cont_assigns()) {
           if (cass->Lhs()->VpiName() == result->VpiName()) {
@@ -141,7 +141,7 @@ void UhdmAdjuster::leaveCase_stmt(const case_stmt* object, vpiHandle handle) {
       } else if (type == uhdmlogic_net) {
         const any* parent = exp->VpiParent();
         if (parent && (parent->UhdmType() == uhdmmodule)) {
-          module* mod = (module*)parent;
+          module_inst* mod = (module_inst*)parent;
           if (mod->Cont_assigns()) {
             for (cont_assign* cass : *mod->Cont_assigns()) {
               if (cass->Lhs()->VpiName() == exp->VpiName()) {

--- a/templates/UhdmLint.cpp
+++ b/templates/UhdmLint.cpp
@@ -104,7 +104,7 @@ void UhdmLint::leaveStruct_typespec(const struct_typespec* object,
   }
 }
 
-void UhdmLint::leaveModule(const module* object, vpiHandle handle) {
+void UhdmLint::leaveModule_inst(const module_inst* object, vpiHandle handle) {
   if (auto assigns = object->Cont_assigns()) {
     checkMultiContAssign(assigns);
   }

--- a/templates/UhdmLint.h
+++ b/templates/UhdmLint.h
@@ -43,7 +43,7 @@ class UhdmLint final : public VpiListener {
   void leaveStruct_typespec(const struct_typespec* object,
                             vpiHandle handle) override;
 
-  void leaveModule(const module* object, vpiHandle handle) override;
+  void leaveModule_inst(const module_inst* object, vpiHandle handle) override;
 
   void leaveAssignment(const assignment* object, vpiHandle handle) override;
 

--- a/templates/clone_tree.cpp
+++ b/templates/clone_tree.cpp
@@ -1317,7 +1317,7 @@ hier_path* hier_path::DeepClone(Serializer* serializer,
                 break;
               }
               case uhdmmodule: {
-                module* mod = (module*)actual;
+                module_inst* mod = (module_inst*)actual;
                 if (mod->Variables()) {
                   for (variables* var : *mod->Variables()) {
                     if (var->VpiName() == name) {
@@ -1463,7 +1463,7 @@ hier_path* hier_path::DeepClone(Serializer* serializer,
                 break;
               }
               case uhdminterface: {
-                interface* interf = (interface*)actual;
+                interface_inst* interf = (interface_inst*)actual;
                 if (interf->Variables()) {
                   for (variables* var : *interf->Variables()) {
                     if (var->VpiName() == name) {
@@ -1912,7 +1912,7 @@ hier_path* hier_path::DeepClone(Serializer* serializer,
             }
           }
         } else if (previous->UhdmType() == uhdmmodule) {
-          module* mod = (module*)previous;
+          module_inst* mod = (module_inst*)previous;
           if (mod->Variables()) {
             for (variables* var : *mod->Variables()) {
               if (var->VpiName() == name) {

--- a/templates/vpi_visitor.cpp
+++ b/templates/vpi_visitor.cpp
@@ -391,7 +391,7 @@ static std::string vpiTypeName(vpiHandle h) {
     case 24: return "vpiInitial";
     case 600: return "vpiPackage";
     case 25: return "vpiIntegerVar";
-    case 601: return "vpiInterface";
+    case 601: return "vpiInterfaceInst";
     case 26: return "vpiInterModPath";
     case 602: return "vpiProgram";
     case 27: return "vpiIterator";
@@ -403,7 +403,7 @@ static std::string vpiTypeName(vpiHandle h) {
     case 605: return "vpiTypespec";
     case 31: return "vpiModPath";
     case 606: return "vpiModport";
-    case 32: return "vpiModule";
+    case 32: return "vpiModuleInst";
     case 607: return "vpiInterfaceTfDecl";
     case 33: return "vpiNamedBegin";
     case 608: return "vpiRefObj";
@@ -544,9 +544,9 @@ void visit_object(vpiHandle obj_h, int indent, const char *relation, VisitedCont
 
 #endif
 
-    if ((objectType == vpiModule) || (objectType == vpiProgram) ||
+    if ((objectType == vpiModuleInst) || (objectType == vpiProgram) ||
         (objectType == vpiClassDefn) || (objectType == vpiPackage) ||
-        (objectType == vpiInterface) || (objectType == vpiUdp) ||
+        (objectType == vpiInterfaceInst) || (objectType == vpiUdp) ||
         (objectType == vpiIncludeFileInfo)) {
       if (const char* s = vpi_get_str(vpiFile, obj_h)) {
         out << ", file:" << s;  // fileName

--- a/tests/classes_test.cpp
+++ b/tests/classes_test.cpp
@@ -17,13 +17,13 @@ static std::vector<vpiHandle> build_designs(Serializer* s) {
   design* d = s->MakeDesign();
   d->VpiName("design1");
   // Module
-  module* m1 = s->MakeModule();
+  module_inst* m1 = s->MakeModule_inst();
   m1->VpiTopModule(true);
   m1->VpiDefName("M1");
   m1->VpiParent(d);
   m1->VpiFile("fake1.sv");
   m1->VpiLineNo(10);
-  VectorOfmodule* v1 = s->MakeModuleVec();
+  VectorOfmodule_inst* v1 = s->MakeModule_instVec();
   v1->push_back(m1);
   d->AllModules(v1);
 
@@ -94,7 +94,7 @@ static std::vector<vpiHandle> build_designs(Serializer* s) {
   f3->Stmt(fcall);
   fcall2->VpiName("f1");  // parent class function
 
-  VectorOfmodule* topModules = s->MakeModuleVec();
+  VectorOfmodule_inst* topModules = s->MakeModule_instVec();
   d->TopModules(topModules);
   topModules->push_back(m1);
 

--- a/tests/error-handler_test.cpp
+++ b/tests/error-handler_test.cpp
@@ -15,13 +15,13 @@ static std::vector<vpiHandle> build_designs(Serializer* s) {
   // Design building
   design* d = s->MakeDesign();
   d->VpiName("design3");
-  module* m1 = s->MakeModule();
+  module_inst* m1 = s->MakeModule_inst();
   m1->VpiTopModule(true);
   m1->VpiDefName("M1");
   m1->VpiParent(d);
   m1->VpiFile("fake1.sv");
   m1->VpiLineNo(10);
-  module* m2 = s->MakeModule();
+  module_inst* m2 = s->MakeModule_inst();
   m2->VpiDefName("M2");
   m2->VpiName("u1");
   m2->VpiFullName("M1.u1");
@@ -69,7 +69,7 @@ static std::vector<vpiHandle> build_designs(Serializer* s) {
   begin_block->Stmts(statements);
   m2->Process(processes);
 
-  module* m3 = s->MakeModule();
+  module_inst* m3 = s->MakeModule_inst();
   m3->VpiDefName("M3");
   m3->VpiName("u2");
   m3->VpiFullName("M1.u2");
@@ -78,10 +78,10 @@ static std::vector<vpiHandle> build_designs(Serializer* s) {
   m3->Module(m1);
   m3->VpiFile("fake3.sv");
   m3->VpiLineNo(30);
-  VectorOfmodule* v1 = s->MakeModuleVec();
+  VectorOfmodule_inst* v1 = s->MakeModule_instVec();
   v1->push_back(m1);
   d->AllModules(v1);
-  VectorOfmodule* v2 = s->MakeModuleVec();
+  VectorOfmodule_inst* v2 = s->MakeModule_instVec();
   v2->push_back(m2);
   v2->push_back(m3);
   m1->Modules(v2);

--- a/tests/expr_reduce_test.cpp
+++ b/tests/expr_reduce_test.cpp
@@ -54,7 +54,7 @@ std::vector<vpiHandle> build_designs(Serializer* s) {
 
   //-------------------------------------------
   // Module definition M1 (non elaborated)
-  module* m1 = s->MakeModule();
+  module_inst* m1 = s->MakeModule_inst();
   {
     m1->VpiDefName("M1");
     m1->VpiParent(d);
@@ -83,7 +83,7 @@ std::vector<vpiHandle> build_designs(Serializer* s) {
     m1->Param_assigns()->push_back(pass);
   }
 
-  VectorOfmodule* topModules = s->MakeModuleVec();
+  VectorOfmodule_inst* topModules = s->MakeModule_instVec();
   d->TopModules(topModules);
   topModules->push_back(m1);
 

--- a/tests/full_elab_test.cpp
+++ b/tests/full_elab_test.cpp
@@ -55,7 +55,7 @@ std::vector<vpiHandle> build_designs(Serializer* s) {
 
   //-------------------------------------------
   // Module definition M1 (non elaborated)
-  module* m1 = s->MakeModule();
+  module_inst* m1 = s->MakeModule_inst();
   {
     m1->VpiDefName("M1");
     m1->VpiParent(d);
@@ -65,7 +65,7 @@ std::vector<vpiHandle> build_designs(Serializer* s) {
 
   //-------------------------------------------
   // Module definition M2 (non elaborated)
-  module* m2 = s->MakeModule();
+  module_inst* m2 = s->MakeModule_inst();
   {
     m2->VpiDefName("M2");
     m2->VpiFile("fake2.sv");
@@ -108,8 +108,8 @@ std::vector<vpiHandle> build_designs(Serializer* s) {
   //-------------------------------------------
   // Instance tree (Elaborated tree)
   // Top level module
-  module* m3 = s->MakeModule();
-  VectorOfmodule* v1 = s->MakeModuleVec();
+  module_inst* m3 = s->MakeModule_inst();
+  VectorOfmodule_inst* v1 = s->MakeModule_instVec();
   {
     m3->VpiDefName("M1");  // Points to the module def (by name)
     m3->VpiName("M1");     // Instance name
@@ -120,7 +120,7 @@ std::vector<vpiHandle> build_designs(Serializer* s) {
 
   //-------------------------------------------
   // Sub Instance
-  module* m4 = s->MakeModule();
+  module_inst* m4 = s->MakeModule_inst();
   {
     m4->VpiDefName("M2");         // Points to the module def (by name)
     m4->VpiName("inst1");         // Instance name
@@ -160,12 +160,12 @@ std::vector<vpiHandle> build_designs(Serializer* s) {
 
   //-------------------------------------------
   // Create both non-elaborated and elaborated lists
-  VectorOfmodule* allModules = s->MakeModuleVec();
+  VectorOfmodule_inst* allModules = s->MakeModule_instVec();
   d->AllModules(allModules);
   allModules->push_back(m1);
   allModules->push_back(m2);
 
-  VectorOfmodule* topModules = s->MakeModuleVec();
+  VectorOfmodule_inst* topModules = s->MakeModule_instVec();
   d->TopModules(topModules);
   topModules->push_back(
       m3);  // Only m3 goes there as it is the top level module
@@ -202,7 +202,7 @@ TEST(FullElabTest, ElaborationRoundtrip) {
             "cont_assign 1\n"
             "design 1\n"
             "logic_net 4\n"
-            "module 4\n"
+            "module_inst 4\n"
             "port 4\n"
             "ref_obj 4\n");
 

--- a/tests/garbage_collect_test.cpp
+++ b/tests/garbage_collect_test.cpp
@@ -17,17 +17,17 @@ static std::vector<vpiHandle> build_designs(Serializer* s) {
   d->VpiName("design1");
 
   // Module
-  module* m1 = s->MakeModule();
+  module_inst* m1 = s->MakeModule_inst();
   m1->VpiTopModule(true);
   m1->VpiDefName("M1");
   m1->VpiParent(d);
 
   // Module
-  module* m2 = s->MakeModule();
+  module_inst* m2 = s->MakeModule_inst();
   m2->VpiDefName("M2");
   m2->VpiName("u1");
 
-  VectorOfmodule* v1 = s->MakeModuleVec();
+  VectorOfmodule_inst* v1 = s->MakeModule_instVec();
   v1->push_back(m1);
   d->TopModules(v1);
 

--- a/tests/group_membership_test.cpp
+++ b/tests/group_membership_test.cpp
@@ -40,7 +40,7 @@ TEST(GroupTest, Membership) {
   VectorOfany* exprs = s.MakeAnyVec();
   constant* legal = s.MakeConstant();
   exprs->push_back(legal);
-  module* illegal = s.MakeModule();
+  module_inst* illegal = s.MakeModule_inst();
   inst->Named_event_sequence_expr_groups(exprs);
   VectorOfany* all_legal = inst->Named_event_sequence_expr_groups();
   EXPECT_EQ(all_legal->size(), 1);

--- a/tests/module-port_test.cpp
+++ b/tests/module-port_test.cpp
@@ -27,7 +27,7 @@ static std::vector<vpiHandle> buildModulePortDesign(Serializer* s) {
   design* d = s->MakeDesign();
   d->VpiName("design1");
   // Module
-  module* m1 = s->MakeModule();
+  module_inst* m1 = s->MakeModule_inst();
   m1->VpiTopModule(true);
   m1->VpiDefName("M1");
   m1->VpiFullName("top::M1");
@@ -42,7 +42,7 @@ static std::vector<vpiHandle> buildModulePortDesign(Serializer* s) {
   lvar->VpiFullName("top::M1::v1");
 
   // Module
-  module* m2 = s->MakeModule();
+  module_inst* m2 = s->MakeModule_inst();
   m2->VpiDefName("M2");
   m2->VpiName("u1");
   m2->VpiParent(m1);
@@ -62,7 +62,7 @@ static std::vector<vpiHandle> buildModulePortDesign(Serializer* s) {
   m2->Ports(vp);
 
   // Module
-  module* m3 = s->MakeModule();
+  module_inst* m3 = s->MakeModule_inst();
   m3->VpiDefName("M3");
   m3->VpiName("u2");
   m3->VpiParent(m1);
@@ -70,16 +70,16 @@ static std::vector<vpiHandle> buildModulePortDesign(Serializer* s) {
   m3->VpiLineNo(30);
 
   // Instance
-  module* m4 = s->MakeModule();
+  module_inst* m4 = s->MakeModule_inst();
   m4->VpiDefName("M4");
   m4->VpiName("u3");
   m4->Ports(vp);
   m4->VpiParent(m3);
   m4->Instance(m3);
-  VectorOfmodule* v1 = s->MakeModuleVec();
+  VectorOfmodule_inst* v1 = s->MakeModule_instVec();
   v1->push_back(m1);
   d->AllModules(v1);
-  VectorOfmodule* v2 = s->MakeModuleVec();
+  VectorOfmodule_inst* v2 = s->MakeModule_instVec();
   v2->push_back(m2);
   v2->push_back(m3);
   m1->Modules(v2);

--- a/tests/process_test.cpp
+++ b/tests/process_test.cpp
@@ -19,7 +19,7 @@ static std::vector<vpiHandle> buildSimpleAlawysDesign(Serializer* s) {
   // Design building
   design* d = s->MakeDesign();
   d->VpiName("design_process");
-  module* m1 = s->MakeModule();
+  module_inst* m1 = s->MakeModule_inst();
   m1->VpiTopModule(true);
   m1->VpiDefName("M1");
   m1->VpiName("u1");
@@ -65,7 +65,7 @@ static std::vector<vpiHandle> buildSimpleAlawysDesign(Serializer* s) {
   begin_block->Stmts(statements);
   m1->Process(processes);
 
-  VectorOfmodule* v1 = s->MakeModuleVec();
+  VectorOfmodule_inst* v1 = s->MakeModule_instVec();
   v1->push_back(m1);
   d->AllModules(v1);
   package* p1 = s->MakePackage();

--- a/tests/statement_test.cpp
+++ b/tests/statement_test.cpp
@@ -18,13 +18,13 @@ static std::vector<vpiHandle> buildStatementDesign(Serializer* s) {
   // Design building
   design* d = s->MakeDesign();
   d->VpiName("design3");
-  module* m1 = s->MakeModule();
+  module_inst* m1 = s->MakeModule_inst();
   m1->VpiTopModule(true);
   m1->VpiDefName("M1");
   m1->VpiParent(d);
   m1->VpiFile("fake1.sv");
   m1->VpiLineNo(10);
-  module* m2 = s->MakeModule();
+  module_inst* m2 = s->MakeModule_inst();
   m2->VpiDefName("M2");
   m2->VpiName("u1");
   m2->VpiFullName("M1.u1");
@@ -73,7 +73,7 @@ static std::vector<vpiHandle> buildStatementDesign(Serializer* s) {
   begin_block->Stmts(statements);
   m2->Process(processes);
 
-  module* m3 = s->MakeModule();
+  module_inst* m3 = s->MakeModule_inst();
   m3->VpiDefName("M3");
   m3->VpiName("u2");
   m3->VpiFullName("M1.u2");
@@ -82,10 +82,10 @@ static std::vector<vpiHandle> buildStatementDesign(Serializer* s) {
   m3->Module(m1);
   m3->VpiFile("fake3.sv");
   m3->VpiLineNo(30);
-  VectorOfmodule* v1 = s->MakeModuleVec();
+  VectorOfmodule_inst* v1 = s->MakeModule_instVec();
   v1->push_back(m1);
   d->AllModules(v1);
-  VectorOfmodule* v2 = s->MakeModuleVec();
+  VectorOfmodule_inst* v2 = s->MakeModule_instVec();
   v2->push_back(m2);
   v2->push_back(m3);
   m1->Modules(v2);

--- a/tests/tf_call_test.cpp
+++ b/tests/tf_call_test.cpp
@@ -13,7 +13,7 @@ static std::vector<vpiHandle> build_tfCallDesign(Serializer* s) {
   // Design building
   design* d = s->MakeDesign();
   d->VpiName("designTF");
-  module* m1 = s->MakeModule();
+  module_inst* m1 = s->MakeModule_inst();
   m1->VpiTopModule(true);
   m1->VpiDefName("M1");
   m1->VpiParent(d);
@@ -56,7 +56,7 @@ static std::vector<vpiHandle> build_tfCallDesign(Serializer* s) {
   begin_block->Stmts(statements);
   m1->Process(processes);
 
-  VectorOfmodule* v1 = s->MakeModuleVec();
+  VectorOfmodule_inst* v1 = s->MakeModule_instVec();
   v1->push_back(m1);
   d->AllModules(v1);
 

--- a/tests/uhdm_listener_test.cpp
+++ b/tests/uhdm_listener_test.cpp
@@ -15,13 +15,13 @@ using testing::ElementsAre;
 
 class MyUhdmListener : public UhdmListener {
  protected:
-  void enterModule(const module* object) override {
+  void enterModule_inst(const module_inst* object) override {
     if (visited.find(object) != visited.end()) return;
     CollectLine("Module", object);
     stack_.push(object);
   }
 
-  void leaveModule(const module* object) override {
+  void leaveModule_inst(const module_inst* object) override {
     if (visited.find(object) != visited.end()) return;
     ASSERT_EQ(stack_.top(), object);
     stack_.pop();
@@ -61,36 +61,36 @@ static design* buildModuleProg(Serializer* s) {
   design* d = s->MakeDesign();
   d->VpiName("design1");
   // Module
-  module* m1 = s->MakeModule();
+  module_inst* m1 = s->MakeModule_inst();
   m1->VpiTopModule(true);
   m1->VpiDefName("M1");
   m1->VpiFullName("top::M1");
   m1->VpiParent(d);
 
   // Module
-  module* m2 = s->MakeModule();
+  module_inst* m2 = s->MakeModule_inst();
   m2->VpiDefName("M2");
   m2->VpiName("u1");
   m2->VpiParent(m1);
 
   // Module
-  module* m3 = s->MakeModule();
+  module_inst* m3 = s->MakeModule_inst();
   m3->VpiDefName("M3");
   m3->VpiName("u2");
   m3->VpiParent(m1);
 
   // Instance
-  module* m4 = s->MakeModule();
+  module_inst* m4 = s->MakeModule_inst();
   m4->VpiDefName("M4");
   m4->VpiName("u3");
   m4->VpiParent(m3);
   m4->Instance(m3);
 
-  VectorOfmodule* v1 = s->MakeModuleVec();
+  VectorOfmodule_inst* v1 = s->MakeModule_instVec();
   v1->push_back(m1);
   d->AllModules(v1);
 
-  VectorOfmodule* v2 = s->MakeModuleVec();
+  VectorOfmodule_inst* v2 = s->MakeModule_instVec();
   v2->push_back(m2);
   v2->push_back(m3);
   m1->Modules(v2);

--- a/tests/vpi_listener_test.cpp
+++ b/tests/vpi_listener_test.cpp
@@ -21,12 +21,12 @@ using testing::HasSubstr;
 
 class MyVpiListener : public VpiListener {
  protected:
-  void enterModule(const module* object, vpiHandle handle) override {
+  void enterModule_inst(const module_inst* object, vpiHandle handle) override {
     CollectLine("Module", object);
     stack_.push(object);
   }
 
-  void leaveModule(const module* object, vpiHandle handle) override {
+  void leaveModule_inst(const module_inst* object, vpiHandle handle) override {
     ASSERT_EQ(stack_.top(), object);
     stack_.pop();
   }
@@ -63,36 +63,36 @@ static std::vector<vpiHandle> buildModuleProg(Serializer* s) {
   design* d = s->MakeDesign();
   d->VpiName("design1");
   // Module
-  module* m1 = s->MakeModule();
+  module_inst* m1 = s->MakeModule_inst();
   m1->VpiTopModule(true);
   m1->VpiDefName("M1");
   m1->VpiFullName("top::M1");
   m1->VpiParent(d);
 
   // Module
-  module* m2 = s->MakeModule();
+  module_inst* m2 = s->MakeModule_inst();
   m2->VpiDefName("M2");
   m2->VpiName("u1");
   m2->VpiParent(m1);
 
   // Module
-  module* m3 = s->MakeModule();
+  module_inst* m3 = s->MakeModule_inst();
   m3->VpiDefName("M3");
   m3->VpiName("u2");
   m3->VpiParent(m1);
 
   // Instance
-  module* m4 = s->MakeModule();
+  module_inst* m4 = s->MakeModule_inst();
   m4->VpiDefName("M4");
   m4->VpiName("u3");
   m4->VpiParent(m3);
   m4->Instance(m3);
 
-  VectorOfmodule* v1 = s->MakeModuleVec();
+  VectorOfmodule_inst* v1 = s->MakeModule_instVec();
   v1->push_back(m1);
   d->AllModules(v1);
 
-  VectorOfmodule* v2 = s->MakeModuleVec();
+  VectorOfmodule_inst* v2 = s->MakeModule_instVec();
   v2->push_back(m2);
   v2->push_back(m3);
   m1->Modules(v2);

--- a/util/uhdm-hier.cpp
+++ b/util/uhdm-hier.cpp
@@ -111,22 +111,22 @@ int main(int argc, char** argv) {
                 path += objectName + ".";
               }
               // Recursive tree traversal
-              if (vpi_get(vpiType, obj_h) == vpiModule ||
+              if (vpi_get(vpiType, obj_h) == vpiModuleInst ||
                   vpi_get(vpiType, obj_h) == vpiGenScope) {
-                vpiHandle subItr = vpi_iterate(vpiModule, obj_h);
+                vpiHandle subItr = vpi_iterate(vpiModuleInst, obj_h);
                 while (vpiHandle sub_h = vpi_scan(subItr)) {
                   res += inst_visit(sub_h, path);
                   vpi_release_handle(sub_h);
                 }
                 vpi_release_handle(subItr);
-                subItr = vpi_iterate(vpiInterface, obj_h);
+                subItr = vpi_iterate(vpiInterfaceInst, obj_h);
                 while (vpiHandle sub_h = vpi_scan(subItr)) {
                   res += inst_visit(sub_h, path);
                   vpi_release_handle(sub_h);
                 }
                 vpi_release_handle(subItr);
               }
-              if (vpi_get(vpiType, obj_h) == vpiModule ||
+              if (vpi_get(vpiType, obj_h) == vpiModuleInst ||
                   vpi_get(vpiType, obj_h) == vpiGenScope) {
                 vpiHandle subItr = vpi_iterate(vpiGenScopeArray, obj_h);
                 while (vpiHandle sub_h = vpi_scan(subItr)) {


### PR DESCRIPTION
Issue #831: Fix compile issues on MinGW

* Use WIN32_LEAN_AND_MEAN when building on Windows to avoid pulling in irrelevant headers
* Rename "interface" to "interface_inst" to avoid conflicing with system defined class with the same name.
* Rename "module" to "module_inst" since the latter is now a C++ reserved word as of C++ 20.