### PR TITLE
Fix a bug in compare logic

### DIFF
--- a/scripts/classes.py
+++ b/scripts/classes.py
@@ -564,7 +564,7 @@ def _get_Compare_implementation(model):
 
     var_declared = False
     for key, value in model.allitems():
-        if key not in ['property', 'obj_ref', 'class_ref', 'class']:
+        if key not in ['property', 'obj_ref', 'class_ref', 'class', 'group_ref']:
             continue
 
         vpi = value.get('vpi')


### PR DESCRIPTION
Fix a bug in compare logic

'group_ref' was being ignored from comparison and param_assign uses that as the key for LHS & RHS.