### PR TITLE
Use ComponentType::value_map instead of std::make_pair

### DIFF
--- a/scripts/ElaboratorListener_cpp.py
+++ b/scripts/ElaboratorListener_cpp.py
@@ -38,7 +38,7 @@ def _generate_module_listeners(models, classname):
                     listeners.append( '    ComponentMap& funcMap = std::get<2>(instStack_.at(instStack_.size()-2).second);')
                     listeners.append( '    auto it = funcMap.find(tf->VpiName());')
                     listeners.append( '    if (it != funcMap.end()) funcMap.erase(it);')
-                    listeners.append( '    funcMap.insert(std::make_pair(tf->VpiName(), tf));')
+                    listeners.append( '    funcMap.insert(ComponentMap::value_type(tf->VpiName(), tf));')
                     listeners.append( '    leaveTask_func(obj, nullptr);')
                     listeners.append( '    tf->VpiParent(inst);')
                     listeners.append( '    clone_vec->push_back(tf);')

--- a/templates/ElaboratorListener.cpp
+++ b/templates/ElaboratorListener.cpp
@@ -252,7 +252,7 @@ void ElaboratorListener::enterModule_inst(const module_inst* object, vpiHandle h
         paramMap.emplace(param->VpiName(), param);
       }
     }
-    
+
     if (object->Typespecs()) {
       for (typespec* tps : *object->Typespecs()) {
         if (tps->UhdmType() == uhdmenum_typespec) {
@@ -447,7 +447,7 @@ void ElaboratorListener::enterPackage(const package* object, vpiHandle handle) {
       paramMap.emplace(param->VpiName(), param);
     }
   }
-  
+
   // Collect func and task declaration
   ComponentMap funcMap;
   ComponentMap modMap;
@@ -644,7 +644,7 @@ void ElaboratorListener::enterInterface_inst(const interface_inst* object,
     if (object->Param_assigns()) {
       for (param_assign* passign : *object->Param_assigns()) {
         paramMap.insert(
-            std::make_pair(passign->Lhs()->VpiName(), passign->Rhs()));
+            ComponentMap::value_type(passign->Lhs()->VpiName(), passign->Rhs()));
       }
     }
     if (object->Parameters()) {
@@ -1054,7 +1054,7 @@ void ElaboratorListener::enterBegin(const begin* object, vpiHandle handle) {
       varMap.emplace(var->VpiName(), var);
     }
   }
-  
+
   ComponentMap paramMap;
   ComponentMap funcMap;
   ComponentMap modMap;
@@ -1213,7 +1213,7 @@ void ElaboratorListener::enterGen_scope(const gen_scope* object,
     }
   }
 
-  
+
 
   // Collect instance parameters, defparams
   ComponentMap paramMap;

--- a/tests/listener_elab_test.cpp
+++ b/tests/listener_elab_test.cpp
@@ -209,7 +209,8 @@ class MyElaboratorListener : public VpiListener {
 
     if (flatModule) {
       // Flat list of module (unelaborated)
-      flatComponentMap_.insert(std::make_pair(object->VpiDefName(), object));
+      flatComponentMap_.insert(
+          ComponentMap::value_type(object->VpiDefName(), object));
     } else {
       // Hierachical module list (elaborated)
 
@@ -217,7 +218,7 @@ class MyElaboratorListener : public VpiListener {
       ComponentMap netMap;
       if (object->Nets()) {
         for (net* net : *object->Nets()) {
-          netMap.insert(std::make_pair(net->VpiName(), net));
+          netMap.insert(ComponentMap::value_type(net->VpiName(), net));
         }
       }
 


### PR DESCRIPTION
This improves compatibility in case the map type is not std::map.
