### PR TITLE
Issue #859: vpiModule & vpiInterface are part of standard

### DIFF
--- a/include/sv_vpi_user.h
+++ b/include/sv_vpi_user.h
@@ -33,7 +33,7 @@ extern "C" {
 
 /****************************** OBJECT TYPES ******************************/
 #define vpiPackage                            600
-#define vpiInterfaceInst                      601
+#define vpiInterface                          601
 #define vpiProgram                            602
 #define vpiInterfaceArray                     603
 #define vpiProgramArray                       604

--- a/include/vpi_user.h
+++ b/include/vpi_user.h
@@ -151,7 +151,7 @@ typedef PLI_UINT32 *vpiHandle;
 #define vpiMemory             29   /* behavioral memory */
 #define vpiMemoryWord         30   /* single word of memory */
 #define vpiModPath            31   /* module path for path delays */
-#define vpiModuleInst         32   /* module instance */
+#define vpiModule             32   /* module instance */
 #define vpiNamedBegin         33   /* named block statement */
 #define vpiNamedEvent         34   /* event variable */
 #define vpiNamedFork          35   /* named fork-join block */

--- a/model/design.yaml
+++ b/model/design.yaml
@@ -51,7 +51,7 @@
     card: any
   - class: allInterfaces
     type: interface_inst
-    vpi_obj: vpiInterfaceInst
+    vpi_obj: vpiInterface
     vpi: uhdmallInterfaces
     card: any
   - class: allUdps
@@ -66,7 +66,7 @@
     card: any
   - class: allModules
     type: module_inst
-    vpi_obj: vpiModuleInst
+    vpi_obj: vpiModule
     vpi: uhdmallModules
     card: any
   - class_ref: typespecs
@@ -95,6 +95,6 @@
     card: any
   - class: topModules
     type: module_inst
-    vpi_obj: vpiModuleInst
+    vpi_obj: vpiModule
     vpi: uhdmtopModules
     card: any

--- a/model/gen_scope.yaml
+++ b/model/gen_scope.yaml
@@ -58,7 +58,7 @@
     card: any
   - obj_ref: modules
     name: modules
-    vpi: vpiModuleInst
+    vpi: vpiModule
     type: module_inst
     card: any
   - obj_ref: module_arrays
@@ -102,7 +102,7 @@
     card: any
   - obj_ref: interfaces
     name: interface_inst
-    vpi: vpiInterfaceInst
+    vpi: vpiInterface
     type: interface_inst
     card: any
   - obj_ref: interface_arrays

--- a/model/instance.yaml
+++ b/model/instance.yaml
@@ -138,7 +138,7 @@
     card: any
   - obj_ref: module_inst
     name: module_inst
-    vpi: vpiModuleInst
+    vpi: vpiModule
     type: module_inst
     card: 1
   - class_ref: instance

--- a/model/instance_array.yaml
+++ b/model/instance_array.yaml
@@ -57,7 +57,7 @@
     card: any
   - obj_ref: modules
     name: modules
-    vpi: vpiModuleInst
+    vpi: vpiModule
     type: module_inst
     card: any
   - class_ref: elem_typespec

--- a/model/interface_inst.yaml
+++ b/model/interface_inst.yaml
@@ -22,7 +22,7 @@
     type: int
     card: 1
   - property: type
-    name: vpiInterfaceInst
+    name: vpiInterface
     vpi: vpiType
     type: unsigned int
     card: 1
@@ -72,7 +72,7 @@
     card: any  
   - obj_ref: interfaces
     name: interface_inst
-    vpi: vpiInterfaceInst
+    vpi: vpiInterface
     type: interface_inst
     card: any
   - obj_ref: interface_arrays

--- a/model/modport.yaml
+++ b/model/modport.yaml
@@ -27,6 +27,6 @@
     card: any
   - obj_ref: interface_inst
     name: interface_inst
-    vpi: vpiInterfaceInst
+    vpi: vpiInterface
     type: interface_inst
     card: 1

--- a/model/module_inst.yaml
+++ b/model/module_inst.yaml
@@ -22,7 +22,7 @@
     type: int
     card: 1
   - property: type
-    name: vpiModuleInst
+    name: vpiModule
     vpi: vpiType
     type: unsigned int
     card: 1
@@ -68,7 +68,7 @@
     card: any
   - obj_ref: interfaces
     name: interface_inst
-    vpi: vpiInterfaceInst
+    vpi: vpiInterface
     type: interface_inst
     card: any
   - obj_ref: interface_arrays
@@ -83,7 +83,7 @@
     card: any
   - obj_ref: modules
     name: modules
-    vpi: vpiModuleInst
+    vpi: vpiModule
     type: module_inst
     card: any
   - obj_ref: module_arrays

--- a/model/nets.yaml
+++ b/model/nets.yaml
@@ -158,6 +158,6 @@
     card: 1
   - obj_ref: module_inst
     name: module_inst
-    vpi: vpiModuleInst
+    vpi: vpiModule
     type: module_inst
     card: 1

--- a/model/ports.yaml
+++ b/model/ports.yaml
@@ -82,6 +82,6 @@
     card: 1
   - obj_ref: module_inst
     name: module_inst
-    vpi: vpiModuleInst
+    vpi: vpiModule
     type: module_inst
     card: 1

--- a/model/process_stmt.yaml
+++ b/model/process_stmt.yaml
@@ -22,7 +22,7 @@
     card: 1
   - obj_ref: module_inst
     name: module_inst
-    vpi: vpiModuleInst
+    vpi: vpiModule
     type: module_inst
     card: 1
   - obj_ref: attributes

--- a/model/program.yaml
+++ b/model/program.yaml
@@ -38,7 +38,7 @@
     card: 1
   - obj_ref: interfaces
     name: interface_inst
-    vpi: vpiInterfaceInst
+    vpi: vpiInterface
     type: interface_inst
     card: any
   - group_ref: expr_dist

--- a/model/tchk.yaml
+++ b/model/tchk.yaml
@@ -18,7 +18,7 @@
   - obj_ref: module_inst
     name: module_inst
     type: module_inst
-    vpi: vpiModuleInst
+    vpi: vpiModule
     card: 1
   - class_ref: expr
     name: expr

--- a/model/test.yaml
+++ b/model/test.yaml
@@ -27,12 +27,12 @@
     vpi: vpiTopModule
     card: 1
   - obj_ref: modules
-    vpi: vpiModuleInst
+    vpi: vpiModule
     type: module_inst
     card: any
 
 - obj_def: design
   - class: uhdmAllModules
     type: module_inst
-    vpi_obj: vpiModuleInst
+    vpi_obj: vpiModule
     card: any

--- a/model/variables.yaml
+++ b/model/variables.yaml
@@ -118,7 +118,7 @@
     card: 1
   - obj_ref: module_inst
     name: module_inst
-    vpi: vpiModuleInst
+    vpi: vpiModule
     type: module_inst
     card: 1
   - class_ref: instance

--- a/scripts/VpiListener.py
+++ b/scripts/VpiListener.py
@@ -6,8 +6,8 @@ def _get_listeners(classname, vpi, type, card):
     listeners = []
 
     if card == '1':
-        # upward vpiModuleInst, vpiInterfaceInst relation (when card == 1, pointing to the parent object) creates loops in visitors
-        if vpi in ['vpiParent', 'vpiInstance', 'vpiModuleInst', 'vpiInterfaceInst', 'vpiUse', 'vpiProgram', 'vpiClassDefn', 'vpiPackage', 'vpiUdp']:
+        # upward vpiModule, vpiInterface relation (when card == 1, pointing to the parent object) creates loops in visitors
+        if vpi in ['vpiParent', 'vpiInstance', 'vpiModule', 'vpiInterface', 'vpiUse', 'vpiProgram', 'vpiClassDefn', 'vpiPackage', 'vpiUdp']:
             return listeners
 
         if 'func_call' in classname and vpi == 'vpiFunction':

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -111,6 +111,11 @@ def get_modellist_filepath():
 
 
 def make_vpi_name(classname):
+    classname_overrides = {
+      'module_inst': 'module',
+      'interface_inst': 'interface'
+    }
+    classname = classname_overrides.get(classname, classname)
     vpiclasstype = f'vpi{classname[:1].upper()}{classname[1:]}'
 
     underscore = False
@@ -125,7 +130,7 @@ def make_vpi_name(classname):
         else:
             vpiclasstype += ch
 
-    overrides = {
+    vpiname_overrides = {
       'vpiForkStmt': 'vpiFork',
       'vpiForStmt': 'vpiFor',
       'vpiIoDecl': 'vpiIODecl',
@@ -149,4 +154,4 @@ def make_vpi_name(classname):
       'vpiSwitchTran': 'vpiSwitch',
     }
 
-    return overrides.get(vpiclasstype, vpiclasstype)
+    return vpiname_overrides.get(vpiclasstype, vpiclasstype)

--- a/scripts/vpi_visitor_cpp.py
+++ b/scripts/vpi_visitor_cpp.py
@@ -9,7 +9,7 @@ def _get_implementation(classname, vpi, card):
     if card == '1':
         shallow_visit = 'false'
 
-        if vpi in ['vpiParent', 'vpiInstance', 'vpiModuleInst', 'vpiInterfaceInst', 'vpiUse', 'vpiProgram', 'vpiClassDefn', 'vpiPackage', 'vpiUdp']:
+        if vpi in ['vpiParent', 'vpiInstance', 'vpiModule', 'vpiInterface', 'vpiUse', 'vpiProgram', 'vpiClassDefn', 'vpiPackage', 'vpiUdp']:
             # Prevent walking upwards and makes the UHDM output cleaner
             # Prevent loop in Standard VPI
             shallow_visit = 'true'

--- a/templates/ElaboratorListener.cpp
+++ b/templates/ElaboratorListener.cpp
@@ -144,14 +144,15 @@ static std::string_view ltrim_until(std::string_view str, char c) {
   return str;
 }
 
-void ElaboratorListener::enterModule_inst(const module_inst* object, vpiHandle handle) {
+void ElaboratorListener::enterModule_inst(const module_inst* object,
+                                          vpiHandle handle) {
   bool topLevelModule = object->VpiTopModule();
   const std::string_view instName = object->VpiName();
   const std::string_view defName = object->VpiDefName();
   bool flatModule =
       instName.empty() && ((object->VpiParent() == 0) ||
                            ((object->VpiParent() != 0) &&
-                            (object->VpiParent()->VpiType() != vpiModuleInst)));
+                            (object->VpiParent()->VpiType() != vpiModule)));
   // false when it is a module in a hierachy tree
   if (debug_)
     std::cout << "Module: " << defName << " (" << instName
@@ -177,9 +178,9 @@ void ElaboratorListener::enterModule_inst(const module_inst* object, vpiHandle h
       for (variables* var : *object->Variables()) {
         netMap.emplace(var->VpiName(), var);
         if (var->UhdmType() == uhdmenum_var) {
-          enum_var* evar = (enum_var*) var;
+          enum_var* evar = (enum_var*)var;
           enum_typespec* etps = (enum_typespec*)evar->Typespec();
-          for(auto c : *etps->Enum_consts()) {
+          for (auto c : *etps->Enum_consts()) {
             netMap.emplace(c->VpiName(), c);
           }
         }
@@ -257,7 +258,7 @@ void ElaboratorListener::enterModule_inst(const module_inst* object, vpiHandle h
       for (typespec* tps : *object->Typespecs()) {
         if (tps->UhdmType() == uhdmenum_typespec) {
           enum_typespec* etps = (enum_typespec*)tps;
-          for(auto c : *etps->Enum_consts()) {
+          for (auto c : *etps->Enum_consts()) {
             paramMap.emplace(c->VpiName(), c);
           }
         }
@@ -294,7 +295,7 @@ void ElaboratorListener::enterModule_inst(const module_inst* object, vpiHandle h
       const BaseClass* comp = (*itrDef).second;
       int compType = comp->VpiType();
       switch (compType) {
-        case vpiModuleInst: {
+        case vpiModule: {
           module_inst* defMod = (module_inst*)comp;
           if (defMod->Typespecs()) {
             for (typespec* tps : *defMod->Typespecs()) {
@@ -358,7 +359,8 @@ void ElaboratorListener::enterModule_inst(const module_inst* object, vpiHandle h
   }
 }
 
-void ElaboratorListener::elabModule_inst(const module_inst* object, vpiHandle handle) {
+void ElaboratorListener::elabModule_inst(const module_inst* object,
+                                         vpiHandle handle) {
   module_inst* inst = const_cast<module_inst*>(object);
   bool topLevelModule = object->VpiTopModule();
   const std::string_view instName = object->VpiName();
@@ -366,7 +368,7 @@ void ElaboratorListener::elabModule_inst(const module_inst* object, vpiHandle ha
   bool flatModule =
       instName.empty() && ((object->VpiParent() == 0) ||
                            ((object->VpiParent() != 0) &&
-                            (object->VpiParent()->VpiType() != vpiModuleInst)));
+                            (object->VpiParent()->VpiType() != vpiModule)));
   // false when it is a module in a hierachy tree
   if (debug_)
     std::cout << "Module: " << defName << " (" << instName
@@ -389,7 +391,7 @@ void ElaboratorListener::elabModule_inst(const module_inst* object, vpiHandle ha
       const BaseClass* comp = (*itrDef).second;
       int compType = comp->VpiType();
       switch (compType) {
-        case vpiModuleInst: {
+        case vpiModule: {
           module_inst* defMod = (module_inst*)comp;
           if (clone_) {
             <MODULE_ELABORATOR_LISTENER>
@@ -403,9 +405,11 @@ void ElaboratorListener::elabModule_inst(const module_inst* object, vpiHandle ha
   }
 }
 
-void ElaboratorListener::leaveModule_inst(const module_inst* object, vpiHandle handle) {
+void ElaboratorListener::leaveModule_inst(const module_inst* object,
+                                          vpiHandle handle) {
   bindScheduledTaskFunc();
-  if (inHierarchy_ && !instStack_.empty() && (instStack_.back().first == object)) {
+  if (inHierarchy_ && !instStack_.empty() &&
+      (instStack_.back().first == object)) {
     instStack_.pop_back();
     if (instStack_.empty()) {
       inHierarchy_ = false;
@@ -532,7 +536,8 @@ void ElaboratorListener::enterClass_defn(const class_defn* object,
   }
 }
 
-void ElaboratorListener::elabClass_defn(const class_defn* object, vpiHandle handle) {
+void ElaboratorListener::elabClass_defn(const class_defn* object,
+                                        vpiHandle handle) {
   class_defn* cl = (class_defn*)object;
   if (clone_) {
 <CLASS_ELABORATOR_LISTENER>
@@ -583,7 +588,7 @@ void ElaboratorListener::enterInterface_inst(const interface_inst* object,
   bool flatModule =
       instName.empty() && ((object->VpiParent() == 0) ||
                            ((object->VpiParent() != 0) &&
-                            (object->VpiParent()->VpiType() != vpiModuleInst)));
+                            (object->VpiParent()->VpiType() != vpiModule)));
   // false when it is an interface in a hierachy tree
   if (debug_)
     std::cout << "Module: " << defName << " (" << instName
@@ -630,7 +635,7 @@ void ElaboratorListener::enterInterface_inst(const interface_inst* object,
     if (object->Interface_arrays()) {
       for (interface_array* inter : *object->Interface_arrays()) {
         for (instance* interf : *inter->Instances())
-        netMap.emplace(interf->VpiName(), interf);
+          netMap.emplace(interf->VpiName(), interf);
       }
     }
     if (object->Named_events()) {
@@ -643,8 +648,8 @@ void ElaboratorListener::enterInterface_inst(const interface_inst* object,
     ComponentMap paramMap;
     if (object->Param_assigns()) {
       for (param_assign* passign : *object->Param_assigns()) {
-        paramMap.insert(
-            ComponentMap::value_type(passign->Lhs()->VpiName(), passign->Rhs()));
+        paramMap.insert(ComponentMap::value_type(passign->Lhs()->VpiName(),
+                                                 passign->Rhs()));
       }
     }
     if (object->Parameters()) {
@@ -689,7 +694,7 @@ void ElaboratorListener::enterInterface_inst(const interface_inst* object,
       const BaseClass* comp = (*itrDef).second;
       int compType = comp->VpiType();
       switch (compType) {
-        case vpiModuleInst: {
+        case vpiModule: {
           module_inst* defMod = (module_inst*)comp;
           if (defMod->Typespecs()) {
             for (typespec* tps : *defMod->Typespecs()) {
@@ -738,7 +743,7 @@ void ElaboratorListener::enterInterface_inst(const interface_inst* object,
       const BaseClass* comp = (*itrDef).second;
       int compType = comp->VpiType();
       switch (compType) {
-        case vpiInterfaceInst: {
+        case vpiInterface: {
           //  interface* defMod = (interface*)comp;
           if (clone_) {
             // Don't activate yet  <INTERFACE//regexp
@@ -889,8 +894,7 @@ bool ElaboratorListener::isFunctionCall(std::string_view name,
   return true;
 }
 
-bool ElaboratorListener::isTaskCall(std::string_view name,
-                                    const expr* prefix) {
+bool ElaboratorListener::isTaskCall(std::string_view name, const expr* prefix) {
   if (instStack_.size()) {
     for (InstStack::reverse_iterator i = instStack_.rbegin();
          i != instStack_.rend(); ++i) {
@@ -935,11 +939,11 @@ void ElaboratorListener::enterTask_func(const task_func* object,
 
   if (const any* parent = object->VpiParent()) {
     if (parent->UhdmType() == uhdmclass_defn) {
-      const class_defn* c = (class_defn*) parent;
+      const class_defn* c = (class_defn*)parent;
       while (c) {
         if (c->Variables()) {
           for (any* var : *c->Variables()) {
-             varMap.emplace(var->VpiName(), var);
+            varMap.emplace(var->VpiName(), var);
           }
         }
         const extends* ext = c->Extends();
@@ -1213,8 +1217,6 @@ void ElaboratorListener::enterGen_scope(const gen_scope* object,
     }
   }
 
-
-
   // Collect instance parameters, defparams
   ComponentMap paramMap;
   if (object->Parameters()) {
@@ -1266,7 +1268,8 @@ void ElaboratorListener::popVar(any* var) {
   }
 }
 
-void ElaboratorListener::enterMethod_func_call(const method_func_call* object, vpiHandle handle) {
+void ElaboratorListener::enterMethod_func_call(const method_func_call* object,
+                                               vpiHandle handle) {
   ComponentMap netMap;
   ComponentMap paramMap;
   ComponentMap funcMap;
@@ -1280,12 +1283,12 @@ void ElaboratorListener::enterMethod_func_call(const method_func_call* object, v
                           std::make_tuple(netMap, paramMap, funcMap, modMap));
 }
 
-void ElaboratorListener::leaveMethod_func_call(const method_func_call* object, vpiHandle handle) {
+void ElaboratorListener::leaveMethod_func_call(const method_func_call* object,
+                                               vpiHandle handle) {
   if (!instStack_.empty() && (instStack_.back().first == object)) {
     instStack_.pop_back();
   }
 }
-
 
 void ElaboratorListener::leaveRef_obj(const ref_obj* object, vpiHandle handle) {
   if (!object->Actual_group())

--- a/templates/UhdmAdjuster.cpp
+++ b/templates/UhdmAdjuster.cpp
@@ -186,12 +186,13 @@ void UhdmAdjuster::leaveCase_stmt(const case_stmt* object, vpiHandle handle) {
   }
 }
 
-void UhdmAdjuster::enterModule_inst(const module_inst* object, vpiHandle handle) {
+void UhdmAdjuster::enterModule_inst(const module_inst* object,
+                                    vpiHandle handle) {
   const std::string_view instName = object->VpiName();
-  bool flatModule = (instName.empty()) &&
-                    ((object->VpiParent() == 0) ||
-                     ((object->VpiParent() != 0) &&
-                      (object->VpiParent()->VpiType() != vpiModuleInst)));
+  bool flatModule =
+      (instName.empty()) && ((object->VpiParent() == 0) ||
+                             ((object->VpiParent() != 0) &&
+                              (object->VpiParent()->VpiType() != vpiModule)));
   if (!flatModule) elaboratedTree_ = true;
   currentInstance_ = object;
 }

--- a/templates/vpi_visitor.cpp
+++ b/templates/vpi_visitor.cpp
@@ -24,8 +24,7 @@
  */
 #include <uhdm/vpi_visitor.h>
 
-#include <string.h>
-
+#include <cstring>
 #include <iostream>
 #include <set>
 #include <sstream>
@@ -391,7 +390,7 @@ static std::string vpiTypeName(vpiHandle h) {
     case 24: return "vpiInitial";
     case 600: return "vpiPackage";
     case 25: return "vpiIntegerVar";
-    case 601: return "vpiInterfaceInst";
+    case 601: return "vpiInterface";
     case 26: return "vpiInterModPath";
     case 602: return "vpiProgram";
     case 27: return "vpiIterator";
@@ -403,7 +402,7 @@ static std::string vpiTypeName(vpiHandle h) {
     case 605: return "vpiTypespec";
     case 31: return "vpiModPath";
     case 606: return "vpiModport";
-    case 32: return "vpiModuleInst";
+    case 32: return "vpiModule";
     case 607: return "vpiInterfaceTfDecl";
     case 33: return "vpiNamedBegin";
     case 608: return "vpiRefObj";
@@ -544,9 +543,9 @@ void visit_object(vpiHandle obj_h, int indent, const char *relation, VisitedCont
 
 #endif
 
-    if ((objectType == vpiModuleInst) || (objectType == vpiProgram) ||
+    if ((objectType == vpiModule) || (objectType == vpiProgram) ||
         (objectType == vpiClassDefn) || (objectType == vpiPackage) ||
-        (objectType == vpiInterfaceInst) || (objectType == vpiUdp) ||
+        (objectType == vpiInterface) || (objectType == vpiUdp) ||
         (objectType == vpiIncludeFileInfo)) {
       if (const char* s = vpi_get_str(vpiFile, obj_h)) {
         out << ", file:" << s;  // fileName

--- a/tests/listener_elab_test.cpp
+++ b/tests/listener_elab_test.cpp
@@ -32,12 +32,11 @@
 
 // Verifies that the forward declaration header compiles
 #include "gtest/gtest.h"
+#include "test_util.h"
 #include "uhdm/VpiListener.h"
 #include "uhdm/uhdm.h"
 #include "uhdm/uhdm_forward_decl.h"
 #include "uhdm/vpi_visitor.h"
-
-#include "test_util.h"
 
 using namespace UHDM;
 
@@ -198,10 +197,10 @@ class MyElaboratorListener : public VpiListener {
     bool topLevelModule = object->VpiTopModule();
     const std::string_view instName = object->VpiName();
     const std::string_view defName = object->VpiDefName();
-    bool flatModule = instName.empty() &&
-                      ((object->VpiParent() == 0) ||
-                       ((object->VpiParent() != 0) &&
-                        (object->VpiParent()->VpiType() != vpiModuleInst)));
+    bool flatModule =
+        instName.empty() && ((object->VpiParent() == 0) ||
+                             ((object->VpiParent() != 0) &&
+                              (object->VpiParent()->VpiType() != vpiModule)));
     // false when it is a module in a hierachy tree
     std::cout << "Module: " << defName << " (" << instName
               << ") Flat:" << flatModule << ", Top:" << topLevelModule
@@ -231,7 +230,7 @@ class MyElaboratorListener : public VpiListener {
         const BaseClass* comp = (*itrDef).second;
         int compType = comp->VpiType();
         switch (compType) {
-          case vpiModuleInst: {
+          case vpiModule: {
             module_inst* defMod = (module_inst*)comp;
 
             // 1) This section illustrates how one can walk the data model in
@@ -287,10 +286,10 @@ class MyElaboratorListener : public VpiListener {
 
   void leaveModule_inst(const module_inst* object, vpiHandle handle) override {
     const std::string_view instName = object->VpiName();
-    bool flatModule = instName.empty() &&
-                      ((object->VpiParent() == 0) ||
-                       ((object->VpiParent() != 0) &&
-                        (object->VpiParent()->VpiType() != vpiModuleInst)));
+    bool flatModule =
+        instName.empty() && ((object->VpiParent() == 0) ||
+                             ((object->VpiParent() != 0) &&
+                              (object->VpiParent()->VpiType() != vpiModule)));
     // false when it is a module in a hierachy tree
     if (!flatModule) instStack_.pop();
   }

--- a/util/uhdm-hier.cpp
+++ b/util/uhdm-hier.cpp
@@ -111,22 +111,22 @@ int main(int argc, char** argv) {
                 path += objectName + ".";
               }
               // Recursive tree traversal
-              if (vpi_get(vpiType, obj_h) == vpiModuleInst ||
+              if (vpi_get(vpiType, obj_h) == vpiModule ||
                   vpi_get(vpiType, obj_h) == vpiGenScope) {
-                vpiHandle subItr = vpi_iterate(vpiModuleInst, obj_h);
+                vpiHandle subItr = vpi_iterate(vpiModule, obj_h);
                 while (vpiHandle sub_h = vpi_scan(subItr)) {
                   res += inst_visit(sub_h, path);
                   vpi_release_handle(sub_h);
                 }
                 vpi_release_handle(subItr);
-                subItr = vpi_iterate(vpiInterfaceInst, obj_h);
+                subItr = vpi_iterate(vpiInterface, obj_h);
                 while (vpiHandle sub_h = vpi_scan(subItr)) {
                   res += inst_visit(sub_h, path);
                   vpi_release_handle(sub_h);
                 }
                 vpi_release_handle(subItr);
               }
-              if (vpi_get(vpiType, obj_h) == vpiModuleInst ||
+              if (vpi_get(vpiType, obj_h) == vpiModule ||
                   vpi_get(vpiType, obj_h) == vpiGenScope) {
                 vpiHandle subItr = vpi_iterate(vpiGenScopeArray, obj_h);
                 while (vpiHandle sub_h = vpi_scan(subItr)) {


### PR DESCRIPTION
Issue #859: vpiModule & vpiInterface are part of standard

Follow up to a previous change where vpiModule & vpiInterface were renamed to vpiModuleInst & vpiInterfaceInst, respectively. This is flawed and doesn't meet the vpi standard. Reverting the names back to vpiModule & vpiInterface. However, the classes generated against the models remain named module_inst & interface_inst.