### PR TITLE
Fix system-provided `gtest` use

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,12 @@ jobs:
   linux-gcc:
     name: ubuntu-gcc
     runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        vendored_dependencies: [true, false]
+
     defaults:
       run:
         shell: bash
@@ -16,14 +22,26 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update -qq
-        sudo apt install -y g++-9 build-essential cmake \
-                            python3 python3-orderedmultidict
+        sudo apt install -y g++-9 build-essential cmake
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
+
+    - name: Setup Python Packages
+      run: pip3 install orderedmultidict
 
     - name: Git pull
       uses: actions/checkout@v3
       with:
         submodules: recursive
         fetch-depth: 0
+      if: ${{ matrix.vendored_dependencies }}
+
+    - name: Git pull
+      uses: actions/checkout@v3
+      if: ${{ !matrix.vendored_dependencies }}
 
     - name: Use ccache
       uses: hendrikmuhs/ccache-action@v1.2
@@ -35,8 +53,20 @@ jobs:
         echo 'CC=gcc-9' >> $GITHUB_ENV
         echo 'CXX=g++-9' >> $GITHUB_ENV
         echo 'PREFIX=/tmp/uhdm-install' >> $GITHUB_ENV
-        echo 'ADDITIONAL_CMAKE_OPTIONS=-DPython3_ROOT_DIR=$pythonLocation' >> $GITHUB_ENV
-        echo 'PATH=/usr/lib/ccache:'"$pythonLocation""$PATH" >> $GITHUB_ENV
+        echo 'PATH=/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
+
+    - name: Install vendored dependencies
+      run: |
+        git clone https://github.com/google/googletest.git
+        cd googletest && cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 . && cmake --build build && sudo cmake --install build
+        git clone https://github.com/capnproto/capnproto.git
+        cd capnproto && cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 . && cmake --build build && sudo cmake --install build
+      if: ${{ !matrix.vendored_dependencies }}
+
+    - name: Configure cmake options
+      run: |
+        echo 'ADDITIONAL_CMAKE_OPTIONS=-DUHDM_USE_HOST_GTEST=ON -DUHDM_USE_HOST_CAPNP=ON' >> $GITHUB_ENV
+      if: ${{ !matrix.vendored_dependencies }}
 
     - name: Build & Test
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # -*- mode:cmake -*-
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 # Detect build type, fallback to release and throw a warning if use didn't
 # specify any
@@ -187,36 +187,33 @@ target_include_directories(uhdm PRIVATE ${GENDIR}/src)
 
 if (UHDM_USE_HOST_CAPNP)
   target_include_directories(uhdm PRIVATE ${CAPNP_INCLUDE_DIRS})
+  target_link_libraries(uhdm PRIVATE CapnProto::capnp)
 else()
   target_include_directories(uhdm PRIVATE ${PROJECT_SOURCE_DIR}/third_party/capnproto/c++/src)
+  target_link_libraries(uhdm PRIVATE capnp)
 endif()
 
 target_compile_definitions(uhdm
   PUBLIC PLI_DLLISPEC=
   PUBLIC PLI_DLLESPEC=)
 
-if (UHDM_USE_HOST_CAPNP)
-  target_link_libraries(uhdm PRIVATE CapnProto::capnp)
-else()
-  target_link_libraries(uhdm PRIVATE capnp)
-
-  if(APPLE)
-    target_link_libraries(uhdm
-       PUBLIC dl
-       PUBLIC util
-       PUBLIC m
-       PUBLIC pthread)
-  elseif(UNIX)
-    target_link_libraries(uhdm
-       PUBLIC dl
-       PUBLIC util
-       PUBLIC m
-       PUBLIC rt
-       PUBLIC pthread)
-  endif()
+if(APPLE)
+  target_link_libraries(uhdm
+      PUBLIC dl
+      PUBLIC util
+      PUBLIC m
+      PUBLIC pthread)
+elseif(UNIX)
+  target_link_libraries(uhdm
+      PUBLIC dl
+      PUBLIC util
+      PUBLIC m
+      PUBLIC rt
+      PUBLIC pthread)
 endif()
 
 add_dependencies(uhdm GenerateCode)
+
 if(NOT UHDM_USE_HOST_CAPNP)
   add_dependencies(GenerateCode capnpc capnp_tool capnpc_cpp)
 endif()
@@ -242,8 +239,8 @@ if (UHDM_BUILD_TESTS)
       get_filename_component(test_prefix ${test_cc_file} DIRECTORY)
 
       add_executable(${test_bin} ${PROJECT_SOURCE_DIR}/${test_cc_file})
-      target_include_directories(${test_bin} PRIVATE ${GTEST_INCLUDE_DIR})
-      target_link_libraries(${test_bin} PRIVATE uhdm gtest gmock gtest_main)
+      target_include_directories(${test_bin} PRIVATE ${GTEST_INCLUDE_DIRS})
+      target_link_libraries(${test_bin} PRIVATE uhdm GTest::gtest GTest::gmock GTest::gtest_main)
       add_test(
         NAME ${test_prefix}/${test_bin} COMMAND ${test_bin}
         WORKING_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
@@ -297,15 +294,24 @@ target_compile_definitions(test_inst
   PUBLIC PLI_DLLESPEC=)
 target_include_directories(test_inst SYSTEM PRIVATE
   ${CMAKE_INSTALL_PREFIX}/include)
-target_link_libraries(test_inst PRIVATE
-  ${CMAKE_INSTALL_PREFIX}/lib/uhdm/${CMAKE_STATIC_LIBRARY_PREFIX}uhdm${CMAKE_STATIC_LIBRARY_SUFFIX}
-  ${CMAKE_INSTALL_PREFIX}/lib/uhdm/${CMAKE_STATIC_LIBRARY_PREFIX}capnp${CMAKE_STATIC_LIBRARY_SUFFIX}
-  ${CMAKE_INSTALL_PREFIX}/lib/uhdm/${CMAKE_STATIC_LIBRARY_PREFIX}kj${CMAKE_STATIC_LIBRARY_SUFFIX}
-  $<$<PLATFORM_ID:Darwin>:dl>
-  $<$<PLATFORM_ID:Darwin>:util>
-  $<$<AND:$<PLATFORM_ID:Darwin>,$<NOT:$<PLATFORM_ID:Apple>>>:m>
-  $<$<PLATFORM_ID:Darwin>:rt>
-  $<$<PLATFORM_ID:Darwin>:pthread>)
+if(NOT UHDM_USE_HOST_CAPNP)
+  target_link_libraries(test_inst PRIVATE
+    ${CMAKE_INSTALL_PREFIX}/lib/uhdm/${CMAKE_STATIC_LIBRARY_PREFIX}uhdm${CMAKE_STATIC_LIBRARY_SUFFIX}
+    ${CMAKE_INSTALL_PREFIX}/lib/uhdm/${CMAKE_STATIC_LIBRARY_PREFIX}capnp${CMAKE_STATIC_LIBRARY_SUFFIX}
+    ${CMAKE_INSTALL_PREFIX}/lib/uhdm/${CMAKE_STATIC_LIBRARY_PREFIX}kj${CMAKE_STATIC_LIBRARY_SUFFIX}
+    $<$<PLATFORM_ID:Darwin>:dl>
+    $<$<PLATFORM_ID:Darwin>:util>
+    $<$<AND:$<PLATFORM_ID:Darwin>,$<NOT:$<PLATFORM_ID:Apple>>>:m>
+    $<$<PLATFORM_ID:Darwin>:rt>
+    $<$<PLATFORM_ID:Darwin>:pthread>)
+else()
+  target_link_libraries(test_inst PRIVATE ${CMAKE_INSTALL_PREFIX}/lib/uhdm/${CMAKE_STATIC_LIBRARY_PREFIX}uhdm${CMAKE_STATIC_LIBRARY_SUFFIX} CapnProto::capnp
+    $<$<PLATFORM_ID:Darwin>:dl>
+    $<$<PLATFORM_ID:Darwin>:util>
+    $<$<AND:$<PLATFORM_ID:Darwin>,$<NOT:$<PLATFORM_ID:Apple>>>:m>
+    $<$<PLATFORM_ID:Darwin>:rt>
+    $<$<PLATFORM_ID:Darwin>:pthread>)
+endif()
 
 if(NOT UHDM_USE_HOST_CAPNP)
   install(

--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,5 @@ build:
 test_install:
 	cmake --build build --target test_inst --config Release -j $(CPU_CORES)
 	find build/bin -name test_inst* -exec {} \;
+
+.PHONY: build release debug test test-junit clean install uninstall test_install


### PR DESCRIPTION
Sorry for push noise, unfortunately there was a lot of annoying GitHub actions nuances to look at


This PR does a few things:
- fixes a small non-typo "typo" introduced in https://github.com/chipsalliance/UHDM/pull/817. Both [`FindGTest`](https://cmake.org/cmake/help/latest/module/FindGTest.html) and the local `CMakeLists.txt` file reference `GTEST_INCLUDE_DIRS`, but the code used `GTEST_INCLUDE_DIR` (gosh don't we all love CMake 😆). This is allegedly "private" in `FindGTest`.
- Splits the `ubuntu` test to test both vendored-dependency and non-vendored-dependency code paths for cmake (`ubuntu` chosen because it's usually the fastest on GitHub Actions). Can see behavior on my [fork actions](https://github.com/timkpaine/UHDM/actions)
- fixes a codepath in `CMakeLists.txt` that only linked when not vendoring `capnproto`



---


A few things discovered along the way:
- You need to install googletest from source on Mac to avoid ugliness:
    - https://gitlab.kitware.com/cmake/cmake/-/issues/22238
    - [This line](https://github.com/chipsalliance/UHDM/blob/a7945203690ee595924207308a835fb5a493eb47/tests/symbol_factory_test.cpp#L64) in `symbol_factory_test.cpp` requires C++17-compiled `gtest`, https://github.com/google/googletest/issues/2021
