### PR TITLE
pkg-config: base inc dir; choose libs depending on USE_HOST_CAPNP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,6 +384,13 @@ configure_package_config_file(
   NO_SET_AND_CHECK_MACRO
   NO_CHECK_REQUIRED_COMPONENTS_MACRO)
 
+# Depending on if we compile capnp from here or got from the host, the
+# package config refers to different libraries.
+if(UHDM_USE_HOST_CAPNP)
+  set(PC_OPTIONAL_REQUIRE_HOST_CAPNP "Requires: capnp")
+else()
+  set(PC_OPTIONAL_LOCAL_CAPNP "-lcapnp -lkj")
+endif()
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/install/UHDM.pc.in
   "${CMAKE_CURRENT_BINARY_DIR}/UHDM.pc"

--- a/install/UHDM.pc.in
+++ b/install/UHDM.pc.in
@@ -1,10 +1,11 @@
 prefix="@CMAKE_INSTALL_PREFIX@"
 exec_prefix="${prefix}"
 libdir="${prefix}/lib/uhdm"
-includedir="${prefix}/include/uhdm"
+includedir="${prefix}/include"
 
 Name: @PROJECT_NAME@
+@PC_OPTIONAL_REQUIRE_HOST_CAPNP@
 Description: @CMAKE_PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
 Cflags: -I${includedir}
-Libs: -L${libdir} -luhdm
+Libs: -L${libdir} -luhdm @PC_OPTIONAL_LOCAL_CAPNP@


### PR DESCRIPTION
In all our examples, we use `#include <uhdm/foo.h>`, so the base include directory should be $PREFIX/include, not $PREFIX/include/uhdm.

The libraries to link depends on of iwe used USE_HOST_CAPNP. If we compiled and installed from third_party/, we need to include the linking of the libraries from there, otherwise we need to require to use the pkg-config from capnp.