### PR TITLE
Add CloneContext, CompareContext & ElaboratorContext

### DIFF
--- a/scripts/ElaboratorListener_cpp.py
+++ b/scripts/ElaboratorListener_cpp.py
@@ -3,208 +3,209 @@ import file_utils
 
 
 def _generate_module_listeners(models, classname):
-    listeners = []
-    while classname:
-        model = models[classname]
+  listeners = []
+  while classname:
+    model = models[classname]
 
-        for key, value in model.allitems():
-            if key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
-                name = value.get('name')
-                type = value.get('type')
-                card = value.get('card')
+    for key, value in model.allitems():
+      if key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
+        name = value.get('name')
+        type = value.get('type')
+        card = value.get('card')
 
-                cast = 'any' if key == 'group_ref' else type
-                Cast = cast[:1].upper() + cast[1:]
-                method = name[:1].upper() + name[1:]
+        cast = 'any' if key == 'group_ref' else type
+        Cast = cast[:1].upper() + cast[1:]
+        method = name[:1].upper() + name[1:]
 
-                if (card == 'any') and not method.endswith('s'):
-                    method += 's'
+        if (card == 'any') and not method.endswith('s'):
+          method += 's'
 
-                if card == '1':
-                    listeners.append(f'if (auto obj = defMod->{method}()) {{')
-                    listeners.append( '  auto* stmt = obj->DeepClone(serializer_, this, defMod);')
-                    listeners.append( '  stmt->VpiParent(inst);')
-                    listeners.append(f'  inst->{method}(stmt);')
-                    listeners.append( '}')
+        if card == '1':
+          listeners.append(f'if (auto obj = defMod->{method}()) {{')
+          listeners.append( '  auto* stmt = obj->DeepClone(defMod, context_);')
+          listeners.append( '  stmt->VpiParent(inst);')
+          listeners.append(f'  inst->{method}(stmt);')
+          listeners.append( '}')
 
-                elif method in ['Task_funcs']:
-                    # We want to deep clone existing instance tasks and funcs
-                    listeners.append(f'if (auto vec = inst->{method}()) {{')
-                    listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
-                    listeners.append(f'  inst->{method}(clone_vec);')
-                    listeners.append( '  for (auto obj : *vec) {')
-                    listeners.append( '    enterTask_func(obj, nullptr);')
-                    listeners.append( '    auto* tf = obj->DeepClone(serializer_, this, inst);')
-                    listeners.append( '    ComponentMap& funcMap = std::get<3>(instStack_.at(instStack_.size() - 2));')
-                    listeners.append( '    auto it = funcMap.find(tf->VpiName());')
-                    listeners.append( '    if (it != funcMap.end()) funcMap.erase(it);')
-                    listeners.append( '    funcMap.emplace(tf->VpiName(), tf);')
-                    listeners.append( '    leaveTask_func(obj, nullptr);')
-                    listeners.append( '    clone_vec->push_back(tf);')
-                    listeners.append( '  }')
-                    listeners.append( '}')
-                elif method in ['Cont_assigns', 'Primitives', 'Primitive_arrays']:
-                    # We want to deep clone existing instance cont assign to perform binding
-                    listeners.append(f'if (auto vec = inst->{method}()) {{')
-                    listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
-                    listeners.append(f'  inst->{method}(clone_vec);')
-                    listeners.append( '  for (auto obj : *vec) {')
-                    listeners.append( '    auto* stmt = obj->DeepClone(serializer_, this, inst);')
-                    listeners.append( '    clone_vec->push_back(stmt);')
-                    listeners.append( '  }')
-                    listeners.append( '}')
+        elif method in ['Task_funcs']:
+          # We want to deep clone existing instance tasks and funcs
+          listeners.append(f'if (auto vec = inst->{method}()) {{')
+          listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
+          listeners.append(f'  inst->{method}(clone_vec);')
+          listeners.append( '  for (auto obj : *vec) {')
+          listeners.append( '    enterTask_func(obj, nullptr);')
+          listeners.append( '    auto* tf = obj->DeepClone(inst, context_);')
+          listeners.append( '    ComponentMap& funcMap = std::get<3>(instStack_.at(instStack_.size() - 2));')
+          listeners.append( '    auto it = funcMap.find(tf->VpiName());')
+          listeners.append( '    if (it != funcMap.end()) funcMap.erase(it);')
+          listeners.append( '    funcMap.emplace(tf->VpiName(), tf);')
+          listeners.append( '    leaveTask_func(obj, nullptr);')
+          listeners.append( '    clone_vec->push_back(tf);')
+          listeners.append( '  }')
+          listeners.append( '}')
 
-                elif method in ['Gen_scope_arrays']:
-                    # We want to deep clone existing instance cont assign to perform binding
-                    listeners.append(f'if (auto vec = inst->{method}()) {{')
-                    listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
-                    listeners.append(f'  inst->{method}(clone_vec);')
-                    listeners.append( '  for (auto obj : *vec) {')
-                    listeners.append( '    auto* stmt = obj->DeepClone(serializer_, this, inst);')
-                    listeners.append( '    clone_vec->push_back(stmt);')
-                    listeners.append( '  }')
-                    listeners.append( '}')
-                    # We also want to clone the module cont assign
-                    listeners.append(f'if (auto vec = defMod->{method}()) {{')
-                    listeners.append(f'  if (inst->{method}() == nullptr) {{')
-                    listeners.append(f'    auto clone_vec = serializer_->Make{Cast}Vec();')
-                    listeners.append(f'    inst->{method}(clone_vec);')
-                    listeners.append( '  }')
-                    listeners.append(f'  auto clone_vec = inst->{method}();')
-                    listeners.append( '  for (auto obj : *vec) {')
-                    listeners.append( '    auto* stmt = obj->DeepClone(serializer_, this, inst);')
-                    listeners.append( '    clone_vec->push_back(stmt);')
-                    listeners.append( '  }')
-                    listeners.append( '}')
+        elif method in ['Cont_assigns', 'Primitives', 'Primitive_arrays']:
+          # We want to deep clone existing instance cont assign to perform binding
+          listeners.append(f'if (auto vec = inst->{method}()) {{')
+          listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
+          listeners.append(f'  inst->{method}(clone_vec);')
+          listeners.append( '  for (auto obj : *vec) {')
+          listeners.append( '    auto* stmt = obj->DeepClone(inst, context_);')
+          listeners.append( '    clone_vec->push_back(stmt);')
+          listeners.append( '  }')
+          listeners.append( '}')
 
-                elif method in ['Typespecs']:
-                    # We don't want to override the elaborated instance ports by the module def ports, same for nets, params and param_assigns
-                    listeners.append(f'if (auto vec = defMod->{method}()) {{')
-                    listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
-                    listeners.append(f'  inst->{method}(clone_vec);')
-                    listeners.append( '  for (auto obj : *vec) {')
-                    listeners.append( '    if (uniquifyTypespec()) {')
-                    listeners.append( '      auto* stmt = obj->DeepClone(serializer_, this, inst);')
-                    listeners.append( '      clone_vec->push_back(stmt);')
-                    listeners.append( '    } else {')
-                    listeners.append( '      clone_vec->push_back(obj);')
-                    listeners.append( '    }')
-                    listeners.append( '  }')
-                    listeners.append( '}')
+        elif method in ['Gen_scope_arrays']:
+          # We want to deep clone existing instance cont assign to perform binding
+          listeners.append(f'if (auto vec = inst->{method}()) {{')
+          listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
+          listeners.append(f'  inst->{method}(clone_vec);')
+          listeners.append( '  for (auto obj : *vec) {')
+          listeners.append( '    auto* stmt = obj->DeepClone(inst, context_);')
+          listeners.append( '    clone_vec->push_back(stmt);')
+          listeners.append( '  }')
+          listeners.append( '}')
+          # We also want to clone the module cont assign
+          listeners.append(f'if (auto vec = defMod->{method}()) {{')
+          listeners.append(f'  if (inst->{method}() == nullptr) {{')
+          listeners.append(f'    auto clone_vec = serializer_->Make{Cast}Vec();')
+          listeners.append(f'    inst->{method}(clone_vec);')
+          listeners.append( '  }')
+          listeners.append(f'  auto clone_vec = inst->{method}();')
+          listeners.append( '  for (auto obj : *vec) {')
+          listeners.append( '    auto* stmt = obj->DeepClone(inst, context_);')
+          listeners.append( '    clone_vec->push_back(stmt);')
+          listeners.append( '  }')
+          listeners.append( '}')
 
-                elif method in ['Ref_modules', 'Gen_stmts']:
-                    pass # No elab
+        elif method in ['Typespecs']:
+          # We don't want to override the elaborated instance ports by the module def ports, same for nets, params and param_assigns
+          listeners.append(f'if (auto vec = defMod->{method}()) {{')
+          listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
+          listeners.append(f'  inst->{method}(clone_vec);')
+          listeners.append( '  for (auto obj : *vec) {')
+          listeners.append( '    if (uniquifyTypespec()) {')
+          listeners.append( '      auto* stmt = obj->DeepClone(inst, context_);')
+          listeners.append( '      clone_vec->push_back(stmt);')
+          listeners.append( '    } else {')
+          listeners.append( '      clone_vec->push_back(obj);')
+          listeners.append( '    }')
+          listeners.append( '  }')
+          listeners.append( '}')
 
-                elif method not in ['Ports', 'Nets', 'Parameters', 'Param_assigns', 'Interface_arrays', 'Module_arrays']:
-                    # We don't want to override the elaborated instance ports by the module def ports, same for nets, params and param_assigns
-                    listeners.append(f'if (auto vec = defMod->{method}()) {{')
-                    listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
-                    listeners.append(f'  inst->{method}(clone_vec);')
-                    listeners.append( '  for (auto obj : *vec) {')
-                    listeners.append( '    auto* stmt = obj->DeepClone(serializer_, this, inst);')
-                    listeners.append( '    clone_vec->push_back(stmt);')
-                    listeners.append( '  }')
-                    listeners.append( '}')
+        elif method in ['Ref_modules', 'Gen_stmts']:
+          pass # No elab
 
-                elif method in ['Ports']:
-                    listeners.append(f'if (auto vec = inst->{method}()) {{')
-                    listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
-                    listeners.append(f'  inst->{method}(clone_vec);')
-                    listeners.append( '  for (auto obj : *vec) {')
-                    listeners.append( '    auto* stmt = obj->DeepClone(serializer_, this, inst);')
-                    listeners.append( '    clone_vec->push_back(stmt);')
-                    listeners.append( '  }')
-                    listeners.append( '}')
+        elif method not in ['Ports', 'Nets', 'Parameters', 'Param_assigns', 'Interface_arrays', 'Module_arrays']:
+          # We don't want to override the elaborated instance ports by the module def ports, same for nets, params and param_assigns
+          listeners.append(f'if (auto vec = defMod->{method}()) {{')
+          listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
+          listeners.append(f'  inst->{method}(clone_vec);')
+          listeners.append( '  for (auto obj : *vec) {')
+          listeners.append( '    auto* stmt = obj->DeepClone(inst, context_);')
+          listeners.append( '    clone_vec->push_back(stmt);')
+          listeners.append( '  }')
+          listeners.append( '}')
 
-        classname = models[classname]['extends']
+        elif method in ['Ports']:
+          listeners.append(f'if (auto vec = inst->{method}()) {{')
+          listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
+          listeners.append(f'  inst->{method}(clone_vec);')
+          listeners.append( '  for (auto obj : *vec) {')
+          listeners.append( '    auto* stmt = obj->DeepClone(inst, context_);')
+          listeners.append( '    clone_vec->push_back(stmt);')
+          listeners.append( '  }')
+          listeners.append( '}')
 
-    return listeners
+    classname = models[classname]['extends']
+
+  return listeners
 
 
 def _generate_class_listeners(models):
-    listeners = []
+  listeners = []
 
-    for model in models.values():
-        modeltype = model.get('type')
-        if modeltype != 'obj_def':
-            continue
+  for model in models.values():
+    modeltype = model.get('type')
+    if modeltype != 'obj_def':
+      continue
 
-        classname = model.get('name')
-        if classname != 'class_defn':
-            continue
+    classname = model.get('name')
+    if classname != 'class_defn':
+      continue
 
-        while classname:
-            model = models[classname]
+    while classname:
+      model = models[classname]
 
-            for key, value in model.allitems():
-                if key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
-                    name = value.get('name')
-                    type = value.get('type')
-                    card = value.get('card')
+      for key, value in model.allitems():
+        if key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
+          name = value.get('name')
+          type = value.get('type')
+          card = value.get('card')
 
-                    cast = 'any' if key == 'group_ref' else type
-                    Cast = cast[:1].upper() + cast[1:]
-                    method = name[:1].upper() + name[1:]
+          cast = 'any' if key == 'group_ref' else type
+          Cast = cast[:1].upper() + cast[1:]
+          method = name[:1].upper() + name[1:]
 
-                    if (card == 'any') and not method.endswith('s'):
-                        method += 's'
+          if (card == 'any') and not method.endswith('s'):
+            method += 's'
 
-                    if card == '1':
-                        listeners.append(f'if (auto obj = cl->{method}()) {{')
-                        listeners.append( '  auto* stmt = obj->DeepClone(serializer_, this, cl);')
-                        listeners.append(f'  cl->{method}(stmt);')
-                        listeners.append( '}')
+          if card == '1':
+            listeners.append(f'if (auto obj = cl->{method}()) {{')
+            listeners.append( '  auto* stmt = obj->DeepClone(cl, context_);')
+            listeners.append(f'  cl->{method}(stmt);')
+            listeners.append( '}')
 
-                    elif method == 'Deriveds':
-                        # Don't deep clone
-                        listeners.append(f'if (auto vec = cl->{method}()) {{')
-                        listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
-                        listeners.append(f'  cl->{method}(clone_vec);')
-                        listeners.append( '  for (auto obj : *vec) {')
-                        listeners.append( '    clone_vec->push_back(obj);')
-                        listeners.append( '  }')
-                        listeners.append( '}')
+          elif method == 'Deriveds':
+            # Don't deep clone
+            listeners.append(f'if (auto vec = cl->{method}()) {{')
+            listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
+            listeners.append(f'  cl->{method}(clone_vec);')
+            listeners.append( '  for (auto obj : *vec) {')
+            listeners.append( '    clone_vec->push_back(obj);')
+            listeners.append( '  }')
+            listeners.append( '}')
 
-                    else:
-                        listeners.append(f'if (auto vec = cl->{method}()) {{')
-                        listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
-                        listeners.append(f'  cl->{method}(clone_vec);')
-                        listeners.append( '  for (auto obj : *vec) {')
-                        listeners.append( '    auto* stmt = obj->DeepClone(serializer_, this, cl);')
-                        listeners.append( '    clone_vec->push_back(stmt);')
-                        listeners.append( '  }')
-                        listeners.append( '}')
+          else:
+            listeners.append(f'if (auto vec = cl->{method}()) {{')
+            listeners.append(f'  auto clone_vec = serializer_->Make{Cast}Vec();')
+            listeners.append(f'  cl->{method}(clone_vec);')
+            listeners.append( '  for (auto obj : *vec) {')
+            listeners.append( '    auto* stmt = obj->DeepClone(cl, context_);')
+            listeners.append( '    clone_vec->push_back(stmt);')
+            listeners.append( '  }')
+            listeners.append( '}')
 
-            classname = models[classname]['extends']
+      classname = models[classname]['extends']
 
-    return listeners
+  return listeners
 
 
 def generate(models):
-    module_listeners = _generate_module_listeners(models, 'module_inst')
-    interface_listeners = _generate_module_listeners(models, 'interface_inst')
-    class_listeners = _generate_class_listeners(models)
+  module_listeners = _generate_module_listeners(models, 'module_inst')
+  interface_listeners = _generate_module_listeners(models, 'interface_inst')
+  class_listeners = _generate_class_listeners(models)
 
-    with open(config.get_template_filepath('ElaboratorListener.cpp'), 'rt') as strm:
-        file_content = strm.read()
+  with open(config.get_template_filepath('ElaboratorListener.cpp'), 'rt') as strm:
+    file_content = strm.read()
 
-    file_content = file_content.replace('<MODULE_ELABORATOR_LISTENER>', (' ' * 6) + ('\n' + (' ' * 6)).join(module_listeners))
-    file_content = file_content.replace('<INTERFACE_ELABORATOR_LISTENER>', (' ' * 10) + ('\n' + (' ' * 10)).join(interface_listeners))
-    file_content = file_content.replace('<CLASS_ELABORATOR_LISTENER>', (' ' * 2) + ('\n' + (' ' * 2)).join(class_listeners))
-    file_utils.set_content_if_changed(config.get_output_source_filepath('ElaboratorListener.cpp'), file_content)
+  file_content = file_content.replace('<MODULE_ELABORATOR_LISTENER>', (' ' * 6) + ('\n' + (' ' * 6)).join(module_listeners))
+  file_content = file_content.replace('<INTERFACE_ELABORATOR_LISTENER>', (' ' * 10) + ('\n' + (' ' * 10)).join(interface_listeners))
+  file_content = file_content.replace('<CLASS_ELABORATOR_LISTENER>', (' ' * 2) + ('\n' + (' ' * 2)).join(class_listeners))
+  file_utils.set_content_if_changed(config.get_output_source_filepath('ElaboratorListener.cpp'), file_content)
 
-    return True
+  return True
 
 
 def _main():
-    import loader
+  import loader
 
-    config.configure()
+  config.configure()
 
-    models = loader.load_models()
-    return generate(models)
+  models = loader.load_models()
+  return generate(models)
 
 
 if __name__ == '__main__':
-    import sys
-    sys.exit(0 if _main() else 1)
+  import sys
+  sys.exit(0 if _main() else 1)

--- a/templates/BaseClass.cpp
+++ b/templates/BaseClass.cpp
@@ -44,9 +44,11 @@ std::tuple<const BaseClass*, UHDM_OBJECT_TYPE,
 BaseClass::GetByVpiType(int32_t type) const {
   switch (type) {
     case vpiParent:
-      return std::make_tuple(vpiParent_, static_cast<UHDM_OBJECT_TYPE>(0), nullptr);
+      return std::make_tuple(vpiParent_, static_cast<UHDM_OBJECT_TYPE>(0),
+                             nullptr);
     default:
-      return std::make_tuple(nullptr, static_cast<UHDM_OBJECT_TYPE>(0), nullptr);
+      return std::make_tuple(nullptr, static_cast<UHDM_OBJECT_TYPE>(0),
+                             nullptr);
   };
 }
 
@@ -85,32 +87,40 @@ BaseClass::vpi_property_value_t BaseClass::GetVpiPropertyValue(
   return vpi_property_value_t();
 }
 
-BaseClass* BaseClass::DeepClone(Serializer* serializer,
-                                ElaboratorListener* elaborator,
-                                BaseClass* parent) const {
+BaseClass* BaseClass::DeepClone(BaseClass* parent,
+                                CloneContext* context) const {
   return nullptr;
 }
 
-void BaseClass::DeepCopy(BaseClass* clone, Serializer* serializer,
-                         ElaboratorListener* elaborator,
-                         BaseClass* parent) const {
+void BaseClass::DeepCopy(BaseClass* clone, BaseClass* parent,
+                         CloneContext* context) const {
   clone->VpiParent(parent);
 }
 
 int32_t BaseClass::Compare(const BaseClass* const other,
-                           AnySet& visited) const {
+                           CompareContext* context) const {
   int32_t r = 0;
 
-  if ((r = VpiType() - other->VpiType()) != 0) return r;
-  if ((r = VpiName().compare(other->VpiName())) != 0) return r;
-  if ((r = VpiDefName().compare(other->VpiDefName())) != 0) return r;
+  const thistype_t* const lhs = this;
+  const thistype_t* const rhs = other;
+
+  if ((r = VpiType() - rhs->VpiType()) != 0) {
+    context->m_failedLhs = lhs;
+    context->m_failedRhs = rhs;
+    return r;
+  }
+  if ((r = VpiName().compare(rhs->VpiName())) != 0) {
+    context->m_failedLhs = lhs;
+    context->m_failedRhs = rhs;
+    return r;
+  }
+  if ((r = VpiDefName().compare(rhs->VpiDefName())) != 0) {
+    context->m_failedLhs = lhs;
+    context->m_failedRhs = rhs;
+    return r;
+  }
 
   return r;
-}
-
-int32_t BaseClass::Compare(const BaseClass* const other) const {
-  AnySet visited;
-  return Compare(other, visited);
 }
 
 }  // namespace UHDM

--- a/templates/ElaboratorListener.cpp
+++ b/templates/ElaboratorListener.cpp
@@ -102,14 +102,13 @@ static void propagateParamAssign(param_assign* pass, const any* target) {
 
 void ElaboratorListener::enterVariables(const variables* object,
                                         vpiHandle handle) {
-  Serializer* s = ((variables*)object)->GetSerializer();
   if (object->UhdmType() == uhdmclass_var) {
     if (!inHierarchy_)
       return;  // Only do class var propagation while in elaboration
     const class_var* cv = (class_var*)object;
     class_var* const rw_cv = (class_var*)cv;
     if (typespec* ctps = (typespec*)cv->Typespec()) {
-      ctps = ctps->DeepClone(s, this, rw_cv);
+      ctps = ctps->DeepClone(rw_cv, context_);
       rw_cv->Typespec(ctps);
       if (class_typespec* cctps = any_cast<class_typespec*>(ctps)) {
         if (VectorOfparam_assign* params = cctps->Param_assigns()) {
@@ -442,7 +441,7 @@ void ElaboratorListener::leavePackage(const package* object, vpiHandle handle) {
       ((package*)object)->Task_funcs(clone_vec);
       for (auto obj : *vec) {
         enterTask_func(obj, nullptr);
-        auto* tf = obj->DeepClone(serializer_, this, (package*)object);
+        auto* tf = obj->DeepClone((package*)object, context_);
         ComponentMap& funcMap =
             std::get<3>(instStack_.at(instStack_.size() - 2));
         auto it = funcMap.find(tf->VpiName());

--- a/templates/ExprEval.cpp
+++ b/templates/ExprEval.cpp
@@ -835,10 +835,10 @@ expr *ExprEval::flattenPatternAssignments(Serializer &s, const typespec *tps,
       index++;
     }
     index = 0;
-    ElaboratorListener listener(&s, false, m_muteError);
+    ElaboratorContext elaboratorContext(&s, false, m_muteError);
     for (auto opi : tmp) {
       if (defaultOp && (opi == nullptr)) {
-        opi = clone_tree((any *)defaultOp, s, &listener);
+        opi = clone_tree((any *)defaultOp, &elaboratorContext);
         if (opi != nullptr) {
           opi->VpiParent(const_cast<any *>(defaultOp->VpiParent()));
         }
@@ -887,7 +887,7 @@ expr *ExprEval::flattenPatternAssignments(Serializer &s, const typespec *tps,
       ordered->push_back(opi);
       index++;
     }
-    operation *opres = (operation *)clone_tree((any *)op, s, &listener);
+    operation *opres = (operation *)clone_tree((any *)op, &elaboratorContext);
     opres->VpiParent(const_cast<any *>(op->VpiParent()));
     opres->Operands(ordered);
     if (flatten) {
@@ -2068,8 +2068,8 @@ any *ExprEval::decodeHierPath(hier_path *path, bool &invalidValue,
     } else if (ref_obj *ref = any_cast<ref_obj *>(object)) {
       object = reduceExpr(ref, invalidValue, inst, pexpr, muteError);
     } else if (constant *cons = any_cast<constant *>(object)) {
-      ElaboratorListener listener(&s);
-      object = UHDM::clone_tree((any *)cons, s, &listener);
+      ElaboratorContext elaboratorContext(&s);
+      object = UHDM::clone_tree((any *)cons, &elaboratorContext);
       cons = any_cast<constant *>(object);
       if (cons->Typespec() == nullptr)
         cons->Typespec((typespec *)path->Typespec());
@@ -4815,8 +4815,8 @@ expr *ExprEval::evalFunc(UHDM::function *func, std::vector<any *> *args,
   if (param_assigns) {
     scope->Param_assigns(s.MakeParam_assignVec());
     for (auto p : *param_assigns) {
-      ElaboratorListener listener(&s, false, muteError);
-      any *pp = UHDM::clone_tree(p, s, &listener);
+      ElaboratorContext elaboratorContext(&s, false, muteError);
+      any *pp = UHDM::clone_tree(p, &elaboratorContext);
       scope->Param_assigns()->push_back((param_assign *)pp);
       const typespec *tps = nullptr;
       const expr *lhs = any_cast<const expr *>(p->Lhs());
@@ -4937,8 +4937,8 @@ expr *ExprEval::evalFunc(UHDM::function *func, std::vector<any *> *args,
           uint64_t si = size(tps, invalidValue, inst, pexpr, true, true);
           if (p->Rhs() && (p->Rhs()->UhdmType() == uhdmconstant)) {
             constant *c = (constant *)p->Rhs();
-            ElaboratorListener listener(&s, false, muteError);
-            c = (constant *)UHDM::clone_tree(c, s, &listener);
+            ElaboratorContext elaboratorContext(&s, false, muteError);
+            c = (constant *)UHDM::clone_tree(c, &elaboratorContext);
             if (c->VpiConstType() == vpiBinaryConst) {
               std::string_view val = c->VpiValue();
               val.remove_prefix(std::string_view("BIN:").length());

--- a/templates/UhdmAdjuster.cpp
+++ b/templates/UhdmAdjuster.cpp
@@ -46,8 +46,8 @@ const any* UhdmAdjuster::resize(const any* object, int32_t maxsize,
   if (type == uhdmconstant) {
     constant* c = (constant*)result;
     if (c->VpiSize() < maxsize) {
-      ElaboratorListener listener(serializer_);
-      c = (constant*)UHDM::clone_tree(c, *serializer_, &listener);
+      ElaboratorContext elaboratorContext(serializer_);
+      c = (constant*)UHDM::clone_tree(c, &elaboratorContext);
       int32_t constType = c->VpiConstType();
       const typespec* tps = c->Typespec();
       bool is_signed = false;
@@ -214,7 +214,7 @@ void UhdmAdjuster::leaveConstant(const constant* object, vpiHandle handle) {
     int32_t size = object->VpiSize();
     bool invalidValue = false;
     UHDM::ExprEval eval;
-    ElaboratorListener listener(serializer_);
+    ElaboratorContext elaboratorContext(serializer_);
     if (parent) {
       if (parent->UhdmType() == uhdmoperation) {
         operation* op = (operation*)parent;
@@ -234,7 +234,7 @@ void UhdmAdjuster::leaveConstant(const constant* object, vpiHandle handle) {
         }
         if (size != object->VpiSize()) {
           constant* newc =
-              (constant*)UHDM::clone_tree(object, *serializer_, &listener);
+              (constant*)UHDM::clone_tree(object, &elaboratorContext);
           newc->VpiSize(size);
           int64_t val = eval.get_value(invalidValue, object);
           if (val == 1) {
@@ -271,7 +271,7 @@ void UhdmAdjuster::leaveConstant(const constant* object, vpiHandle handle) {
         }
         if (size != object->VpiSize()) {
           constant* newc =
-              (constant*)UHDM::clone_tree(object, *serializer_, &listener);
+              (constant*)UHDM::clone_tree(object, &elaboratorContext);
           newc->VpiSize(size);
           int64_t val = eval.get_value(invalidValue, object);
           if (val == 1) {

--- a/templates/class_header.h
+++ b/templates/class_header.h
@@ -50,8 +50,9 @@ public:
   <VIRTUAL> UHDM_OBJECT_TYPE UhdmType() const <OVERRIDE_OR_FINAL> { return uhdm<CLASSNAME>; }
 
 protected:
-  void DeepCopy(<CLASSNAME>* clone, Serializer* serializer,
-                ElaboratorListener* elaborator, BaseClass* parent) const;
+  void DeepCopy(<CLASSNAME>* clone,
+                BaseClass* parent,
+                CloneContext* context) const;
 
 private:
 <MEMBERS>

--- a/templates/clone_tree.h
+++ b/templates/clone_tree.h
@@ -29,11 +29,10 @@
 
 namespace UHDM {
 class BaseClass;
-class ElaboratorListener;
-class Serializer;
+class CloneContext;
 
-BaseClass* clone_tree (const BaseClass* root, Serializer& s, ElaboratorListener* elaborator = nullptr);
+BaseClass* clone_tree(const BaseClass* root, CloneContext* context);
 
-};
+};  // namespace UHDM
 
 #endif  // UHDM_CLONE_TREE_H

--- a/templates/vpi_user.cpp
+++ b/templates/vpi_user.cpp
@@ -269,7 +269,8 @@ PLI_INT32 vpi_compare_objects(vpiHandle handle1, vpiHandle handle2) {
   // NOTE: As per the standard, this API is expected to return a 1 for equal.
   // And, yes that is counter intuitive. But BaseClass::Compare returns a 0
   // for equal. Negate the result here to meet standard requirements.
-  return (object1 == object2) ? 1 : ((object1->Compare(object2) == 0) ? 1 : 0);
+  CompareContext context;
+  return (object1 == object2) ? 1 : ((object1->Compare(object2, &context) == 0) ? 1 : 0);
 }
 
 vpiHandle vpi_scan(vpiHandle iterator) {

--- a/templates/vpi_visitor.cpp
+++ b/templates/vpi_visitor.cpp
@@ -604,19 +604,18 @@ void visit_designs(const std::vector<vpiHandle>& designs, std::ostream &out) {
   visit_designs(designs, &visitor);
 }
 
-std::string decompile(UHDM::any* handle) {
-  UHDM::VisitedContainer visited;
-  vpi_show_ids(true);
+std::string decompile(const UHDM::any* handle) {
   if (handle == nullptr) {
     std::cout << "NULL HANDLE\n";
     return "NULL HANDLE";
   }
+  UHDM::VisitedContainer visited;
+  vpi_show_ids(true);
   vpiHandle dh =
       handle->GetSerializer()->MakeUhdmHandle(handle->UhdmType(), handle);
   std::stringstream out;
   VpiVisitor visitor(out);
   visitor.visit_object(dh, 0, "decompile", false);
-  std::cout << out.str() << std::endl;
   vpi_release_handle(dh);
   return out.str();
 }

--- a/templates/vpi_visitor.h
+++ b/templates/vpi_visitor.h
@@ -48,7 +48,7 @@ void visit_designs(const std::vector<vpiHandle>& designs, VpiVisitor* visitor);
 void visit_designs(const std::vector<vpiHandle>& designs, std::ostream& out);
 
 // For debug use in GDB
-std::string decompile(UHDM::any* handle);
+std::string decompile(const UHDM::any* handle);
 
 class VpiVisitor final {
  private:

--- a/tests/classes_test.cpp
+++ b/tests/classes_test.cpp
@@ -2,12 +2,11 @@
 #include <iostream>
 
 #include "gtest/gtest.h"
-#include "uhdm/ElaboratorListener.h"
-#include "uhdm/uhdm.h"
-#include "uhdm/VpiListener.h"
-#include "uhdm/vpi_visitor.h"
-
 #include "test_util.h"
+#include "uhdm/ElaboratorListener.h"
+#include "uhdm/VpiListener.h"
+#include "uhdm/uhdm.h"
+#include "uhdm/vpi_visitor.h"
 
 using namespace UHDM;
 
@@ -117,9 +116,10 @@ TEST(ClassesTest, DesignSaveRestoreRoundtrip) {
   EXPECT_EQ(before, restored);
 
   // Elaborate restored designs
-  ElaboratorListener* listener = new ElaboratorListener(&serializer, true);
-  listener->listenDesigns(restoredDesigns);
-  delete listener;
+  ElaboratorContext* elaboratorContext =
+      new ElaboratorContext(&serializer, true);
+  elaboratorContext->m_elaborator.listenDesigns(restoredDesigns);
+  delete elaboratorContext;
 
   const std::string elaborated = designs_to_string(restoredDesigns);
   EXPECT_NE(restored, elaborated);  // Elaboration should've done _something_

--- a/tests/expr_prettyPrint_test.cpp
+++ b/tests/expr_prettyPrint_test.cpp
@@ -4,13 +4,12 @@
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "uhdm/ElaboratorListener.h"
-#include "uhdm/uhdm.h"
-#include "uhdm/VpiListener.h"
-#include "uhdm/vpi_visitor.h"
-#include "uhdm/ExprEval.h"
-
 #include "test_util.h"
+#include "uhdm/ElaboratorListener.h"
+#include "uhdm/ExprEval.h"
+#include "uhdm/VpiListener.h"
+#include "uhdm/uhdm.h"
+#include "uhdm/vpi_visitor.h"
 
 using namespace UHDM;
 
@@ -26,21 +25,21 @@ std::vector<vpiHandle> build_designs_MinusOp(Serializer* s) {
   {
     dut->VpiDefName("M1");
     dut->VpiParent(d);
-    //dut->VpiFile("fake1.sv");
-    //dut->VpiLineNo(10);
-    VectorOfport *vp = s->MakePortVec();
+    // dut->VpiFile("fake1.sv");
+    // dut->VpiLineNo(10);
+    VectorOfport* vp = s->MakePortVec();
     dut->Ports(vp);
     port* p = s->MakePort();
     vp->push_back(p);
     p->VpiName("wire_i");
     p->VpiDirection(vpiInput);
 
-    logic_typespec * tps = s->MakeLogic_typespec();
+    logic_typespec* tps = s->MakeLogic_typespec();
     p->Typespec(tps);
 
     VectorOfrange* ranges = s->MakeRangeVec();
     tps->Ranges(ranges);
-    range * range = s->MakeRange();
+    range* range = s->MakeRange();
     ranges->push_back(range);
 
     operation* oper = s->MakeOperation();
@@ -67,7 +66,6 @@ std::vector<vpiHandle> build_designs_MinusOp(Serializer* s) {
     c2->VpiDecompile("0");
 
     range->Right_expr(c2);
-
   }
 
   VectorOfmodule_inst* topModules = s->MakeModule_instVec();
@@ -80,13 +78,12 @@ std::vector<vpiHandle> build_designs_MinusOp(Serializer* s) {
   return designs;
 }
 
-
-TEST(exprVal,prettyPrint_MinusOp) {
+TEST(exprVal, prettyPrint_MinusOp) {
   Serializer serializer;
   const std::vector<vpiHandle>& designs = build_designs_MinusOp(&serializer);
-  //serializer.Save("expr_MinusOp_test.uhdm");
-  //const std::string before = designs_to_string(designs);
-  //std::cout << before <<std::endl;
+  // serializer.Save("expr_MinusOp_test.uhdm");
+  // const std::string before = designs_to_string(designs);
+  // std::cout << before <<std::endl;
 
   bool elaborated = false;
   for (auto design : designs) {
@@ -94,9 +91,10 @@ TEST(exprVal,prettyPrint_MinusOp) {
   }
   EXPECT_FALSE(elaborated);
 
-  ElaboratorListener* listener = new ElaboratorListener(&serializer, true);
-  listener->listenDesigns(designs);
-  delete listener;
+  ElaboratorContext* elaboratorContext =
+      new ElaboratorContext(&serializer, true);
+  elaboratorContext->m_elaborator.listenDesigns(designs);
+  delete elaboratorContext;
 
   elaborated = false;
   for (auto design : designs) {
@@ -110,27 +108,22 @@ TEST(exprVal,prettyPrint_MinusOp) {
   ExprEval eval;
   for (auto m : *d->TopModules()) {
     for (auto p : *m->Ports()) {
-	logic_typespec *  typespec = (logic_typespec *) p->Typespec();
-    	VectorOfrange* ranges = typespec->Ranges();
-	for (auto range : *ranges) {
+      logic_typespec* typespec = (logic_typespec*)p->Typespec();
+      VectorOfrange* ranges = typespec->Ranges();
+      for (auto range : *ranges) {
+        expr* left = (expr*)range->Left_expr();
+        std::string left_str = eval.prettyPrint((any*)left);
+        EXPECT_EQ(left_str, "SIZE - 1");
 
-	  expr * left = (expr *) range->Left_expr();
-	  std::string left_str = eval.prettyPrint((any *) left);
-	  EXPECT_EQ(left_str,"SIZE - 1");
-
-	  expr * right = (expr *) range->Right_expr();
-	  std::string right_str = eval.prettyPrint((any *) right);
-	  EXPECT_EQ(right_str,"0");
-	}
-
+        expr* right = (expr*)range->Right_expr();
+        std::string right_str = eval.prettyPrint((any*)right);
+        EXPECT_EQ(right_str, "0");
+      }
     }
   }
-
 }
 
-
 std::vector<vpiHandle> build_designs_ConditionOp(Serializer* s) {
-
   std::vector<vpiHandle> designs;
   // Design building
   design* d = s->MakeDesign();
@@ -144,8 +137,8 @@ std::vector<vpiHandle> build_designs_ConditionOp(Serializer* s) {
     dut->VpiParent(d);
     dut->Parameters(s->MakeAnyVec());
 
-    VectorOfparam_assign *vpa = s->MakeParam_assignVec();
-    
+    VectorOfparam_assign* vpa = s->MakeParam_assignVec();
+
     param_assign* param = s->MakeParam_assign();
     vpa->push_back(param);
     dut->Param_assigns(vpa);
@@ -175,7 +168,6 @@ std::vector<vpiHandle> build_designs_ConditionOp(Serializer* s) {
     c2->VpiDecompile("3");
     operands->push_back(c2);
     param->Rhs(oper);
-
   }
 
   VectorOfmodule_inst* topModules = s->MakeModule_instVec();
@@ -188,12 +180,13 @@ std::vector<vpiHandle> build_designs_ConditionOp(Serializer* s) {
   return designs;
 }
 
-TEST(exprVal,prettyPrint_ConditionOp) {
+TEST(exprVal, prettyPrint_ConditionOp) {
   Serializer serializer;
-  const std::vector<vpiHandle>& designs = build_designs_ConditionOp(&serializer);
-  //serializer.Save("expr_ConditionOp_test.uhdm");
-  //const std::string before = designs_to_string(designs);
-  //std::cout << before <<std::endl;
+  const std::vector<vpiHandle>& designs =
+      build_designs_ConditionOp(&serializer);
+  // serializer.Save("expr_ConditionOp_test.uhdm");
+  // const std::string before = designs_to_string(designs);
+  // std::cout << before <<std::endl;
 
   bool elaborated = false;
   for (auto design : designs) {
@@ -201,9 +194,10 @@ TEST(exprVal,prettyPrint_ConditionOp) {
   }
   EXPECT_FALSE(elaborated);
 
-  ElaboratorListener* listener = new ElaboratorListener(&serializer, true);
-  listener->listenDesigns(designs);
-  delete listener;
+  ElaboratorContext* elaboratorContext =
+      new ElaboratorContext(&serializer, true);
+  elaboratorContext->m_elaborator.listenDesigns(designs);
+  delete elaboratorContext;
 
   elaborated = false;
   for (auto design : designs) {
@@ -218,16 +212,13 @@ TEST(exprVal,prettyPrint_ConditionOp) {
   for (auto m : *d->TopModules()) {
     for (auto pa : *m->Param_assigns()) {
       const any* rhs = pa->Rhs();
-      std::string result = eval.prettyPrint( (any*) rhs);
-      EXPECT_EQ(result,"b ? 1 : 3");
+      std::string result = eval.prettyPrint((any*)rhs);
+      EXPECT_EQ(result, "b ? 1 : 3");
     }
   }
-
 }
 
-
 std::vector<vpiHandle> build_designs_functionCall(Serializer* s) {
-
   std::vector<vpiHandle> designs;
   // Design building
   design* d = s->MakeDesign();
@@ -241,7 +232,7 @@ std::vector<vpiHandle> build_designs_functionCall(Serializer* s) {
     dut->VpiParent(d);
     dut->Parameters(s->MakeAnyVec());
 
-    VectorOfparam_assign *vpa = s->MakeParam_assignVec();
+    VectorOfparam_assign* vpa = s->MakeParam_assignVec();
 
     param_assign* param = s->MakeParam_assign();
     vpa->push_back(param);
@@ -252,13 +243,12 @@ std::vector<vpiHandle> build_designs_functionCall(Serializer* s) {
     p->VpiName("a");
     param->Lhs(p);
 
-    sys_func_call* sfc  = s->MakeSys_func_call();
+    sys_func_call* sfc = s->MakeSys_func_call();
     param->Rhs(sfc);
 
     sfc->VpiName("$sformatf");
 
-
-    VectorOfany * args = s->MakeAnyVec();
+    VectorOfany* args = s->MakeAnyVec();
     sfc->Tf_call_args(args);
     constant* c1 = s->MakeConstant();
     c1->VpiValue("%d");
@@ -266,13 +256,11 @@ std::vector<vpiHandle> build_designs_functionCall(Serializer* s) {
     c1->VpiDecompile("\"%d\"");
     args->push_back(c1);
 
-
     ref_obj* b = s->MakeRef_obj();
     b->VpiName("b");
     args->push_back(b);
     logic_net* n = s->MakeLogic_net();
     b->Actual_group(n);
-
   }
 
   VectorOfmodule_inst* topModules = s->MakeModule_instVec();
@@ -285,12 +273,13 @@ std::vector<vpiHandle> build_designs_functionCall(Serializer* s) {
   return designs;
 }
 
-TEST(exprVal,prettyPrint_functionCall) {
+TEST(exprVal, prettyPrint_functionCall) {
   Serializer serializer;
-  const std::vector<vpiHandle>& designs = build_designs_functionCall(&serializer);
-  //serializer.Save("expr_functionCall_test.uhdm");
-  //const std::string before = designs_to_string(designs);
-  //std::cout << before <<std::endl;
+  const std::vector<vpiHandle>& designs =
+      build_designs_functionCall(&serializer);
+  // serializer.Save("expr_functionCall_test.uhdm");
+  // const std::string before = designs_to_string(designs);
+  // std::cout << before <<std::endl;
 
   bool elaborated = false;
   for (auto design : designs) {
@@ -298,9 +287,10 @@ TEST(exprVal,prettyPrint_functionCall) {
   }
   EXPECT_FALSE(elaborated);
 
-  ElaboratorListener* listener = new ElaboratorListener(&serializer, true);
-  listener->listenDesigns(designs);
-  delete listener;
+  ElaboratorContext* elaboratorContext =
+      new ElaboratorContext(&serializer, true);
+  elaboratorContext->m_elaborator.listenDesigns(designs);
+  delete elaboratorContext;
 
   elaborated = false;
   for (auto design : designs) {
@@ -315,20 +305,16 @@ TEST(exprVal,prettyPrint_functionCall) {
   for (auto m : *d->TopModules()) {
     for (auto pa : *m->Param_assigns()) {
       const any* rhs = pa->Rhs();
-      std::string result = eval.prettyPrint( (any*) rhs);
+      std::string result = eval.prettyPrint((any*)rhs);
       std::string expected_result = "$sformatf(\"%d\",b)";
       std::cout << expected_result << std::endl;
 
-      EXPECT_EQ(expected_result,result);
+      EXPECT_EQ(expected_result, result);
     }
   }
-
 }
 
-
-
 std::vector<vpiHandle> build_designs_select(Serializer* s) {
-
   std::vector<vpiHandle> designs;
   // Design building
   design* d = s->MakeDesign();
@@ -342,7 +328,7 @@ std::vector<vpiHandle> build_designs_select(Serializer* s) {
     dut->VpiParent(d);
     dut->Parameters(s->MakeAnyVec());
 
-    VectorOfparam_assign *vpa = s->MakeParam_assignVec();
+    VectorOfparam_assign* vpa = s->MakeParam_assignVec();
 
     param_assign* param = s->MakeParam_assign();
     vpa->push_back(param);
@@ -353,11 +339,11 @@ std::vector<vpiHandle> build_designs_select(Serializer* s) {
     p->VpiName("a");
     param->Lhs(p);
 
-    var_select* vs  = s->MakeVar_select();
+    var_select* vs = s->MakeVar_select();
     param->Rhs(vs);
 
     vs->VpiName("b");
-    VectorOfexpr * exprs = s->MakeExprVec();
+    VectorOfexpr* exprs = s->MakeExprVec();
     vs->Exprs(exprs);
 
     constant* c1 = s->MakeConstant();
@@ -366,17 +352,15 @@ std::vector<vpiHandle> build_designs_select(Serializer* s) {
     c1->VpiDecompile("3");
     exprs->push_back(c1);
 
-
     constant* c2 = s->MakeConstant();
     c2->VpiValue("UINT:2");
     c2->VpiConstType(vpiIntConst);
     c2->VpiDecompile("2");
     exprs->push_back(c2);
 
-    part_select * ps = s->MakePart_select();
+    part_select* ps = s->MakePart_select();
     exprs->push_back(ps);
     ps->VpiConstantSelect(true);
-
 
     constant* c3 = s->MakeConstant();
     c3->VpiValue("UINT:1");
@@ -389,7 +373,6 @@ std::vector<vpiHandle> build_designs_select(Serializer* s) {
     c4->VpiConstType(vpiIntConst);
     c4->VpiDecompile("0");
     ps->Right_range(c4);
-
   }
 
   VectorOfmodule_inst* topModules = s->MakeModule_instVec();
@@ -402,12 +385,12 @@ std::vector<vpiHandle> build_designs_select(Serializer* s) {
   return designs;
 }
 
-TEST(exprVal,prettyPrint_select) {
+TEST(exprVal, prettyPrint_select) {
   Serializer serializer;
   const std::vector<vpiHandle>& designs = build_designs_select(&serializer);
-  //serializer.Save("expr_select_test.uhdm");
-  //const std::string before = designs_to_string(designs);
-  //std::cout << before <<std::endl;
+  // serializer.Save("expr_select_test.uhdm");
+  // const std::string before = designs_to_string(designs);
+  // std::cout << before <<std::endl;
 
   bool elaborated = false;
   for (auto design : designs) {
@@ -415,9 +398,10 @@ TEST(exprVal,prettyPrint_select) {
   }
   EXPECT_FALSE(elaborated);
 
-  ElaboratorListener* listener = new ElaboratorListener(&serializer, true);
-  listener->listenDesigns(designs);
-  delete listener;
+  ElaboratorContext* elaboratorContext =
+      new ElaboratorContext(&serializer, true);
+  elaboratorContext->m_elaborator.listenDesigns(designs);
+  delete elaboratorContext;
 
   elaborated = false;
   for (auto design : designs) {
@@ -432,19 +416,16 @@ TEST(exprVal,prettyPrint_select) {
   for (auto m : *d->TopModules()) {
     for (auto pa : *m->Param_assigns()) {
       const any* rhs = pa->Rhs();
-      std::string result = eval.prettyPrint( (any*) rhs);
+      std::string result = eval.prettyPrint((any*)rhs);
       std::string expected_result = "b[3][2][1:0]";
       std::cout << expected_result << std::endl;
 
-      EXPECT_EQ(expected_result,result);
+      EXPECT_EQ(expected_result, result);
     }
   }
-
 }
 
-
 std::vector<vpiHandle> build_designs_AssignmentPatternOp(Serializer* s) {
-
   std::vector<vpiHandle> designs;
   // Design building
   design* d = s->MakeDesign();
@@ -458,7 +439,7 @@ std::vector<vpiHandle> build_designs_AssignmentPatternOp(Serializer* s) {
     dut->VpiParent(d);
     dut->Parameters(s->MakeAnyVec());
 
-    VectorOfparam_assign *vpa = s->MakeParam_assignVec();
+    VectorOfparam_assign* vpa = s->MakeParam_assignVec();
 
     param_assign* param = s->MakeParam_assign();
     vpa->push_back(param);
@@ -469,7 +450,7 @@ std::vector<vpiHandle> build_designs_AssignmentPatternOp(Serializer* s) {
     p->VpiName("a");
     param->Lhs(p);
 
-    operation* op  = s->MakeOperation();
+    operation* op = s->MakeOperation();
     param->Rhs(op);
 
     op->VpiOpType(vpiAssignmentPatternOp);
@@ -482,7 +463,6 @@ std::vector<vpiHandle> build_designs_AssignmentPatternOp(Serializer* s) {
     c1->VpiDecompile("1");
     operands->push_back(c1);
 
-
     constant* c2 = s->MakeConstant();
     c2->VpiValue("UINT:2");
     c2->VpiConstType(vpiIntConst);
@@ -494,7 +474,6 @@ std::vector<vpiHandle> build_designs_AssignmentPatternOp(Serializer* s) {
     c3->VpiConstType(vpiIntConst);
     c3->VpiDecompile("3");
     operands->push_back(c3);
-
   }
 
   VectorOfmodule_inst* topModules = s->MakeModule_instVec();
@@ -507,12 +486,13 @@ std::vector<vpiHandle> build_designs_AssignmentPatternOp(Serializer* s) {
   return designs;
 }
 
-TEST(exprVal,prettyPrint_array) {
+TEST(exprVal, prettyPrint_array) {
   Serializer serializer;
-  const std::vector<vpiHandle>& designs = build_designs_AssignmentPatternOp(&serializer);
-  //serializer.Save("expr_AssignmentPatternOp_test.uhdm");
-  //const std::string before = designs_to_string(designs);
-  //std::cout << before <<std::endl;
+  const std::vector<vpiHandle>& designs =
+      build_designs_AssignmentPatternOp(&serializer);
+  // serializer.Save("expr_AssignmentPatternOp_test.uhdm");
+  // const std::string before = designs_to_string(designs);
+  // std::cout << before <<std::endl;
 
   bool elaborated = false;
   for (auto design : designs) {
@@ -520,9 +500,10 @@ TEST(exprVal,prettyPrint_array) {
   }
   EXPECT_FALSE(elaborated);
 
-  ElaboratorListener* listener = new ElaboratorListener(&serializer, true);
-  listener->listenDesigns(designs);
-  delete listener;
+  ElaboratorContext* elaboratorContext =
+      new ElaboratorContext(&serializer, true);
+  elaboratorContext->m_elaborator.listenDesigns(designs);
+  delete elaboratorContext;
 
   elaborated = false;
   for (auto design : designs) {
@@ -537,12 +518,11 @@ TEST(exprVal,prettyPrint_array) {
   for (auto m : *d->TopModules()) {
     for (auto pa : *m->Param_assigns()) {
       const any* rhs = pa->Rhs();
-      std::string result = eval.prettyPrint( (any*) rhs);
+      std::string result = eval.prettyPrint((any*)rhs);
       std::string expected_result = "'{1,2,3}";
       std::cout << expected_result << std::endl;
 
-      EXPECT_EQ(expected_result,result);
+      EXPECT_EQ(expected_result, result);
     }
   }
-
 }

--- a/tests/expr_reduce_test.cpp
+++ b/tests/expr_reduce_test.cpp
@@ -28,13 +28,12 @@
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "uhdm/ElaboratorListener.h"
-#include "uhdm/uhdm.h"
-#include "uhdm/VpiListener.h"
-#include "uhdm/vpi_visitor.h"
-#include "uhdm/ExprEval.h"
-
 #include "test_util.h"
+#include "uhdm/ElaboratorListener.h"
+#include "uhdm/ExprEval.h"
+#include "uhdm/VpiListener.h"
+#include "uhdm/uhdm.h"
+#include "uhdm/vpi_visitor.h"
 
 using namespace UHDM;
 
@@ -104,9 +103,10 @@ TEST(FullElabTest, ElaborationRoundtrip) {
   }
   EXPECT_FALSE(elaborated);
 
-  ElaboratorListener* listener = new ElaboratorListener(&serializer, true);
-  listener->listenDesigns(designs);
-  delete listener;
+  ElaboratorContext* elaboratorContext =
+      new ElaboratorContext(&serializer, true);
+  elaboratorContext->m_elaborator.listenDesigns(designs);
+  delete elaboratorContext;
 
   elaborated = false;
   for (auto design : designs) {
@@ -127,5 +127,4 @@ TEST(FullElabTest, ElaborationRoundtrip) {
       EXPECT_EQ(invalidValue, false);
     }
   }
-
 }

--- a/tests/full_elab_test.cpp
+++ b/tests/full_elab_test.cpp
@@ -29,12 +29,11 @@
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "uhdm/ElaboratorListener.h"
-#include "uhdm/uhdm.h"
-#include "uhdm/VpiListener.h"
-#include "uhdm/vpi_visitor.h"
-
 #include "test_util.h"
+#include "uhdm/ElaboratorListener.h"
+#include "uhdm/VpiListener.h"
+#include "uhdm/uhdm.h"
+#include "uhdm/vpi_visitor.h"
 
 using namespace UHDM;
 
@@ -206,9 +205,10 @@ TEST(FullElabTest, ElaborationRoundtrip) {
             "port 4\n"
             "ref_obj 4\n");
 
-  ElaboratorListener* listener = new ElaboratorListener(&serializer, true);
-  listener->listenDesigns(designs);
-  delete listener;
+  ElaboratorContext* elaboratorContext =
+      new ElaboratorContext(&serializer, true);
+  elaboratorContext->m_elaborator.listenDesigns(designs);
+  delete elaboratorContext;
 
   elaborated = false;
   for (auto design : designs) {

--- a/util/uhdm-cmp.cpp
+++ b/util/uhdm-cmp.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <uhdm/uhdm.h>
+#include <uhdm/vpi_visitor.h>
 #include <uhdm/uhdm-version.h>
 
 #include <algorithm>
@@ -97,8 +98,20 @@ int32_t main(int32_t argc, char **argv) {
                  to_design);
 
   for (size_t i = 0, n = designsA.size(); i < n; ++i) {
-    UHDM::AnySet visited;
-    if (designsA[i]->Compare(designsB[i], visited) != 0) {
+    UHDM::CompareContext context;
+    if (designsA[i]->Compare(designsB[i], &context) != 0) {
+      if (context.m_failedLhs != nullptr) {
+        std::cerr << "LHS:" << std::endl;
+        std::cerr << UHDM::decompile(context.m_failedLhs);
+      } else {
+        std::cerr << "LHS: <null>" << std::endl;
+      }
+      if (context.m_failedRhs != nullptr) {
+        std::cerr << "RHS:" << std::endl;
+        std::cerr << UHDM::decompile(context.m_failedRhs);
+      } else {
+        std::cerr << "RHS: <null>" << std::endl;
+      }
       return -1;
     }
   }

--- a/util/uhdm-dump.cpp
+++ b/util/uhdm-dump.cpp
@@ -144,9 +144,10 @@ int32_t main(int32_t argc, char **argv) {
   }
 
   if (elab) {
-    ElaboratorListener *listener = new ElaboratorListener(&serializer, false);
-    listener->listenDesigns(restoredDesigns);
-    delete listener;
+    ElaboratorContext *elaboratorContext =
+        new ElaboratorContext(&serializer, false);
+    elaboratorContext->m_elaborator.listenDesigns(restoredDesigns);
+    delete elaboratorContext;
 
     std::cout << uhdmFile << ": Restored design Post-Elab: " << std::endl;
     visit_designs(restoredDesigns, std::cout);

--- a/util/uhdm-hier.cpp
+++ b/util/uhdm-hier.cpp
@@ -111,8 +111,7 @@ int32_t main(int32_t argc, char** argv) {
                               " (" + defName + " " + fileName + ":" +
                               std::to_string(vpi_get(vpiLineNo, obj_h)) + ":)")
                         : "";
-                std::string res = path + objectName + lineInfo + "\n";
-                std::cout << res;
+                std::cout << path << objectName << lineInfo << "\n";
                 path += objectName + ".";
               }
               // Recursive tree traversal


### PR DESCRIPTION
Add CloneContext, CompareContext & ElaboratorContext

This is initial change for a larger goal to untie the tight coupling between cloning and elaboration. As it stands today, cloning doesn't work except for the specific case of elaboration.

* Context classes allows for adding additional args to the API without having to change the API itself.
* CompareContext returns the first failed comparison
* CloneContext has no concept of Elaboration to support cloning without elaboration or binding logic
* ElaboratorContext is a subclass of CloneContext that extends the cloning functionality with elaboration.
* uhdm-cmp now prints the first mismatch, if comparison fails.