### PR TITLE
Avoid cycles in VpiListener & in ElaboratorListener

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # -*- mode:cmake -*-
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
-project(UHDM VERSION 1.66)
+project(UHDM VERSION 1.67)
 
 # Detect build type, fallback to release and throw a warning if use didn't
 # specify any

--- a/scripts/VpiListener.py
+++ b/scripts/VpiListener.py
@@ -3,138 +3,142 @@ import file_utils
 
 
 def _get_listeners(classname, vpi, type, card):
-    listeners = []
+  listeners = []
 
-    if card == '1':
-        # upward vpiModule, vpiInterface relation (when card == 1, pointing to the parent object) creates loops in visitors
-        if vpi in ['vpiParent', 'vpiInstance', 'vpiModule', 'vpiInterface', 'vpiUse', 'vpiProgram', 'vpiClassDefn', 'vpiPackage', 'vpiUdp']:
-            return listeners
+  if card == '1':
+    # upward vpiModule, vpiInterface relation (when card == 1, pointing to the parent object) creates loops in visitors
+    if vpi in ['vpiParent', 'vpiInstance', 'vpiModule', 'vpiInterface', 'vpiUse', 'vpiProgram', 'vpiClassDefn', 'vpiPackage', 'vpiUdp']:
+        return listeners
 
-        if 'func_call' in classname and vpi == 'vpiFunction':
-          # Prevent stepping inside functions while processing calls (func_call, method_func_call) to them
-          return listeners
+    if 'func_call' in classname and vpi == 'vpiFunction':
+      # Prevent stepping inside functions while processing calls (func_call, method_func_call) to them
+      return listeners
 
-        if 'task_call' in classname and vpi == 'vpiTask':
-          # Prevent stepping inside tasks while processing calls (task_call, method_task_call) to them
-          return listeners
+    if 'task_call' in classname and vpi == 'vpiTask':
+      # Prevent stepping inside tasks while processing calls (task_call, method_task_call) to them
+      return listeners
 
-        listeners.append(f'  if (vpiHandle itr = vpi_handle({vpi}, handle)) {{')
-        listeners.append(f'    listenAny(itr);')
-        listeners.append( '    vpi_free_object(itr);')
-        listeners.append( '  }')
+    listeners.append(f'  if (vpiHandle itr = vpi_handle({vpi}, handle)) {{')
+    listeners.append(f'    listenAny(itr);')
+    listeners.append( '    vpi_free_object(itr);')
+    listeners.append( '  }')
 
-    else:
-        if 'uhdmall' in vpi:
-          listeners.append(f'  uhdmAllIterator = true;')    
-        listeners.append(f'  if (vpiHandle itr = vpi_iterate({vpi}, handle)) {{')
-        listeners.append( '    while (vpiHandle obj = vpi_scan(itr)) {')
-        listeners.append(f'      listenAny(obj);')
-        listeners.append( '      vpi_free_object(obj);')
-        listeners.append( '    }')
-        listeners.append( '    vpi_free_object(itr);')
-        listeners.append( '  }')
-        if 'uhdmall' in vpi:
-          listeners.append(f'  uhdmAllIterator = false;')
-          listeners.append(f'  visited.clear();')
-    return listeners
+  else:
+    if 'uhdmall' in vpi:
+      listeners.append(f'  uhdmAllIterator = true;')
+
+    listeners.append(f'  if (vpiHandle itr = vpi_iterate({vpi}, handle)) {{')
+    listeners.append( '    while (vpiHandle obj = vpi_scan(itr)) {')
+    listeners.append(f'      listenAny(obj);')
+    listeners.append( '      vpi_free_object(obj);')
+    listeners.append( '    }')
+    listeners.append( '    vpi_free_object(itr);')
+    listeners.append( '  }')
+
+    if 'uhdmall' in vpi:
+      listeners.append(f'  uhdmAllIterator = false;')
+      listeners.append(f'  visited.clear();')
+      listeners.append(f'  visited.emplace((const any*)((const uhdm_handle*)handle)->object);')
+
+  return listeners
 
 
 def generate(models):
-    private_declarations = []
-    private_implementations = []
-    public_implementations = []
-    classnames = set()
+  private_declarations = []
+  private_implementations = []
+  public_implementations = []
+  classnames = set()
 
-    for model in models.values():
-        modeltype = model['type']
-        if modeltype == 'group_def':
-            continue
+  for model in models.values():
+    modeltype = model['type']
+    if modeltype == 'group_def':
+      continue
 
-        classname = model['name']
-        Classname_ = classname[:1].upper() + classname[1:]
+    classname = model['name']
+    Classname_ = classname[:1].upper() + classname[1:]
 
-        baseclass = model.get('extends')
+    baseclass = model.get('extends')
 
-        if model.get('subclasses') or modeltype == 'obj_def':
-            private_declarations.append(f'  void listen{Classname_}_(vpiHandle handle);')
-            private_implementations.append(f'void VpiListener::listen{Classname_}_(vpiHandle handle) {{')
-            if baseclass:
-                Baseclass_ = baseclass[:1].upper() + baseclass[1:]
-                private_implementations.append(f'  listen{Baseclass_}_(handle);')
+    if model.get('subclasses') or modeltype == 'obj_def':
+      private_declarations.append(f'  void listen{Classname_}_(vpiHandle handle);')
+      private_implementations.append(f'void VpiListener::listen{Classname_}_(vpiHandle handle) {{')
+      if baseclass:
+        Baseclass_ = baseclass[:1].upper() + baseclass[1:]
+        private_implementations.append(f'  listen{Baseclass_}_(handle);')
 
-            for key, value in model.allitems():
-                if key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
-                    vpi  = value.get('vpi')
-                    type = value.get('type')
-                    card = value.get('card')
+      for key, value in model.allitems():
+        if key in ['class', 'obj_ref', 'class_ref', 'group_ref']:
+          vpi  = value.get('vpi')
+          type = value.get('type')
+          card = value.get('card')
 
-                    if key == 'group_ref':
-                        type = 'any'
+          if key == 'group_ref':
+            type = 'any'
 
-                    private_implementations.extend(_get_listeners(classname, vpi, type, card))
+          private_implementations.extend(_get_listeners(classname, vpi, type, card))
 
-            private_implementations.append( '}')
-            private_implementations.append( '')
+      private_implementations.append( '}')
+      private_implementations.append( '')
 
-        if modeltype != 'class_def':
-            classnames.add(classname)
+    if modeltype != 'class_def':
+      classnames.add(classname)
 
-            public_implementations.append(f'void VpiListener::listen{Classname_}(vpiHandle handle) {{')
-            public_implementations.append(f'  const {classname}* object = (const {classname}*) ((const uhdm_handle*)handle)->object;')
-            public_implementations.append(f'  callstack.push_back(object);')
-            public_implementations.append(f'  enter{Classname_}(object, handle);')
-            public_implementations.append( '  if (visited.insert(object).second) {')
-            public_implementations.append(f'    listen{Classname_}_(handle);')
-            public_implementations.append( '  }')
-            public_implementations.append(f'  leave{Classname_}(object, handle);')
-            public_implementations.append(f'  callstack.pop_back();')
-            public_implementations.append(f'}}')
-            public_implementations.append( '')
+      public_implementations.append(f'void VpiListener::listen{Classname_}(vpiHandle handle) {{')
+      public_implementations.append(f'  const {classname}* object = (const {classname}*) ((const uhdm_handle*)handle)->object;')
+      public_implementations.append(f'  callstack.push_back(object);')
+      public_implementations.append(f'  enter{Classname_}(object, handle);')
+      public_implementations.append( '  if (visited.insert(object).second) {')
+      public_implementations.append(f'    listen{Classname_}_(handle);')
+      public_implementations.append( '  }')
+      public_implementations.append(f'  leave{Classname_}(object, handle);')
+      public_implementations.append(f'  callstack.pop_back();')
+      public_implementations.append(f'}}')
+      public_implementations.append( '')
 
-    any_implementation = []
-    enter_leave_declarations = []
-    public_declarations = []
-    for classname in sorted(classnames):
-        Classname_ = classname[:1].upper() + classname[1:]
+  any_implementation = []
+  enter_leave_declarations = []
+  public_declarations = []
+  for classname in sorted(classnames):
+    Classname_ = classname[:1].upper() + classname[1:]
 
-        any_implementation.append(f'    case uhdm{classname}: listen{Classname_}(handle); break;')
+    any_implementation.append(f'    case uhdm{classname}: listen{Classname_}(handle); break;')
 
-        enter_leave_declarations.append(f'  virtual void enter{Classname_}(const {classname}* object, vpiHandle handle) {{}}')
-        enter_leave_declarations.append(f'  virtual void leave{Classname_}(const {classname}* object, vpiHandle handle) {{}}')
-        enter_leave_declarations.append( '')
+    enter_leave_declarations.append(f'  virtual void enter{Classname_}(const {classname}* object, vpiHandle handle) {{}}')
+    enter_leave_declarations.append(f'  virtual void leave{Classname_}(const {classname}* object, vpiHandle handle) {{}}')
+    enter_leave_declarations.append( '')
 
-        public_declarations.append(f'  void listen{Classname_}(vpiHandle handle);')
+    public_declarations.append(f'  void listen{Classname_}(vpiHandle handle);')
 
-    # VpiListener.h
-    with open(config.get_template_filepath('VpiListener.h'), 'rt') as strm:
-        file_content = strm.read()
+  # VpiListener.h
+  with open(config.get_template_filepath('VpiListener.h'), 'rt') as strm:
+    file_content = strm.read()
 
-    file_content = file_content.replace('<VPI_PUBLIC_LISTEN_DECLARATIONS>', '\n'.join(public_declarations))
-    file_content = file_content.replace('<VPI_PRIVATE_LISTEN_DECLARATIONS>', '\n'.join(private_declarations))
-    file_content = file_content.replace('<VPI_ENTER_LEAVE_DECLARATIONS>', '\n'.join(enter_leave_declarations))
-    file_utils.set_content_if_changed(config.get_output_header_filepath('VpiListener.h'), file_content)
+  file_content = file_content.replace('<VPI_PUBLIC_LISTEN_DECLARATIONS>', '\n'.join(public_declarations))
+  file_content = file_content.replace('<VPI_PRIVATE_LISTEN_DECLARATIONS>', '\n'.join(private_declarations))
+  file_content = file_content.replace('<VPI_ENTER_LEAVE_DECLARATIONS>', '\n'.join(enter_leave_declarations))
+  file_utils.set_content_if_changed(config.get_output_header_filepath('VpiListener.h'), file_content)
 
-    # VpiListener.cpp
-    with open(config.get_template_filepath('VpiListener.cpp'), 'rt') as strm:
-        file_content = strm.read()
+  # VpiListener.cpp
+  with open(config.get_template_filepath('VpiListener.cpp'), 'rt') as strm:
+    file_content = strm.read()
 
-    file_content = file_content.replace('<VPI_PRIVATE_LISTEN_IMPLEMENTATIONS>', '\n'.join(private_implementations))
-    file_content = file_content.replace('<VPI_PUBLIC_LISTEN_IMPLEMENTATIONS>', '\n'.join(public_implementations))
-    file_content = file_content.replace('<VPI_LISTENANY_IMPLEMENTATION>', '\n'.join(any_implementation))
-    file_utils.set_content_if_changed(config.get_output_source_filepath('VpiListener.cpp'), file_content)
+  file_content = file_content.replace('<VPI_PRIVATE_LISTEN_IMPLEMENTATIONS>', '\n'.join(private_implementations))
+  file_content = file_content.replace('<VPI_PUBLIC_LISTEN_IMPLEMENTATIONS>', '\n'.join(public_implementations))
+  file_content = file_content.replace('<VPI_LISTENANY_IMPLEMENTATION>', '\n'.join(any_implementation))
+  file_utils.set_content_if_changed(config.get_output_source_filepath('VpiListener.cpp'), file_content)
 
-    return True
+  return True
 
 
 def _main():
-    import loader
+  import loader
 
-    config.configure()
+  config.configure()
 
-    models = loader.load_models()
-    return generate(models)
+  models = loader.load_models()
+  return generate(models)
 
 
 if __name__ == '__main__':
-    import sys
-    sys.exit(0 if _main() else 1)
+  import sys
+  sys.exit(0 if _main() else 1)

--- a/templates/ElaboratorListener.cpp
+++ b/templates/ElaboratorListener.cpp
@@ -763,7 +763,11 @@ any* ElaboratorListener::bindNet(std::string_view name) const {
     const ComponentMap& netMap = std::get<1>(*i);
     ComponentMap::const_iterator netItr = netMap.find(name);
     if (netItr != netMap.end()) {
-      return (any*)netItr->second;
+      const any* p = netItr->second;
+      if (const ref_obj* r = any_cast<const ref_obj*>(p)) {
+        p = r->Actual_group();
+      }
+      return const_cast<any*>(p);
     }
   }
   return nullptr;
@@ -779,19 +783,31 @@ any* ElaboratorListener::bindAny(std::string_view name) const {
     const ComponentMap& netMap = std::get<1>(*i);
     ComponentMap::const_iterator netItr = netMap.find(name);
     if (netItr != netMap.end()) {
-      return (any*)netItr->second;
+      const any* p = netItr->second;
+      if (const ref_obj* r = any_cast<const ref_obj*>(p)) {
+        p = r->Actual_group();
+      }
+      return const_cast<any*>(p);
     }
 
     const ComponentMap& paramMap = std::get<2>(*i);
     ComponentMap::const_iterator paramItr = paramMap.find(name);
     if (paramItr != paramMap.end()) {
-      return (any*)paramItr->second;
+      const any* p = paramItr->second;
+      if (const ref_obj* r = any_cast<const ref_obj*>(p)) {
+        p = r->Actual_group();
+      }
+      return const_cast<any*>(p);
     }
 
     const ComponentMap& modMap = std::get<4>(*i);
     ComponentMap::const_iterator modItr = modMap.find(name);
     if (modItr != modMap.end()) {
-      return (any*)modItr->second;
+      const any* p = modItr->second;
+      if (const ref_obj* r = any_cast<const ref_obj*>(p)) {
+        p = r->Actual_group();
+      }
+      return const_cast<any*>(p);
     }
   }
   return nullptr;
@@ -807,7 +823,11 @@ any* ElaboratorListener::bindParam(std::string_view name) const {
     const ComponentMap& paramMap = std::get<2>(*i);
     ComponentMap::const_iterator paramItr = paramMap.find(name);
     if (paramItr != paramMap.end()) {
-      return (any*)paramItr->second;
+      const any* p = paramItr->second;
+      if (const ref_obj* r = any_cast<const ref_obj*>(p)) {
+        p = r->Actual_group();
+      }
+      return const_cast<any*>(p);
     }
   }
   return nullptr;
@@ -824,7 +844,11 @@ any* ElaboratorListener::bindTaskFunc(std::string_view name,
     const ComponentMap& funcMap = std::get<3>(*i);
     ComponentMap::const_iterator funcItr = funcMap.find(name);
     if (funcItr != funcMap.end()) {
-      return (any*)funcItr->second;
+      const any* p = funcItr->second;
+      if (const ref_obj* r = any_cast<const ref_obj*>(p)) {
+        p = r->Actual_group();
+      }
+      return const_cast<any*>(p);
     }
   }
   if (prefix) {
@@ -1244,8 +1268,10 @@ void ElaboratorListener::leaveMethod_func_call(const method_func_call* object,
 }
 
 void ElaboratorListener::leaveRef_obj(const ref_obj* object, vpiHandle handle) {
-  if (any* res = bindAny(object->VpiName())) {
-    ((ref_obj*)object)->Actual_group(res);
+  if (object->Actual_group() == nullptr) {
+    if (any* res = bindAny(object->VpiName())) {
+      ((ref_obj*)object)->Actual_group(res);
+    }
   }
 }
 

--- a/templates/ElaboratorListener.cpp
+++ b/templates/ElaboratorListener.cpp
@@ -1268,10 +1268,8 @@ void ElaboratorListener::leaveMethod_func_call(const method_func_call* object,
 }
 
 void ElaboratorListener::leaveRef_obj(const ref_obj* object, vpiHandle handle) {
-  if (object->Actual_group() == nullptr) {
-    if (any* res = bindAny(object->VpiName())) {
-      ((ref_obj*)object)->Actual_group(res);
-    }
+  if (any* res = bindAny(object->VpiName())) {
+    ((ref_obj*)object)->Actual_group(res);
   }
 }
 

--- a/templates/VpiListener.cpp
+++ b/templates/VpiListener.cpp
@@ -55,7 +55,7 @@ void VpiListener::listenAny(vpiHandle handle) {
 void VpiListener::listenDesigns(const std::vector<vpiHandle>& designs) {
   for (auto design_h : designs) {
     currentDesign_ = (design*) ((const uhdm_handle*)design_h)->object;
-    listenDesign(design_h);
+    listenAny(design_h);
   }
 }
 }  // namespace UHDM


### PR DESCRIPTION
Avoid cycles in VpiListener & in ElaboratorListener

* A ref_obj shouldn't point to another ref_obj as its actual_group.
* listenDesign_ clears the visited container between iterating allXXX and topXXX. That removes the top level design as well (which was added by listenDesign) causing infinite loops.
  This is found in cases where "$root" is used and the corresponding ref_obj::actual_group points to a design.