### PR TITLE
Check for null before attempting to save

### DIFF
--- a/scripts/serializer.py
+++ b/scripts/serializer.py
@@ -112,7 +112,7 @@ def generate(models):
 
                         restore_adapters.append(f'    obj->{Name_}(({type}*)serializer->GetObject(reader.get{Name}().getType(), reader.get{Name}().getIndex() - 1));')
                     else:
-                        saves_adapters.append(f'    builder.set{Name}(serializer->GetId(obj->{Name_}()));')
+                        saves_adapters.append(f'    if (obj->{Name_}() != nullptr) builder.set{Name}(serializer->GetId(obj->{Name_}()));')
 
                         restore_adapters.append(f'    if (reader.get{Name}()) {{')
                         restore_adapters.append(f'      obj->{Name_}(serializer->{type}Maker.objects_[reader.get{Name}() - 1]);')


### PR DESCRIPTION
Check for null before attempting to save

The issue surfaced in cases where multiple unsupported_typespec got erased. The accumulation of nullptr in allIds_ would return the index of the first such attempt which may not be same for other subsequent ones.