### PR TITLE
chipsalliance/Surelog#65: Deprecate flatbuffers in favor of Cap'n'Proto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ include(GNUInstallDirs)
 
 # NOTE: Policy changes has to happen before adding any subprojects
 cmake_policy(SET CMP0091 NEW)
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -60,9 +60,9 @@ else()
   set(BUILD_TESTING OFF CACHE BOOL "Don't build capnproto tests")
   set(WITH_FIBERS "OFF" CACHE STRING "Whether or not to build libkj-async with fibers")
   add_subdirectory(third_party/capnproto EXCLUDE_FROM_ALL)
-  set(CAPNP_DIR ${CMAKE_CURRENT_BINARY_DIR}/third_party/capnproto/c++/src/capnp)
-  set(CAPNP_EXECUTABLE ${CAPNP_DIR}/capnp)
-  set(CAPNPC_CXX_EXECUTABLE ${CAPNP_DIR}/capnpc-c++)
+  set(CAPNP_DIR ${CMAKE_CURRENT_BINARY_DIR}/third_party/capnproto/c++/src/capnp CACHE PATH "Location of capnp installation" FORCE)
+  set(CAPNP_EXECUTABLE ${CAPNP_DIR}/capnp CACHE FILEPATH "Location of capnp executable" FORCE)
+  set(CAPNPC_CXX_EXECUTABLE ${CAPNP_DIR}/capnpc-c++ CACHE FILEPATH "Location of capnp-c++ executable" FORCE)
 endif()
 
 # NOTE: Set the global output directories after the subprojects have had their go at it
@@ -216,11 +216,13 @@ target_include_directories(uhdm SYSTEM PUBLIC
 target_include_directories(uhdm PRIVATE ${GENDIR}/src)
 
 if (UHDM_USE_HOST_CAPNP)
-  target_include_directories(uhdm PRIVATE ${CAPNP_INCLUDE_DIRS})
-  target_link_libraries(uhdm PRIVATE CapnProto::capnp)
+  target_include_directories(uhdm PUBLIC ${CAPNP_INCLUDE_DIRS})
+  target_link_libraries(uhdm PUBLIC CapnProto::capnp)
 else()
-  target_include_directories(uhdm PRIVATE ${PROJECT_SOURCE_DIR}/third_party/capnproto/c++/src)
-  target_link_libraries(uhdm PRIVATE capnp)
+  target_include_directories(uhdm PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/capnproto/c++/src>
+    $<INSTALL_INTERFACE:include>)
+  target_link_libraries(uhdm PUBLIC capnp)
 endif()
 
 target_compile_definitions(uhdm

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -25,5 +25,25 @@
 #cmakedefine01 UHDM_SYMBOLID_DEBUG_ENABLED
 
 #if defined(_MSC_VER)
+  // Since windows is built with /w4, disable a few warnings
+  // that aren't very useful
   #pragma warning(disable: 4100)  // unreferenced formal parameter
+  #pragma warning(disable: 4146)  // unary minus operator applied to unsigned
+                                  // type, result still unsigned
+  #pragma warning(disable: 4244)  // 'argument' : conversion from 'type1' to
+                                  // 'type2', possible loss of data
+  #pragma warning(disable: 4267)  // 'argument': conversion from 'size_t' to
+                                  // 'unsigned int', possible loss of data
+  #pragma warning(disable: 4334)  // '<<': result of 32-bit shift implicitly
+                                  // converted to 64 bits (was 64-bit shift
+                                  // intended?)
+  #pragma warning(disable: 4456)  // declaration of '' hides previous local
+                                  // declaration
+  #pragma warning(disable: 4457)  // declaration of '' hides function parameter
+  #pragma warning(disable: 4458)  // declaration of '' hides class member
+  #pragma warning(disable: 4706)  // assignment within conditional expression
+
+  #define S_IRWXU (_S_IREAD | _S_IWRITE)
+#elif !(defined(__MINGW32__) || defined(__CYGWIN__))
+  #define O_BINARY 0
 #endif

--- a/templates/Serializer.cpp
+++ b/templates/Serializer.cpp
@@ -35,11 +35,6 @@
 
 #include <uhdm/uhdm.h>
 
-#if defined(_MSC_VER)
-  #pragma warning(push)
-  #pragma warning(disable : 4267)  // 'var' : conversion from 'size_t' to 'type', possible loss of data
-#endif
-
 namespace UHDM {
 
 const uint32_t Serializer::kVersion = 1;
@@ -149,7 +144,3 @@ void Serializer::Purge() {
 <FACTORY_PURGE>
 }
 }  // namespace UHDM
-
-#if defined(_MSC_VER)
-  #pragma warning(pop)
-#endif

--- a/templates/Serializer_restore.cpp
+++ b/templates/Serializer_restore.cpp
@@ -31,13 +31,8 @@
 
 #if defined(_MSC_VER)
   #include <io.h>
-  #pragma warning(push)
-  #pragma warning(disable : 4244)  // 'argument' : conversion from 'type1' to 'type2', possible loss of data
 #else
   #include <unistd.h>
-  #if !(defined(__MINGW32__) || defined(__CYGWIN__))
-    #define O_BINARY 0
-  #endif
 #endif
 
 #include <iostream>
@@ -142,7 +137,3 @@ const std::vector<vpiHandle> Serializer::Restore(const std::string& filepath) {
   return designs;
 }
 }  // namespace UHDM
-
-#if defined(_MSC_VER)
-  #pragma warning(pop)
-#endif

--- a/templates/Serializer_save.cpp
+++ b/templates/Serializer_save.cpp
@@ -30,14 +30,8 @@
 
 #if defined(_MSC_VER)
   #include <io.h>
-  #define S_IRWXU (_S_IREAD | _S_IWRITE)
-  #pragma warning(push)
-  #pragma warning(disable : 4267)  // 'var' : conversion from 'size_t' to 'type', possible loss of data
 #else
   #include <unistd.h>
-  #if !(defined(__MINGW32__) || defined(__CYGWIN__))
-    #define O_BINARY 0
-  #endif
 #endif
 
 #include <iostream>
@@ -128,7 +122,3 @@ void Serializer::Save(const std::string& filepath) {
   close(fileid);
 }
 }  // namespace UHDM
-
-#if defined(_MSC_VER)
-  #pragma warning(pop)
-#endif


### PR DESCRIPTION
chipsalliance/Surelog#65: Deprecate flatbuffers in favor of Cap'n'Proto

Make use of Cap'n'Proto in UHDM public. Also, set the Cap'n'Proto related
output variables in the cache so outer projects can use then without
defining them again.

In cmake terms, make use of Cap'n'Proto in UHDM transitive.