### PR TITLE
make utility executables exit with error code 0 when running --help

### DIFF
--- a/util/uhdm-cmp.cpp
+++ b/util/uhdm-cmp.cpp
@@ -39,7 +39,7 @@ static int32_t usage(const char *progName) {
             << "  = 0, if input files are equal" << std::endl
             << "  < 0, if input files are not equal" << std::endl
             << "  > 0, for any failures" << std::endl;
-  return 1;
+  return 0;
 }
 
 int32_t main(int32_t argc, char **argv) {

--- a/util/uhdm-dump.cpp
+++ b/util/uhdm-dump.cpp
@@ -83,7 +83,7 @@ static int32_t usage(const char *progname) {
           "\nIf golden file is given to compare, exit code represent if output "
           "matches.\n");
 
-  return 1;
+  return 0;
 }
 
 int32_t main(int32_t argc, char **argv) {

--- a/util/uhdm-hier.cpp
+++ b/util/uhdm-hier.cpp
@@ -42,7 +42,7 @@ static int32_t usage(const char* progname) {
   fprintf(stderr, "Usage:\n%s [options] <uhdm-file> ?--line?\n", progname);
   fprintf(stderr,
           "Reads UHDM binary representation and prints hierarchy tree.\n");
-  return 1;
+  return 0;
 }
 
 int32_t main(int32_t argc, char** argv) {

--- a/util/uhdm-lint.cpp
+++ b/util/uhdm-lint.cpp
@@ -36,7 +36,7 @@ static int32_t usage(const char *progName) {
             << std::endl
             << std::endl
             << "Exits with code" << std::endl;
-  return 1;
+  return 0;
 }
 
 class MyLinter : public UHDM::VpiListener {


### PR DESCRIPTION
It can be difficult to determine that all linking has been done correctly in a build environment by just looking at the generated libraries. A common pattern I've been seeing (e.g. on homebrew, conda, etc) is to run `my-executable --help` which seems to be expected to not have an error exit code. A quick survey of CLIs on my box confirms this pattern >50% of the time, so I propose we use it here. This is also the behavior of the `surelog` command. 