### PR TITLE
Remove uhdm libs out of own folder, use soversion (fixes #992)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ endif()
 
 # NOTE: Set the global output directories after the subprojects have had their go at it
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 
 set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
@@ -198,7 +198,10 @@ message("Building UHDM version v${UHDM_VERSION_MAJOR}.${UHDM_VERSION_MINOR} [${U
 configure_file(${PROJECT_SOURCE_DIR}/include/uhdm-version.h.in ${GENDIR}/uhdm/uhdm-version.h)
 
 add_library(uhdm ${uhdm-GENERATED_SRC})
-set_target_properties(uhdm PROPERTIES PUBLIC_HEADER ${GENDIR}/uhdm/uhdm.h)
+set_target_properties(uhdm PROPERTIES
+  PUBLIC_HEADER ${GENDIR}/uhdm/uhdm.h
+  SOVERSION "${UHDM_VERSION_MAJOR}.${UHDM_VERSION_MINOR}"
+)
 configure_file(${PROJECT_SOURCE_DIR}/include/config.h.in ${GENDIR}/uhdm/config.h)
 target_compile_options(uhdm PUBLIC
   "SHELL:$<IF:$<CXX_COMPILER_ID:MSVC>,/FI uhdm/config.h,-include uhdm/config.h>")
@@ -349,8 +352,8 @@ if(NOT UHDM_USE_HOST_CAPNP)
   install(
     TARGETS capnp kj
     EXPORT uhdmTargets
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/uhdm
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/uhdm
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/include/uhdm)
 endif()
 
@@ -358,13 +361,13 @@ endif()
 install(
   TARGETS uhdm uhdm-cmp uhdm-dump uhdm-hier uhdm-lint
   EXPORT uhdmTargets
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/uhdm
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/uhdm
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/include/uhdm)
 install(DIRECTORY ${GENDIR}/uhdm/
         DESTINATION ${CMAKE_INSTALL_PREFIX}/include/uhdm/)
 install(FILES ${GENDIR}/src/UHDM.capnp
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/uhdm)
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 
 # Generate cmake config files for reuse by downstream packages
 include(CMakePackageConfigHelpers)

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ install-shared: release-shared
 	cmake --install build --config Release
 
 uninstall:
-	$(RM) $(PREFIX)/bin/uhdm-dump $(PREFIX)/bin/uhdm-dump
-	$(RM) -r $(PREFIX)/lib/uhdm
+	$(RM) $(PREFIX)/bin/uhdm-*
+	$(RM) -r $(PREFIX)/lib/libuhdm*
 	$(RM) -r $(PREFIX)/include/uhdm
 
 build:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@
 
 # Linking libuhdm.a to your application
  * After instaling (`make install`), create your own executable (Read [`Makefile`](Makefile)) , ie:
- * `$(CXX) -std=c++17 tests/test1.cpp -I/usr/local/include/uhdm -I/usr/local/include/uhdm/include /usr/local/lib/uhdm/libuhdm.a /usr/local/lib/uhdm/libcapnp.a /usr/local/lib/uhdm/libkj.a -ldl -lutil -lm -lrt -lpthread -o test_inst`
+ * `$(CXX) -std=c++17 tests/test1.cpp -I/usr/local/include/uhdm -I/usr/local/include/uhdm/include /usr/local/lib/libuhdm.a /usr/local/lib/libcapnp.a /usr/local/lib/libkj.a -ldl -lutil -lm -lrt -lpthread -o test_inst`
 
 
 # Generating uhdm databases

--- a/cmake/configs/UHDM.pc.in
+++ b/cmake/configs/UHDM.pc.in
@@ -1,6 +1,6 @@
 prefix="@CMAKE_INSTALL_PREFIX@"
 exec_prefix="${prefix}"
-libdir="@CMAKE_INSTALL_FULL_LIBDIR@/uhdm"
+libdir="@CMAKE_INSTALL_FULL_LIBDIR@"
 includedir="@CMAKE_INSTALL_FULL_INCLUDEDIR@"
 
 Name: @PROJECT_NAME@

--- a/cmake/configs/UHDMConfig.cmake.in
+++ b/cmake/configs/UHDMConfig.cmake.in
@@ -7,6 +7,6 @@ include(${CMAKE_CURRENT_LIST_DIR}/UHDMTargets.cmake)
 set_and_check(UHDM_BIN_DIR @CMAKE_INSTALL_PREFIX@/bin)
 set_and_check(UHDM_INCLUDE_DIR @CMAKE_INSTALL_FULL_INCLUDEDIR@)
 set_and_check(UHDM_INCLUDE_DIRS @CMAKE_INSTALL_FULL_INCLUDEDIR@)
-set_and_check(UHDM_LIB_DIR @CMAKE_INSTALL_FULL_LIBDIR@/uhdm)
+set_and_check(UHDM_LIB_DIR @CMAKE_INSTALL_FULL_LIBDIR@)
 
 check_required_components(UHDM)


### PR DESCRIPTION
This PR does two things:
- instead of installing into `lib/uhdm/`, we will install into `lib`. This is the normal method, installing into `lib/uhdm/` has caused problems on both conda and homebrew, and is sure to continue to cause headaches
- we use `SOVERSION` so that `lib/libuhdm.so` is now a symlink, and we install a versioned `lib/libuhdm.so.<major>.<minor>`

Fixes #992 

(I will do a similar PR for Surelog)

---

```
-- Installing: /tmp/uhdm-install/lib/libuhdm.so.1.71
-- Installing: /tmp/uhdm-install/lib/libuhdm.so
```

