### PR TITLE
Make sure serializers include the config.h

### DIFF
--- a/templates/Serializer_restore.cpp
+++ b/templates/Serializer_restore.cpp
@@ -44,6 +44,7 @@
 #include "UHDM.capnp.h"
 #include <uhdm/uhdm.h>
 
+#include "uhdm/config.h"
 
 namespace UHDM {
 static constexpr std::string_view kUnknownRawSymbol = "<unknown>";

--- a/templates/Serializer_save.cpp
+++ b/templates/Serializer_save.cpp
@@ -46,6 +46,7 @@
 #include <uhdm/uhdm.h>
 #include <uhdm/uhdm_types.h>
 
+#include "uhdm/config.h"
 
 namespace UHDM {
 inline static uint32_t GetId(const BaseClass* p, const Serializer::IdMap &idMap) {


### PR DESCRIPTION
The files should be self-contained and include the header that defines the windows-specific O_BINARY.
(Currently that only works accidentally if compiled with cmake)