### PR TITLE
Use ref_obj to reference typespecs

### DIFF
--- a/model/actual_group.yaml
+++ b/model/actual_group.yaml
@@ -35,7 +35,6 @@
   - obj_ref: ref_obj
   - obj_ref: indexed_part_select
   - obj_ref: typespec_member
+  - class_ref: typespec
   - class_ref: task_func
   - class_ref: scope
-
-

--- a/model/array_typespec.yaml
+++ b/model/array_typespec.yaml
@@ -39,12 +39,12 @@
   - class_ref: index_typespec
     name: index typespec
     vpi: vpiIndexTypespec
-    type: typespec
+    type: ref_obj
     card: 1
   - class_ref: elem_typespec
     name: elem typespec
     vpi: vpiElemTypespec
-    type: typespec
+    type: ref_obj
     card: 1
   - obj_ref: resolution_func
     name: resolution func

--- a/model/bit_typespec.yaml
+++ b/model/bit_typespec.yaml
@@ -24,7 +24,7 @@
   - obj_ref: bit_typespec
     name: bit typespec
     vpi: vpiElemTypespec
-    type: bit_typespec
+    type: ref_obj
     card: 1
   - obj_ref: ranges
     name: ranges
@@ -44,7 +44,7 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiIndexTypespec
-    type: typespec
+    type: ref_obj
     card: 1
   - property: sign
     name: sign

--- a/model/class_defn.yaml
+++ b/model/class_defn.yaml
@@ -49,5 +49,5 @@
   - obj_ref: class_typespecs
     name: class typespecs
     vpi: vpiClassTypespec
-    type: class_typespec
+    type: ref_obj
     card: any

--- a/model/class_obj.yaml
+++ b/model/class_obj.yaml
@@ -24,7 +24,7 @@
   - obj_ref: class_typespec
     name: class typespec
     vpi: vpiClassTypespec
-    type: class_typespec
+    type: ref_obj
     card: 1
   - obj_ref: threads
     name: threads
@@ -46,7 +46,4 @@
     vpi: vpiConstraint
     type: constraint
     card: any
-
-
-    
 

--- a/model/class_typespec.yaml
+++ b/model/class_typespec.yaml
@@ -27,10 +27,10 @@
     vpi: vpiAutomatic
     type: bool
     card: 1
-  - obj_ref: class_typespec
-    name: class typespec
+  - obj_ref: extends
+    name: extends
     vpi: vpiExtends
-    type: class_typespec
+    type: ref_obj
     card: 1    
   - class_ref: variables
     name: variables

--- a/model/enum_struct_union_packed_array_typespec_group.yaml
+++ b/model/enum_struct_union_packed_array_typespec_group.yaml
@@ -19,5 +19,4 @@
   - obj_ref: struct_typespec
   - obj_ref: union_typespec
   - obj_ref: packed_array_typespec
-
-
+  - obj_ref: ref_obj

--- a/model/enum_typespec.yaml
+++ b/model/enum_typespec.yaml
@@ -19,7 +19,7 @@
   - class_ref: base_typespec
     name: base typespec
     vpi: vpiBaseTypespec
-    type: typespec
+    type: ref_obj
     card: 1
   - obj_ref: enum_consts
     name: enum consts

--- a/model/expr.yaml
+++ b/model/expr.yaml
@@ -33,5 +33,5 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiTypespec
-    type: typespec
+    type: ref_obj
     card: 1

--- a/model/extends.yaml
+++ b/model/extends.yaml
@@ -18,7 +18,7 @@
   - obj_ref: class_typespec
     name: class typespec
     vpi: vpiClassTypespec
-    type: class_typespec
+    type: ref_obj
     card: 1
  - class_ref: arguments
     name: arguments

--- a/model/instance_array.yaml
+++ b/model/instance_array.yaml
@@ -63,7 +63,7 @@
   - class_ref: elem_typespec
     name: elem typespec
     vpi: vpiElemTypespec
-    type: typespec
+    type: ref_obj
     card: 1
   - obj_ref: ports
     vpi: vpiPort

--- a/model/io_decl.yaml
+++ b/model/io_decl.yaml
@@ -73,5 +73,5 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiTypedef
-    type: typespec
+    type: ref_obj
     card: 1

--- a/model/logic_typespec.yaml
+++ b/model/logic_typespec.yaml
@@ -21,10 +21,10 @@
     vpi: vpiVector
     type: bool
     card: 1
-  - obj_ref: logic_typespec
-    name: logic typespec
+  - obj_ref: elem_typespec
+    name: elem typespec
     vpi: vpiElemTypespec
-    type: logic_typespec
+    type: ref_obj
     card: 1
   - obj_ref: ranges
     name: ranges
@@ -41,10 +41,10 @@
     vpi: vpiRightRange
     type: expr
     card: 1
-  - class_ref: typespec
-    name: typespec
+  - class_ref: index_typespec
+    name: index typespec
     vpi: vpiIndexTypespec
-    type: typespec
+    type: ref_obj
     card: 1
   - property: sign
     name: sign

--- a/model/named_event.yaml
+++ b/model/named_event.yaml
@@ -48,7 +48,7 @@
   - obj_ref: event_typespec
     name: event typespec
     vpi: vpiTypespec
-    type: event_typespec
+    type: ref_obj
     card: 1
   - obj_ref: threads
     name: threads

--- a/model/packed_array_typespec.yaml
+++ b/model/packed_array_typespec.yaml
@@ -36,18 +36,18 @@
     vpi: vpiRightRange
     type: expr
     card: 1
-  - group_ref: elem_typespec
+  - class_ref: elem_typespec
     name: elem typespec
     vpi: vpiElemTypespec
-    type: enum_struct_union_packed_array_typespec_group
+    type: ref_obj
     card: 1
   - class_ref: typespec
     name: typespec
     vpi: vpiIndexTypespec
-    type: typespec
+    type: ref_obj
     card: 1
   - obj_ref: resolution_func
     name: resolution func
     vpi: vpiFunction
     type: function
-    card: 1    
+    card: 1

--- a/model/ports.yaml
+++ b/model/ports.yaml
@@ -73,7 +73,7 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiTypedef
-    type: typespec
+    type: ref_obj
     card: 1
   - class_ref: instance
     name: instance

--- a/model/prop_formal_decl.yaml
+++ b/model/prop_formal_decl.yaml
@@ -30,9 +30,8 @@
     vpi: vpiExpr
     type: property_expr_named_event_group
     card: 1
-  - class_ref: vpiTypespec
-    name: vpiTypespec
+  - class_ref: typespec
+    name: typespec
     vpi: vpiTypespec
-    type: typespec
+    type: ref_obj
     card: 1
- 

--- a/model/seq_formal_decl.yaml
+++ b/model/seq_formal_decl.yaml
@@ -38,6 +38,6 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiTypespec
-    type: typespec
+    type: ref_obj
     card: 1
     

--- a/model/tagged_pattern.yaml
+++ b/model/tagged_pattern.yaml
@@ -28,5 +28,5 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiTypespec
-    type: typespec
+    type: ref_obj
     card: 1

--- a/model/type_parameter.yaml
+++ b/model/type_parameter.yaml
@@ -29,12 +29,12 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiTypespec
-    type: typespec
+    type: ref_obj
     card: 1
   - class_ref: expr
     name: expr 
     vpi: vpiExpr
-    type: typespec
+    type: ref_obj
     card: 1
 # Not standard, name of the package it is imported from     
   - property: imported

--- a/model/typespec.yaml
+++ b/model/typespec.yaml
@@ -23,7 +23,7 @@
   - class_ref: typedef_alias
     name: typedef alias
     vpi: vpiTypedefAlias
-    type: typespec
+    type: ref_obj
     card: 1
   - class_ref: instance
     name: instance

--- a/model/typespec_member.yaml
+++ b/model/typespec_member.yaml
@@ -28,7 +28,7 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiTypespec
-    type: typespec
+    type: ref_obj
     card: 1
   - class_ref: default_value
     name: default value

--- a/python/swig_test.cpp
+++ b/python/swig_test.cpp
@@ -46,7 +46,10 @@ std::vector<vpiHandle> buildTestTypedef(UHDM::Serializer* s){
   members->push_back(member1);
 
   bit_typespec* btps = s->MakeBit_typespec();
-  member1->Typespec(btps);
+
+  ref_obj* btps_ro = s->MakeRef_obj();
+  btps_ro->Actual_group(btps);
+  member1->Typespec(btps_ro);
 
   VectorOfrange* ranges = s->MakeRangeVec();
   btps->VpiParent(member1);
@@ -76,7 +79,10 @@ std::vector<vpiHandle> buildTestTypedef(UHDM::Serializer* s){
   members->push_back(member2);
 
   btps = s->MakeBit_typespec();
-  member2->Typespec(btps);
+
+  btps_ro = s->MakeRef_obj();
+  btps_ro->Actual_group(btps);
+  member2->Typespec(btps_ro);
 
   ranges = s->MakeRangeVec();
   btps->VpiParent(member2);

--- a/scripts/classes.py
+++ b/scripts/classes.py
@@ -175,7 +175,21 @@ def _get_DeepClone_implementation(model, models):
 
             # Unary relations
             if card == '1':
-                if (classname in ['ref_obj', 'ref_var']) and (method == 'Actual_group'):
+                if (classname in ['ref_obj']) and (method == 'Actual_group'):
+                    includes.add('ElaboratorListener')
+                    includes.add('typespec')
+                    content.append(f'  if (typespec* obj = (typespec*){method}<typespec>()) {{')
+                    content.append( '    if (elaboratorContext->m_elaborator.uniquifyTypespec()) {')
+                    content.append(f'      clone->{method}(obj->DeepClone(clone, context));')
+                    content.append( '    } else {')
+                    content.append(f'      clone->{method}(obj);')
+                    content.append( '    }')
+                    content.append( '  } else {')
+                    content.append(f'    if (!clone->{method}()) clone->{method}(elaboratorContext->m_elaborator.bindAny(VpiName()));')
+                    content.append(f'    if (!clone->{method}()) clone->{method}((any*) {method}());')
+                    content.append( '  }')
+
+                elif (classname in ['ref_var']) and (method == 'Actual_group'):
                     includes.add('ElaboratorListener')
                     content.append(f'  if (!clone->{method}()) clone->{method}(elaboratorContext->m_elaborator.bindAny(VpiName()));')
                     content.append(f'  if (!clone->{method}()) clone->{method}((any*) {method}());')
@@ -235,14 +249,6 @@ def _get_DeepClone_implementation(model, models):
                     includes.add('module_inst')
                     content.append(f'  if (auto obj = {method}()) clone->{method}((interface_inst*) obj);')
 
-                elif method == 'Typespec':
-                    includes.add('typespec')
-                    content.append( '  if (elaboratorContext->m_elaborator.uniquifyTypespec()) {')
-                    content.append(f'    if (auto obj = {method}()) clone->{method}(obj->DeepClone(clone, context));')
-                    content.append( '  } else {')
-                    content.append(f'    if (auto obj = {method}()) clone->{method}((typespec*) obj);')
-                    content.append( '  }')
-
                 else:
                     content.append(f'  if (auto obj = {method}()) clone->{method}(obj->DeepClone(clone, context));')
 
@@ -250,16 +256,11 @@ def _get_DeepClone_implementation(model, models):
                 pass # No cloning
 
             elif method == 'Typespecs':
+                # Don't deep clone
                 content.append(f'  if (auto vec = {method}()) {{')
                 content.append(f'    auto clone_vec = context->m_serializer->Make{Cast}Vec();')
                 content.append(f'    clone->{method}(clone_vec);')
-                content.append( '    for (auto obj : *vec) {')
-                content.append( '      if (elaboratorContext->m_elaborator.uniquifyTypespec()) {')
-                content.append( '        clone_vec->push_back(obj->DeepClone(clone, context));')
-                content.append( '      } else {')
-                content.append( '        clone_vec->push_back(obj);')
-                content.append( '      }')
-                content.append( '    }')
+                content.append( '    clone_vec->insert(clone_vec->cend(), vec->cbegin(), vec->cend());')
                 content.append( '  }')
 
             elif (classname == 'class_defn') and (method == 'Deriveds'):
@@ -279,6 +280,7 @@ def _get_DeepClone_implementation(model, models):
                 content.append( '      clone_vec->push_back(obj->DeepClone(clone, context));')
                 content.append( '    }')
                 content.append( '  }')
+
     if modeltype != 'class_def':
         content.append(f'  elaboratorContext->m_elaborator.leave{Classname}(clone, nullptr);')
 

--- a/templates/SynthSubset.cpp
+++ b/templates/SynthSubset.cpp
@@ -36,7 +36,8 @@ SynthSubset::SynthSubset(Serializer* serializer,
                          bool reportErrors, bool allowFormal)
     : serializer_(serializer),
       nonSynthesizableObjects_(nonSynthesizableObjects),
-      reportErrors_(reportErrors), allowFormal_(allowFormal) {
+      reportErrors_(reportErrors),
+      allowFormal_(allowFormal) {
   constexpr std::string_view kDollar("$");
   for (auto s :
        {// "display",
@@ -107,8 +108,8 @@ void SynthSubset::reportError(const any* object) {
   if (reportErrors_ && !reportedParent(object)) {
     if (!object->VpiFile().empty()) {
       const std::string errMsg(object->VpiName());
-      serializer_->GetErrorHandler()(ErrorType::UHDM_NON_SYNTHESIZABLE,
-                                     errMsg, object, nullptr);
+      serializer_->GetErrorHandler()(ErrorType::UHDM_NON_SYNTHESIZABLE, errMsg,
+                                     object, nullptr);
     }
   }
   mark(object);
@@ -196,8 +197,7 @@ void SynthSubset::leaveAny(const any* object, vpiHandle handle) {
     case UHDM_OBJECT_TYPE::uhdmrestrict:
     case UHDM_OBJECT_TYPE::uhdmimmediate_assume:
     case UHDM_OBJECT_TYPE::uhdmimmediate_cover:
-      if (!allowFormal_)
-        reportError(object);
+      if (!allowFormal_) reportError(object);
       break;  
     default:
       break;
@@ -318,11 +318,13 @@ void SynthSubset::leaveClass_typespec(const class_typespec* object,
 }
 
 void SynthSubset::leaveClass_var(const class_var* object, vpiHandle handle) {
-  if (const class_typespec* spec = (class_typespec*)object->Typespec()) {
-    if (const class_defn* def = spec->Class_defn()) {
-      if (reportedParent(def)) {
-        mark(object);
-        return;
+  if (const ref_obj* ro = object->Typespec()) {
+    if (const class_typespec* spec = ro->Typespec<class_typespec>()) {
+      if (const class_defn* def = spec->Class_defn()) {
+        if (reportedParent(def)) {
+          mark(object);
+          return;
+        }
       }
     }
   }

--- a/templates/vpi_visitor.h
+++ b/templates/vpi_visitor.h
@@ -79,7 +79,7 @@ class VpiVisitor final {
   AnySet m_weaklyReferenced1;
   AnySet m_weaklyReferenced2;
   VisitedContainer m_visited;
-  bool m_visitWeaklyReferenced = false;
+  bool m_visitWeaklyReferenced = true;
 };
 #endif
 

--- a/tests/classes_test.cpp
+++ b/tests/classes_test.cpp
@@ -75,7 +75,10 @@ static std::vector<vpiHandle> build_designs(Serializer* s) {
   UHDM::class_defn* parent = base;
   UHDM::extends* extends = s->MakeExtends();
   UHDM::class_typespec* tps = s->MakeClass_typespec();
-  extends->Class_typespec(tps);
+  UHDM::ref_obj* ro = s->MakeRef_obj();
+  ro->Actual_group(tps);
+  ro->VpiParent(extends);
+  extends->Class_typespec(ro);
   tps->Class_defn(parent);
   derived->Extends(extends);
   UHDM::VectorOfclass_defn* all_derived = s->MakeClass_defnVec();

--- a/tests/expr_prettyPrint_test.cpp
+++ b/tests/expr_prettyPrint_test.cpp
@@ -34,8 +34,16 @@ std::vector<vpiHandle> build_designs_MinusOp(Serializer* s) {
     p->VpiName("wire_i");
     p->VpiDirection(vpiInput);
 
+    VectorOftypespec* typespecs = s->MakeTypespecVec();
+    dut->Typespecs(typespecs);
+
     logic_typespec* tps = s->MakeLogic_typespec();
-    p->Typespec(tps);
+    typespecs->emplace_back(tps);
+
+    ref_obj* tps_ro = s->MakeRef_obj();
+    tps_ro->Actual_group(tps);
+    tps_ro->VpiParent(p);
+    p->Typespec(tps_ro);
 
     VectorOfrange* ranges = s->MakeRangeVec();
     tps->Ranges(ranges);
@@ -108,7 +116,8 @@ TEST(exprVal, prettyPrint_MinusOp) {
   ExprEval eval;
   for (auto m : *d->TopModules()) {
     for (auto p : *m->Ports()) {
-      logic_typespec* typespec = (logic_typespec*)p->Typespec();
+      const ref_obj* ro = p->Typespec();
+      const logic_typespec* typespec = ro->Actual_group<logic_typespec>();
       VectorOfrange* ranges = typespec->Ranges();
       for (auto range : *ranges) {
         expr* left = (expr*)range->Left_expr();


### PR DESCRIPTION
Use ref_obj to reference typespecs

scope::Typespecs are cloned from non-elaborated tree to the elaborated tree. However, at the moment, this collection doesn't have all the typespecs in the non-elaborated tree.

This change solves a few different problems -

* Avoids too many duplicates in the elaborated tree.
* ref_obj will hold the type location information in parameter declaration.

Known Issues -
* Need to collect all typespecs in the scope subtree to populate scope::Typespecs
* Though the typespecs are cloned, elaborated tree is still using the ones from the non-elaborated tree. The tree is still complete but typespecs are crossing the boundary between elaborated and non-elaborated. Need to fix this during binding.