### PR TITLE
do not return early from reportError

### DIFF
--- a/templates/SynthSubset.cpp
+++ b/templates/SynthSubset.cpp
@@ -98,7 +98,6 @@ void SynthSubset::report(std::ostream& out) {
 }
 
 void SynthSubset::reportError(const any* object) {
-  if (isInUhdmAllIterator()) return;
   const any* tmp = object;
   while (tmp && tmp->VpiFile().empty()) {
     tmp = tmp->VpiParent();


### PR DESCRIPTION
After a recent change to `synth subset checker` we're not able to check if a node belongs to the non-synthesizable set or not, and as a result non-synthesizable parts of this test cause errors:
https://github.com/zachjs/sv2v/blob/764a11af7f861dfbf9e2c40422fe7b02f7a166c2/test/core/struct_part_select.sv

Here's the change in UHDM:
https://github.com/chipsalliance/UHDM/commit/da7e6cfc0d84a3498f8a90ec050f5d57cd128b41

I've observed that we can safely bump the Surelog submodule when we use UHDM without the early return from `SynthSubset::reportError`
I've run tests here: https://github.com/chipsalliance/synlig/actions/runs/6198609315/attempts/1

FYI @kbieganski 