### PR TITLE
Sort capnp factories, ref_typespec, and naming consistency

### DIFF
--- a/include/sv_vpi_user.h
+++ b/include/sv_vpi_user.h
@@ -89,6 +89,7 @@ extern "C" {
 #define vpiPropertyTypespec                   697
 #define vpiEventTypespec                      698
 #define vpiModuleTypespec                     768 /* !!! NOT Standard !!! */
+#define vpiRefTypespec                        769 /* !!! NOT Standard !!! */
 
 #define vpiClockingBlock                      650
 #define vpiClockingIODecl                     651

--- a/model/models.lst
+++ b/model/models.lst
@@ -106,6 +106,7 @@ operation.yaml
 actual_group.yaml
 ref_obj.yaml
 ref_module.yaml
+ref_typespec.yaml
 part_select.yaml
 indexed_part_select.yaml
 var_select.yaml

--- a/model/prop_formal_decl.yaml
+++ b/model/prop_formal_decl.yaml
@@ -30,9 +30,8 @@
     vpi: vpiExpr
     type: property_expr_named_event_group
     card: 1
-  - class_ref: vpiTypespec
-    name: vpiTypespec
+  - class_ref: typespec
+    name: typespec
     vpi: vpiTypespec
     type: typespec
     card: 1
- 

--- a/model/ref_typespec.yaml
+++ b/model/ref_typespec.yaml
@@ -1,0 +1,38 @@
+# Copyright 2019 Alain Dargelas
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Universal Hardware Data Model (UHDM) "ref_obj" formal description
+ 
+- obj_def: ref_typespec
+  - extends: simple_expr
+  - property: name
+    name: name
+    vpi: vpiName
+    type: string
+    card: 1
+  - property: full_name
+    name: full name
+    vpi: vpiFullName
+    type: string
+    card: 1
+  - property: definition_name
+    name: definition name
+    vpi: vpiDefName
+    type: string
+    card: 1  
+  - class_ref: actual_typespec
+    name: actual typespec
+    vpi: vpiActual
+    type: typespec
+    card: 1


### PR DESCRIPTION
Sort capnp factories, ref_typespec, and naming consistency

* Sort the factories in capnp output so comparisons are easier
* Introducing ref_typespec, parallel to ref_obj to reference typespecs
* Enforce naming consistency
