### PR TITLE
Introducing ref_typespec, parallel to ref_obj for referencing typespecs

### DIFF
--- a/model/array_typespec.yaml
+++ b/model/array_typespec.yaml
@@ -39,12 +39,12 @@
   - class_ref: index_typespec
     name: index typespec
     vpi: vpiIndexTypespec
-    type: typespec
+    type: ref_typespec
     card: 1
   - class_ref: elem_typespec
     name: elem typespec
     vpi: vpiElemTypespec
-    type: typespec
+    type: ref_typespec
     card: 1
   - obj_ref: resolution_func
     name: resolution func

--- a/model/bit_typespec.yaml
+++ b/model/bit_typespec.yaml
@@ -24,7 +24,7 @@
   - obj_ref: bit_typespec
     name: bit typespec
     vpi: vpiElemTypespec
-    type: bit_typespec
+    type: ref_typespec
     card: 1
   - obj_ref: ranges
     name: ranges
@@ -44,7 +44,7 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiIndexTypespec
-    type: typespec
+    type: ref_typespec
     card: 1
   - property: sign
     name: sign

--- a/model/class_obj.yaml
+++ b/model/class_obj.yaml
@@ -24,7 +24,7 @@
   - obj_ref: class_typespec
     name: class typespec
     vpi: vpiClassTypespec
-    type: class_typespec
+    type: ref_typespec
     card: 1
   - obj_ref: threads
     name: threads
@@ -46,7 +46,4 @@
     vpi: vpiConstraint
     type: constraint
     card: any
-
-
-    
 

--- a/model/class_typespec.yaml
+++ b/model/class_typespec.yaml
@@ -27,11 +27,11 @@
     vpi: vpiAutomatic
     type: bool
     card: 1
-  - obj_ref: class_typespec
-    name: class typespec
+  - obj_ref: extends
+    name: extends
     vpi: vpiExtends
-    type: class_typespec
-    card: 1    
+    type: ref_typespec
+    card: 1
   - class_ref: variables
     name: variables
     vpi: vpiVariables
@@ -55,7 +55,7 @@
   - obj_ref: param_assigns
     vpi: vpiParamAssign
     type: param_assign
-    card: any     
+    card: any
   - obj_ref: virtual_interface_vars
     name: virtual interface vars
     vpi: vpiVirtualInterfaceVar
@@ -70,12 +70,12 @@
     name: named event arrays
     vpi: vpiNamedEventArray
     type: named_event_array
-    card: any    
+    card: any
   - class_ref: scopes
     name: scopes
     vpi: vpiInternalScope
     type: scope
-    card: any    
+    card: any
   - obj_ref: class_defn
     name: class defn
     vpi: vpiClassDefn

--- a/model/enum_typespec.yaml
+++ b/model/enum_typespec.yaml
@@ -19,7 +19,7 @@
   - class_ref: base_typespec
     name: base typespec
     vpi: vpiBaseTypespec
-    type: typespec
+    type: ref_typespec
     card: 1
   - obj_ref: enum_consts
     name: enum consts

--- a/model/expr.yaml
+++ b/model/expr.yaml
@@ -33,5 +33,5 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiTypespec
-    type: typespec
+    type: ref_typespec
     card: 1

--- a/model/extends.yaml
+++ b/model/extends.yaml
@@ -18,7 +18,7 @@
   - obj_ref: class_typespec
     name: class typespec
     vpi: vpiClassTypespec
-    type: class_typespec
+    type: ref_typespec
     card: 1
  - class_ref: arguments
     name: arguments

--- a/model/instance_array.yaml
+++ b/model/instance_array.yaml
@@ -63,7 +63,7 @@
   - class_ref: elem_typespec
     name: elem typespec
     vpi: vpiElemTypespec
-    type: typespec
+    type: ref_typespec
     card: 1
   - obj_ref: ports
     vpi: vpiPort

--- a/model/io_decl.yaml
+++ b/model/io_decl.yaml
@@ -73,5 +73,5 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiTypedef
-    type: typespec
+    type: ref_typespec
     card: 1

--- a/model/logic_typespec.yaml
+++ b/model/logic_typespec.yaml
@@ -21,10 +21,10 @@
     vpi: vpiVector
     type: bool
     card: 1
-  - obj_ref: logic_typespec
-    name: logic typespec
+  - obj_ref: elem_typespec
+    name: elem typespec
     vpi: vpiElemTypespec
-    type: logic_typespec
+    type: ref_typespec
     card: 1
   - obj_ref: ranges
     name: ranges
@@ -41,10 +41,10 @@
     vpi: vpiRightRange
     type: expr
     card: 1
-  - class_ref: typespec
-    name: typespec
+  - class_ref: index_typespec
+    name: index typespec
     vpi: vpiIndexTypespec
-    type: typespec
+    type: ref_typespec
     card: 1
   - property: sign
     name: sign

--- a/model/named_event.yaml
+++ b/model/named_event.yaml
@@ -48,7 +48,7 @@
   - obj_ref: event_typespec
     name: event typespec
     vpi: vpiTypespec
-    type: event_typespec
+    type: ref_typespec
     card: 1
   - obj_ref: threads
     name: threads

--- a/model/packed_array_typespec.yaml
+++ b/model/packed_array_typespec.yaml
@@ -36,18 +36,18 @@
     vpi: vpiRightRange
     type: expr
     card: 1
-  - group_ref: elem_typespec
+  - class_ref: elem_typespec
     name: elem typespec
     vpi: vpiElemTypespec
-    type: enum_struct_union_packed_array_typespec_group
+    type: ref_typespec
     card: 1
   - class_ref: typespec
     name: typespec
     vpi: vpiIndexTypespec
-    type: typespec
+    type: ref_typespec
     card: 1
   - obj_ref: resolution_func
     name: resolution func
     vpi: vpiFunction
     type: function
-    card: 1    
+    card: 1

--- a/model/ports.yaml
+++ b/model/ports.yaml
@@ -73,7 +73,7 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiTypedef
-    type: typespec
+    type: ref_typespec
     card: 1
   - class_ref: instance
     name: instance

--- a/model/prop_formal_decl.yaml
+++ b/model/prop_formal_decl.yaml
@@ -33,5 +33,5 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiTypespec
-    type: typespec
+    type: ref_typespec
     card: 1

--- a/model/ref_obj.yaml
+++ b/model/ref_obj.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Universal Hardware Data Model (UHDM) "ref_obj" formal description
- 
+
 - obj_def: ref_obj
   - extends: simple_expr
   - property: name
@@ -30,12 +30,12 @@
     name: definition name
     vpi: vpiDefName
     type: string
-    card: 1  
+    card: 1
   - property: generic
     name: generic
     vpi: vpiGeneric
     type: bool
-    card: 1 
+    card: 1
   - group_ref: actual_group
     name: actual group
     vpi: vpiActual
@@ -46,4 +46,4 @@
     name: is struct member
     vpi: vpiStructMember
     type: bool
-    card: 1    
+    card: 1

--- a/model/ref_typespec.yaml
+++ b/model/ref_typespec.yaml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Universal Hardware Data Model (UHDM) "ref_obj" formal description
- 
+# Universal Hardware Data Model (UHDM) "ref_typespec" formal description
+
 - obj_def: ref_typespec
   - extends: simple_expr
   - property: name
@@ -30,7 +30,7 @@
     name: definition name
     vpi: vpiDefName
     type: string
-    card: 1  
+    card: 1
   - class_ref: actual_typespec
     name: actual typespec
     vpi: vpiActual

--- a/model/seq_formal_decl.yaml
+++ b/model/seq_formal_decl.yaml
@@ -38,6 +38,6 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiTypespec
-    type: typespec
+    type: ref_typespec
     card: 1
     

--- a/model/tagged_pattern.yaml
+++ b/model/tagged_pattern.yaml
@@ -28,5 +28,5 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiTypespec
-    type: typespec
+    type: ref_typespec
     card: 1

--- a/model/type_parameter.yaml
+++ b/model/type_parameter.yaml
@@ -29,12 +29,12 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiTypespec
-    type: typespec
+    type: ref_typespec
     card: 1
   - class_ref: expr
     name: expr 
     vpi: vpiExpr
-    type: typespec
+    type: ref_typespec
     card: 1
 # Not standard, name of the package it is imported from     
   - property: imported

--- a/model/typespec.yaml
+++ b/model/typespec.yaml
@@ -23,7 +23,7 @@
   - class_ref: typedef_alias
     name: typedef alias
     vpi: vpiTypedefAlias
-    type: typespec
+    type: ref_typespec
     card: 1
   - class_ref: instance
     name: instance

--- a/model/typespec_member.yaml
+++ b/model/typespec_member.yaml
@@ -28,7 +28,7 @@
   - class_ref: typespec
     name: typespec
     vpi: vpiTypespec
-    type: typespec
+    type: ref_typespec
     card: 1
   - class_ref: default_value
     name: default value

--- a/python/swig_test.cpp
+++ b/python/swig_test.cpp
@@ -46,7 +46,10 @@ std::vector<vpiHandle> buildTestTypedef(UHDM::Serializer* s){
   members->push_back(member1);
 
   bit_typespec* btps = s->MakeBit_typespec();
-  member1->Typespec(btps);
+
+  ref_typespec* btps_rt = s->MakeRef_typespec();
+  btps_rt->Actual_typespec(btps);
+  member1->Typespec(btps_rt);
 
   VectorOfrange* ranges = s->MakeRangeVec();
   btps->VpiParent(member1);
@@ -76,7 +79,10 @@ std::vector<vpiHandle> buildTestTypedef(UHDM::Serializer* s){
   members->push_back(member2);
 
   btps = s->MakeBit_typespec();
-  member2->Typespec(btps);
+
+  btps_rt = s->MakeRef_typespec();
+  btps_rt->Actual_typespec(btps);
+  member2->Typespec(btps_rt);
 
   ranges = s->MakeRangeVec();
   btps->VpiParent(member2);

--- a/scripts/vpi_visitor.py
+++ b/scripts/vpi_visitor.py
@@ -23,7 +23,7 @@ def _get_implementation(classname, vpi, card):
             # Prevent stepping inside tasks while processing calls (task_call, method_task_call) to them
             shallow_visit = 'true'
 
-        if classname in ['ref_obj']:
+        if classname in ['ref_obj', 'ref_typespec']:
             # Ref_obj are always printed shallow
             shallow_visit = 'true'
 

--- a/templates/ElaboratorListener.cpp
+++ b/templates/ElaboratorListener.cpp
@@ -56,7 +56,9 @@ static void propagateParamAssign(param_assign* pass, const any* target) {
         }
       }
       if (const UHDM::extends* ext = defn->Extends()) {
-        propagateParamAssign(pass, ext->Class_typespec());
+        if (const ref_typespec* rt = ext->Class_typespec()) {
+          propagateParamAssign(pass, rt->Actual_typespec<class_typespec>());
+        }
       }
       if (const auto vars = defn->Variables()) {
         for (auto var : *vars) {
@@ -67,7 +69,9 @@ static void propagateParamAssign(param_assign* pass, const any* target) {
     }
     case UHDM_OBJECT_TYPE::uhdmclass_var: {
       class_var* var = (class_var*)target;
-      propagateParamAssign(pass, var->Typespec());
+      if (const ref_typespec* rt = var->Typespec()) {
+        propagateParamAssign(pass, rt->Actual_typespec());
+      }
       break;
     }
     case UHDM_OBJECT_TYPE::uhdmclass_typespec: {
@@ -107,10 +111,11 @@ void ElaboratorListener::enterVariables(const variables* object,
       return;  // Only do class var propagation while in elaboration
     const class_var* cv = (class_var*)object;
     class_var* const rw_cv = (class_var*)cv;
-    if (typespec* ctps = (typespec*)cv->Typespec()) {
-      ctps = ctps->DeepClone(rw_cv, context_);
+    if (const ref_typespec* tps = cv->Typespec()) {
+      ref_typespec* ctps = tps->DeepClone(rw_cv, context_);
       rw_cv->Typespec(ctps);
-      if (class_typespec* cctps = any_cast<class_typespec*>(ctps)) {
+      if (const class_typespec* cctps =
+              ctps->Actual_typespec<class_typespec>()) {
         if (VectorOfparam_assign* params = cctps->Param_assigns()) {
           for (param_assign* pass : *params) {
             propagateParamAssign(pass, cctps->Class_defn());
@@ -176,10 +181,14 @@ void ElaboratorListener::enterModule_inst(const module_inst* object,
         }
         if (var->UhdmType() == UHDM_OBJECT_TYPE::uhdmenum_var) {
           enum_var* evar = (enum_var*)var;
-          enum_typespec* etps = evar->Typespec<enum_typespec>();
-          for (auto c : *etps->Enum_consts()) {
-            if (!c->VpiName().empty()) {
-              netMap.emplace(c->VpiName(), c);
+          if (const ref_typespec* rt = evar->Typespec()) {
+            if (const enum_typespec* etps =
+                    rt->Actual_typespec<enum_typespec>()) {
+              for (auto c : *etps->Enum_consts()) {
+                if (!c->VpiName().empty()) {
+                  netMap.emplace(c->VpiName(), c);
+                }
+              }
             }
           }
         }
@@ -457,10 +466,14 @@ void ElaboratorListener::enterPackage(const package* object, vpiHandle handle) {
       }
       if (var->UhdmType() == UHDM_OBJECT_TYPE::uhdmenum_var) {
         enum_var* evar = (enum_var*)var;
-        enum_typespec* etps = (enum_typespec*)evar->Typespec();
-        for (auto c : *etps->Enum_consts()) {
-          if (!c->VpiName().empty()) {
-            netMap.emplace(c->VpiName(), c);
+        if (const ref_typespec* rt = evar->Typespec()) {
+          if (const enum_typespec* etps =
+                  rt->Actual_typespec<enum_typespec>()) {
+            for (auto c : *etps->Enum_consts()) {
+              if (!c->VpiName().empty()) {
+                netMap.emplace(c->VpiName(), c);
+              }
+            }
           }
         }
       }
@@ -536,10 +549,13 @@ void ElaboratorListener::enterClass_defn(const class_defn* object,
         }
         if (var->UhdmType() == UHDM_OBJECT_TYPE::uhdmenum_var) {
           enum_var* evar = (enum_var*)var;
-          enum_typespec* etps = (enum_typespec*)evar->Typespec();
-          for (auto c : *etps->Enum_consts()) {
-            if (!c->VpiName().empty()) {
-              varMap.emplace(c->VpiName(), c);
+          if (const ref_typespec* rt = evar->Typespec()) {
+            if (const enum_typespec* etps = rt->Actual_typespec<enum_typespec>()) {
+              for (auto c : *etps->Enum_consts()) {
+                if (!c->VpiName().empty()) {
+                  varMap.emplace(c->VpiName(), c);
+                }
+              }
             }
           }
         }
@@ -577,8 +593,11 @@ void ElaboratorListener::enterClass_defn(const class_defn* object,
 
     const class_defn* base_defn = nullptr;
     if (const extends* ext = defn->Extends()) {
-      if (const class_typespec* ctps = ext->Class_typespec()) {
-        base_defn = ctps->Class_defn();
+      if (const ref_typespec* rt = ext->Class_typespec()) {
+        if (const class_typespec* ctps =
+                rt->Actual_typespec<class_typespec>()) {
+          base_defn = ctps->Class_defn();
+        }
       }
     }
     defn = base_defn;
@@ -680,10 +699,14 @@ void ElaboratorListener::enterInterface_inst(const interface_inst* object,
         }
         if (var->UhdmType() == UHDM_OBJECT_TYPE::uhdmenum_var) {
           enum_var* evar = (enum_var*)var;
-          enum_typespec* etps = (enum_typespec*)evar->Typespec();
-          for (auto c : *etps->Enum_consts()) {
-            if (!c->VpiName().empty()) {
-              netMap.emplace(c->VpiName(), c);
+          if (const ref_typespec* rt = evar->Typespec()) {
+            if (const enum_typespec* etps =
+                    rt->Actual_typespec<enum_typespec>()) {
+              for (auto c : *etps->Enum_consts()) {
+                if (!c->VpiName().empty()) {
+                  netMap.emplace(c->VpiName(), c);
+                }
+              }
             }
           }
         }
@@ -954,23 +977,27 @@ any* ElaboratorListener::bindTaskFunc(std::string_view name,
     }
   }
   if (prefix) {
-    const typespec* tps = prefix->Typespec();
-    if (tps && tps->UhdmType() == UHDM_OBJECT_TYPE::uhdmclass_typespec) {
-      const class_defn* defn = ((const class_typespec*)tps)->Class_defn();
-      while (defn) {
-        if (defn->Task_funcs()) {
-          for (task_func* tf : *defn->Task_funcs()) {
-            if (tf->VpiName() == name) return tf;
+    if (const ref_typespec* rt = prefix->Typespec()) {
+      if (const class_typespec* tps = rt->Actual_typespec<class_typespec>()) {
+        const class_defn* defn = tps->Class_defn();
+        while (defn) {
+          if (defn->Task_funcs()) {
+            for (task_func* tf : *defn->Task_funcs()) {
+              if (tf->VpiName() == name) return tf;
+            }
           }
-        }
 
-        const class_defn* base_defn = nullptr;
-        if (const extends* ext = defn->Extends()) {
-          if (const class_typespec* ctps = ext->Class_typespec()) {
-            base_defn = ctps->Class_defn();
+          const class_defn* base_defn = nullptr;
+          if (const extends* ext = defn->Extends()) {
+            if (const ref_typespec* ctps_rt = ext->Class_typespec()) {
+              if (const class_typespec* ctps =
+                      ctps_rt->Actual_typespec<class_typespec>()) {
+                base_defn = ctps->Class_defn();
+              }
+            }
           }
+          defn = base_defn;
         }
-        defn = base_defn;
       }
     }
   }
@@ -1057,8 +1084,11 @@ void ElaboratorListener::enterTask_func(const task_func* object,
 
         const class_defn* base_defn = nullptr;
         if (const extends* ext = defn->Extends()) {
-          if (const class_typespec* ctps = ext->Class_typespec()) {
-            base_defn = ctps->Class_defn();
+          if (const ref_typespec* rt = ext->Class_typespec()) {
+            if (const class_typespec* ctps =
+                    rt->Actual_typespec<class_typespec>()) {
+              base_defn = ctps->Class_defn();
+            }
           }
         }
         defn = base_defn;
@@ -1337,10 +1367,13 @@ void ElaboratorListener::enterGen_scope(const gen_scope* object,
       }
       if (var->UhdmType() == UHDM_OBJECT_TYPE::uhdmenum_var) {
         enum_var* evar = (enum_var*)var;
-        enum_typespec* etps = (enum_typespec*)evar->Typespec();
-        for (auto c : *etps->Enum_consts()) {
-          if (!c->VpiName().empty()) {
-            netMap.emplace(c->VpiName(), c);
+        if (const ref_typespec* rt = evar->Typespec()) {
+          if (const enum_typespec* etps = rt->Typespec<enum_typespec>()) {
+            for (auto c : *etps->Enum_consts()) {
+              if (!c->VpiName().empty()) {
+                netMap.emplace(c->VpiName(), c);
+              }
+            }
           }
         }
       }

--- a/templates/ExprEval.h
+++ b/templates/ExprEval.h
@@ -27,8 +27,8 @@
 #ifndef UHDM_EXPREVAL_H
 #define UHDM_EXPREVAL_H
 
-#include <uhdm/expr.h>
-#include <uhdm/typespec.h>
+#include <uhdm/containers.h>
+#include <uhdm/uhdm_forward_decl.h>
 
 #include <functional>
 #include <map>

--- a/templates/SynthSubset.cpp
+++ b/templates/SynthSubset.cpp
@@ -36,7 +36,8 @@ SynthSubset::SynthSubset(Serializer* serializer,
                          bool reportErrors, bool allowFormal)
     : serializer_(serializer),
       nonSynthesizableObjects_(nonSynthesizableObjects),
-      reportErrors_(reportErrors), allowFormal_(allowFormal) {
+      reportErrors_(reportErrors),
+      allowFormal_(allowFormal) {
   constexpr std::string_view kDollar("$");
   for (auto s :
        {// "display",
@@ -106,8 +107,8 @@ void SynthSubset::reportError(const any* object) {
   if (reportErrors_ && !reportedParent(object)) {
     if (!object->VpiFile().empty()) {
       const std::string errMsg(object->VpiName());
-      serializer_->GetErrorHandler()(ErrorType::UHDM_NON_SYNTHESIZABLE,
-                                     errMsg, object, nullptr);
+      serializer_->GetErrorHandler()(ErrorType::UHDM_NON_SYNTHESIZABLE, errMsg,
+                                     object, nullptr);
     }
   }
   mark(object);
@@ -195,8 +196,7 @@ void SynthSubset::leaveAny(const any* object, vpiHandle handle) {
     case UHDM_OBJECT_TYPE::uhdmrestrict:
     case UHDM_OBJECT_TYPE::uhdmimmediate_assume:
     case UHDM_OBJECT_TYPE::uhdmimmediate_cover:
-      if (!allowFormal_)
-        reportError(object);
+      if (!allowFormal_) reportError(object);
       break;  
     default:
       break;
@@ -317,11 +317,13 @@ void SynthSubset::leaveClass_typespec(const class_typespec* object,
 }
 
 void SynthSubset::leaveClass_var(const class_var* object, vpiHandle handle) {
-  if (const class_typespec* spec = (class_typespec*)object->Typespec()) {
-    if (const class_defn* def = spec->Class_defn()) {
-      if (reportedParent(def)) {
-        mark(object);
-        return;
+  if (const ref_typespec* rt = object->Typespec()) {
+    if (const class_typespec* spec = rt->Actual_typespec<class_typespec>()) {
+      if (const class_defn* def = spec->Class_defn()) {
+        if (reportedParent(def)) {
+          mark(object);
+          return;
+        }
       }
     }
   }

--- a/templates/UhdmAdjuster.cpp
+++ b/templates/UhdmAdjuster.cpp
@@ -49,11 +49,9 @@ const any* UhdmAdjuster::resize(const any* object, int32_t maxsize,
       ElaboratorContext elaboratorContext(serializer_);
       c = (constant*)clone_tree(c, &elaboratorContext);
       int32_t constType = c->VpiConstType();
-      const typespec* tps = c->Typespec();
       bool is_signed = false;
-      if (tps) {
-        if (tps->UhdmType() == UHDM_OBJECT_TYPE::uhdmint_typespec) {
-          int_typespec* itps = (int_typespec*)tps;
+      if (const ref_typespec* rt = c->Typespec()) {
+        if (const int_typespec* itps = rt->Actual_typespec<int_typespec>()) {
           if (itps->VpiSigned()) {
             is_signed = true;
           }
@@ -125,11 +123,9 @@ void UhdmAdjuster::leaveCase_stmt(const case_stmt* object, vpiHandle handle) {
       if (type == UHDM_OBJECT_TYPE::uhdmconstant) {
         constant* ccond = (constant*)exp;
         maxsize = std::max(ccond->VpiSize(), maxsize);
-        const typespec* tps = ccond->Typespec();
         bool is_signed = false;
-        if (tps) {
-          if (tps->UhdmType() == UHDM_OBJECT_TYPE::uhdmint_typespec) {
-            int_typespec* itps = (int_typespec*)tps;
+        if (const ref_typespec* rt = ccond->Typespec()) {
+          if (const int_typespec* itps = rt->Actual_typespec<int_typespec>()) {
             if (itps->VpiSigned()) {
               is_signed = true;
             }
@@ -253,16 +249,17 @@ void UhdmAdjuster::leaveConstant(const constant* object, vpiHandle handle) {
           if (last->UhdmType() == UHDM_OBJECT_TYPE::uhdmref_obj) {
             ref_obj* ref = (ref_obj*)last;
             if (const any* actual = ref->Actual_group()) {
-              const typespec* tps = nullptr;
-              if (actual->UhdmType() == UHDM_OBJECT_TYPE::uhdmtypespec_member) {
+              if (actual->UhdmType() == uhdmtypespec_member) {
                 typespec_member* member = (typespec_member*)actual;
-                tps = member->Typespec();
-              }
-              if (tps) {
-                int32_t tmp = static_cast<int32_t>(eval.size(
-                    tps, invalidValue, currentInstance_, assign, true, true));
-                if (!invalidValue) {
-                  size = tmp;
+                if (const ref_typespec* rt = member->Typespec()) {
+                  if (const typespec* tps = rt->Actual_typespec()) {
+                    uint64_t tmp =
+                        eval.size(tps, invalidValue, currentInstance_, assign,
+                                  true, true);
+                    if (!invalidValue) {
+                      size = static_cast<int32_t>(tmp);
+                    }
+                  }
                 }
               }
             }

--- a/templates/class_header.h
+++ b/templates/class_header.h
@@ -50,9 +50,7 @@ public:
   <VIRTUAL> UHDM_OBJECT_TYPE UhdmType() const <OVERRIDE_OR_FINAL> { return UHDM_OBJECT_TYPE::uhdm<CLASSNAME>; }
 
 protected:
-  void DeepCopy(<CLASSNAME>* clone,
-                BaseClass* parent,
-                CloneContext* context) const;
+  void DeepCopy(<CLASSNAME>* clone, BaseClass* parent, CloneContext* context) const;
 
 private:
 <MEMBERS>

--- a/templates/vpi_visitor.cpp
+++ b/templates/vpi_visitor.cpp
@@ -539,11 +539,6 @@ void VpiVisitor::visit_object(vpiHandle obj_h, int32_t indent,
   }
   m_out << "\n";
 
-  // Force shallow visit for all vpiParent except for vpiRefObj
-  if (strcmp(relation, "vpiParent") == 0) {
-    shallowVisit = (objectType != vpiRefObj);
-  }
-
   if (!alreadyVisited && shallowVisit) {
     m_weaklyReferenced1.emplace(object);
   }

--- a/templates/vpi_visitor.h
+++ b/templates/vpi_visitor.h
@@ -79,7 +79,7 @@ class VpiVisitor final {
   AnySet m_weaklyReferenced1;
   AnySet m_weaklyReferenced2;
   VisitedContainer m_visited;
-  bool m_visitWeaklyReferenced = false;
+  bool m_visitWeaklyReferenced = true;
 };
 #endif
 

--- a/tests/classes_test.cpp
+++ b/tests/classes_test.cpp
@@ -75,7 +75,10 @@ static std::vector<vpiHandle> build_designs(Serializer* s) {
   UHDM::class_defn* parent = base;
   UHDM::extends* extends = s->MakeExtends();
   UHDM::class_typespec* tps = s->MakeClass_typespec();
-  extends->Class_typespec(tps);
+  UHDM::ref_typespec* rt = s->MakeRef_typespec();
+  rt->Actual_typespec(tps);
+  rt->VpiParent(extends);
+  extends->Class_typespec(rt);
   tps->Class_defn(parent);
   derived->Extends(extends);
   UHDM::VectorOfclass_defn* all_derived = s->MakeClass_defnVec();

--- a/tests/expr_prettyPrint_test.cpp
+++ b/tests/expr_prettyPrint_test.cpp
@@ -34,8 +34,16 @@ std::vector<vpiHandle> build_designs_MinusOp(Serializer* s) {
     p->VpiName("wire_i");
     p->VpiDirection(vpiInput);
 
+    VectorOftypespec* typespecs = s->MakeTypespecVec();
+    dut->Typespecs(typespecs);
+
     logic_typespec* tps = s->MakeLogic_typespec();
-    p->Typespec(tps);
+    typespecs->emplace_back(tps);
+
+    ref_typespec* tps_rt = s->MakeRef_typespec();
+    tps_rt->Actual_typespec(tps);
+    tps_rt->VpiParent(p);
+    p->Typespec(tps_rt);
 
     VectorOfrange* ranges = s->MakeRangeVec();
     tps->Ranges(ranges);
@@ -108,7 +116,8 @@ TEST(exprVal, prettyPrint_MinusOp) {
   ExprEval eval;
   for (auto m : *d->TopModules()) {
     for (auto p : *m->Ports()) {
-      logic_typespec* typespec = (logic_typespec*)p->Typespec();
+      const ref_typespec* rt = p->Typespec();
+      const logic_typespec* typespec = rt->Actual_typespec<logic_typespec>();
       VectorOfrange* ranges = typespec->Ranges();
       for (auto range : *ranges) {
         expr* left = (expr*)range->Left_expr();


### PR DESCRIPTION
Introducing ref_typespec, parallel to ref_obj for referencing typespecs

scope::Typespecs are cloned from non-elaborated tree to the elaborated tree. However, at the moment, this collection doesn't have all the typespecs in the non-elaborated tree.

This solves a few different problems -

* Avoids too many duplicates in the elaborated tree.
* For functions like $size and $bits, the parameter binding doesn't work because the parameter is a type and not an object. ref_typespec solves that binding problem.
* ref_typespec will hold the type location information in parameter declaration.

Known Issues -

* Need to collect all typespecs in the scope subtree to populate scope::Typespecs
* Though the typespecs are cloned, elaborated tree is still using the ones from the non-elaborated tree. The tree is still complete but typespecs are crossing the boundary between elaborated and non-elaborated. Need to fix this during binding.