### PR TITLE
Add property to track end labels for scopes

### DIFF
--- a/include/sv_vpi_user.h
+++ b/include/sv_vpi_user.h
@@ -90,6 +90,8 @@ extern "C" {
 #define vpiEventTypespec                      698
 #define vpiModuleTypespec                     768 /* !!! NOT Standard !!! */
 #define vpiRefTypespec                        769 /* !!! NOT Standard !!! */
+#define vpiLabel                              770
+#define vpiEndLabel                           771
 
 #define vpiClockingBlock                      650
 #define vpiClockingIODecl                     651

--- a/model/class_defn.yaml
+++ b/model/class_defn.yaml
@@ -51,3 +51,8 @@
     vpi: vpiClassTypespec
     type: class_typespec
     card: any
+  - property: endlabel
+    name: endlabel
+    vpi: vpiEndLabel
+    type: string
+    card: 1

--- a/model/interface_inst.yaml
+++ b/model/interface_inst.yaml
@@ -102,4 +102,9 @@
   - class_ref: gen_stmts
     vpi: vpiGenStmt
     type: gen_stmt
-    card: any  
+    card: any
+  - property: endlabel
+    name: endlabel
+    vpi: vpiEndLabel
+    type: string
+    card: 1

--- a/model/module_inst.yaml
+++ b/model/module_inst.yaml
@@ -147,3 +147,8 @@
     vpi: vpiGenStmt
     type: gen_stmt
     card: any
+  - property: endlabel
+    name: endlabel
+    vpi: vpiEndLabel
+    type: string
+    card: 1

--- a/model/named_begin.yaml
+++ b/model/named_begin.yaml
@@ -21,4 +21,8 @@
     vpi: vpiStmt
     type: stmt
     card: any
-    
+  - property: endlabel
+    name: endlabel
+    vpi: vpiEndLabel
+    type: string
+    card: 1

--- a/model/named_event.yaml
+++ b/model/named_event.yaml
@@ -55,3 +55,8 @@
     vpi: vpiWaitingProcesses
     type: thread_obj
     card: any
+  - property: endlabel
+    name: endlabel
+    vpi: vpiEndLabel
+    type: string
+    card: 1

--- a/model/named_fork.yaml
+++ b/model/named_fork.yaml
@@ -26,3 +26,8 @@
     vpi: vpiStmt
     type: stmt
     card: any
+  - property: endlabel
+    name: endlabel
+    vpi: vpiEndLabel
+    type: string
+    card: 1

--- a/model/package.yaml
+++ b/model/package.yaml
@@ -26,3 +26,8 @@
     vpi: vpiUnit
     type: bool
     card: 1
+  - property: endlabel
+    name: endlabel
+    vpi: vpiEndLabel
+    type: string
+    card: 1

--- a/model/program.yaml
+++ b/model/program.yaml
@@ -75,3 +75,8 @@
     vpi: vpiGenScopeArray
     type: gen_scope_array
     card: any   
+  - property: endlabel
+    name: endlabel
+    vpi: vpiEndLabel
+    type: string
+    card: 1


### PR DESCRIPTION
Add property to track end labels for scopes

P.S. Change in sp_vpi_user.h to include two new properties vpiLabel & vpiEndLabel.