### PR TITLE
Fix compilation with gcc 14; Fix evaluation of `$left`, `$right`, `$high`, `$low`

### DIFF
--- a/templates/ExprEval.cpp
+++ b/templates/ExprEval.cpp
@@ -2568,12 +2568,12 @@ any *ExprEval::hierarchicalSelector(std::vector<std::string> &select_path,
         }
         tmp->Ranges(tmpR);
         return tmp;
-      } 
+      }
     } else if (const array_typespec *ltps =
                    any_cast<const array_typespec *>(object)) {
       if (const ref_typespec *rt = ltps->Elem_typespec()) {
         return (typespec *)rt->Actual_typespec();
-      } 
+      }
     } else if (const packed_array_typespec *ltps =
                    any_cast<const packed_array_typespec *>(object)) {
       if (const ref_typespec *rt = ltps->Elem_typespec()) {
@@ -4049,17 +4049,17 @@ expr *ExprEval::reduceExpr(const any *result, bool &invalidValue,
               int64_t lrv = eval.get_value(invalidValue, lr);
               rr = reduceExpr(rr, invalidValue, inst, pexpr, muteError);
               int64_t rrv = eval.get_value(invalidValue, rr);
-              if (name == "left") {
+              if (name == "$left") {
                 return lr;
-              } else if (name == "right") {
+              } else if (name == "$right") {
                 return rr;
-              } else if (name == "high") {
+              } else if (name == "$high") {
                 if (lrv > rrv) {
                   return lr;
                 } else {
                   return rr;
                 }
-              } else if (name == "low") {
+              } else if (name == "$low") {
                 if (lrv > rrv) {
                   return rr;
                 } else {

--- a/templates/vpi_visitor.cpp
+++ b/templates/vpi_visitor.cpp
@@ -30,6 +30,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 static bool showIDs = false;
 static constexpr int32_t kLevelIndent = 2;


### PR DESCRIPTION
This PR fixes compilation for newer gcc version by adding missing include.

It also fixes evaluation of `$left`, `$right`, `$high`, `$low` by adding missing `$` when comparing function name.