### PR TITLE
Add IWYU pragmas in header meant to export other headers.

### DIFF
--- a/templates/uhdm.h
+++ b/templates/uhdm.h
@@ -25,9 +25,7 @@
 #ifndef UHDM_UHDM_H
 #define UHDM_UHDM_H
 
-#include <string>
-#include <vector>
-#include <set>
+// IWYU pragma: begin_exports
 
 #include <uhdm/sv_vpi_user.h>
 #include <uhdm/vhpi_user.h>
@@ -40,5 +38,7 @@
 <INCLUDE_FILES>
 
 #include <uhdm/Serializer.h>
+
+// IWYU pragma: end_exports
 
 #endif  // UHDM_UHDM_H


### PR DESCRIPTION
clang-tidy usually would complain if not a direct header for a particular symbol is included.

The uhdm.h header is meant as a 'catchall' header that provides all the symbols in all the headers is includes. So mark them as such so that toolings understand that this is the intention.

A common way is to use the IWYU pragmas for that:
https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-begin_exportsend_exports