### PR TITLE
Add missing break in switch.

### DIFF
--- a/templates/NumUtils.cpp
+++ b/templates/NumUtils.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <bitset>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <locale>

--- a/templates/SynthSubset.cpp
+++ b/templates/SynthSubset.cpp
@@ -875,6 +875,7 @@ void collectAssignmentStmt(const any* stmt, std::vector<const assignment*>& bloc
       } else { 
         nonblocking_assigns.push_back(as);
       }
+      break;
     }
     default:
       break;


### PR DESCRIPTION
It accidentally doesn't make any difference, as this is the last case in that switch, but this removes ambiguity about intention.