### PR TITLE
Fix evaluation of $size for array

### DIFF
--- a/templates/ExprEval.cpp
+++ b/templates/ExprEval.cpp
@@ -1272,7 +1272,9 @@ uint64_t ExprEval::size(const any *ts, bool &invalidValue, const any *inst,
     case UHDM_OBJECT_TYPE::uhdmarray_typespec: {
       array_typespec *lts = (array_typespec *)ts;
       ranges = lts->Ranges();
-      if (const ref_typespec *rt = lts->Elem_typespec()) {
+      if (!full) {
+        bits = 1;
+      } else if (const ref_typespec *rt = lts->Elem_typespec()) {
         bits = size(rt->Actual_typespec(), invalidValue, inst, pexpr, full);
       }
       break;


### PR DESCRIPTION
Addresses #1094 

The solution is very ad-hoc. A better solution would be to move `$size` implementation from `ExprEval::size` to where `$high` and `$low` are evaluated, but that section of code is also unused, untested and very likely broken. See https://github.com/chipsalliance/UHDM/issues/1094#issuecomment-2705321758 for more details.