### PR TITLE
Adding UHDM cmp Python script

### DIFF
--- a/python/UHDM.i
+++ b/python/UHDM.i
@@ -1,17 +1,25 @@
 %module uhdm
 /* 
-Everithing in the %{ ... %} block is simply copied verbatim to the resulting wraper file created by swig.
+Everithing in the %{ ... %} block is simply copied verbatim to the resulting wrapper file created by swig.
 It is not parsed or interpreted by swig
 */
 %{
 #include <stdarg.h>
+#include <sstream>
+#include <vector>
+
+#include "uhdm_forward_decl.h"
 #include "vpi_user.h"
 #include "sv_vpi_user.h"
+
+#include "uhdm_types.h"
+#include "RTTI.h"
 #include "Serializer.h"
+#include "VpiListener.h"
+#include "ElaboratorListener.h"
 #include "ExprEval.h"
 #include "vpi_visitor.h"
 #include "swig_test.h"
-
 %}
 %include "std_iostream.i"
 %include "std_sstream.i"
@@ -22,18 +30,42 @@ It is not parsed or interpreted by swig
 %apply bool& OUTPUT { bool &invalidValue};
 
 /* some api function using va_list are exclude using #ifndef SWIG/#endif */
+%include "uhdm_forward_decl.h"
 %include "vpi_user.h"
 %include "sv_vpi_user.h"
 
-%include "Serializer.h"
 %include "uhdm_types.h"
+%include "VpiListener.h"
+%include "ElaboratorListener.h"
 %include "ExprEval.h"
-%include "vpi_visitor.h"
 %include "swig_test.h"
 
 %include "uhdm_vpi_user.h"
 %include "uhdm-version.h"
 
+// PrintStats requires a C++ output stream, here we convert to a Pythonic string
+%ignore UHDM::Serializer::PrintStats;
+%include "Serializer.h"
+%extend UHDM::Serializer {
+  std::string GetStats(const std::string& infoText) {
+    std::ostringstream oss;
+    $self->PrintStats(oss, infoText);
+    return oss.str();
+  }
+}
+
+// visit_designs requires a C++ output stream, here we convert to a Pythonic string
+%ignore UHDM::visit_designs;
+%include "vpi_visitor.h"
+%inline %{
+  std::string visit_designs(const std::vector<vpiHandle>& designs) {
+    std::ostringstream oss;
+    UHDM::visit_designs(designs, oss);
+    return oss.str();
+  }
+%}
+
 namespace std {
   %template(vpiHandleVector) vector<vpiHandle>;
 }
+

--- a/python/UHDM.i
+++ b/python/UHDM.i
@@ -13,13 +13,17 @@ It is not parsed or interpreted by swig
 #include "sv_vpi_user.h"
 
 #include "uhdm_types.h"
+#include "vpi_uhdm.h"
 #include "RTTI.h"
 #include "Serializer.h"
-#include "VpiListener.h"
-#include "ElaboratorListener.h"
 #include "ExprEval.h"
 #include "vpi_visitor.h"
 #include "swig_test.h"
+
+#include "BaseClass.h"
+#include "VpiListener.h"
+#include "ElaboratorListener.h"
+
 %}
 %include "std_iostream.i"
 %include "std_sstream.i"
@@ -35,13 +39,20 @@ It is not parsed or interpreted by swig
 %include "sv_vpi_user.h"
 
 %include "uhdm_types.h"
-%include "VpiListener.h"
-%include "ElaboratorListener.h"
+%include "vpi_uhdm.h"
 %include "ExprEval.h"
 %include "swig_test.h"
 
 %include "uhdm_vpi_user.h"
 %include "uhdm-version.h"
+
+// We ignore RTTI because it's largely incompatible with base SWIG
+%ignore RTTI;
+class UHDM::RTTI {};
+#define UHDM_IMPLEMENT_RTTI(a,b) ;
+#define UHDM_IMPLEMENT_RTTI_2_BASES(a,b,c) ;
+#define UHDM_IMPLEMENT_RTTI_CAST_FUNCTIONS(a,b) ;
+#define UHDM_IMPLEMENT_RTTI_VIRTUAL_CAST_FUNCTIONS(a,b) ;
 
 // PrintStats requires a C++ output stream, here we convert to a Pythonic string
 %ignore UHDM::Serializer::PrintStats;
@@ -63,6 +74,18 @@ It is not parsed or interpreted by swig
     UHDM::visit_designs(designs, oss);
     return oss.str();
   }
+%}
+
+%include "BaseClass.h"
+%include "VpiListener.h"
+%include "ElaboratorListener.h"
+
+// SWIG doesn't seem to expose some methods to the child classes
+%inline %{
+    UHDM::BaseClass* UhdmBaseClassFromVpiHandle(vpiHandle hdesign) {
+        if (!hdesign) return (UHDM::BaseClass*)Py_None;
+        return (UHDM::BaseClass*)((uhdm_handle*)hdesign)->object;
+    }
 %}
 
 namespace std {

--- a/python/tests/test_module.py
+++ b/python/tests/test_module.py
@@ -66,10 +66,9 @@ class  test_module(unittest.TestCase):
         s  = uhdm.Serializer()
 
         data = uhdm.buildTestDesign(s)
-        o = uhdm.ostringstream()
-        uhdm.visit_designs(data,o)
+        o = uhdm.visit_designs(data)
 
-        self.assertEqual(o.str(),ref)
+        self.assertEqual(o,ref)
 
 
 if __name__ == '__main__':

--- a/templates/BaseClass.h
+++ b/templates/BaseClass.h
@@ -42,7 +42,9 @@
 namespace UHDM {
 class BaseClass;
 class Serializer;
+#ifndef SWIG
 static inline constexpr std::string_view kEmpty("");
+#endif
 
 #ifdef STANDARD_VPI
 typedef std::set<vpiHandle> VisitedContainer;
@@ -296,7 +298,6 @@ class FactoryT final {
 
 typedef FactoryT<std::vector<BaseClass*>> VectorOfBaseClassFactory;
 typedef FactoryT<std::vector<BaseClass*>> VectorOfanyFactory;
-
 }  // namespace UHDM
 
 UHDM_IMPLEMENT_RTTI_CAST_FUNCTIONS(clonecontext_cast, UHDM::CloneContext)

--- a/templates/ElaboratorListener.h
+++ b/templates/ElaboratorListener.h
@@ -171,9 +171,7 @@ class ElaboratorListener final : public VpiListener {
 };
 
 class ElaboratorContext final : public CloneContext {
-#ifndef SWIG
   UHDM_IMPLEMENT_RTTI(ElaboratorContext, CloneContext)
-#endif
 
  public:
   explicit ElaboratorContext(Serializer* serializer, bool debug = false,

--- a/templates/ElaboratorListener.h
+++ b/templates/ElaboratorListener.h
@@ -171,7 +171,9 @@ class ElaboratorListener final : public VpiListener {
 };
 
 class ElaboratorContext final : public CloneContext {
+#ifndef SWIG
   UHDM_IMPLEMENT_RTTI(ElaboratorContext, CloneContext)
+#endif
 
  public:
   explicit ElaboratorContext(Serializer* serializer, bool debug = false,

--- a/templates/vpi_visitor.h
+++ b/templates/vpi_visitor.h
@@ -49,11 +49,11 @@ void visit_designs(const std::vector<vpiHandle>& designs, VpiVisitor* visitor);
 #endif
 void visit_designs(const std::vector<vpiHandle>& designs, std::ostream& out);
 
-#ifndef SWIG
 // For debug use in GDB
 std::string decompile(const UHDM::any* handle);
 std::string decompileVPI(vpiHandle handle);
 
+#ifndef SWIG
 class VpiVisitor final {
  private:
   std::ostream& stream_indent(int32_t indent) const;

--- a/util/uhdm-cmp.py
+++ b/util/uhdm-cmp.py
@@ -1,0 +1,71 @@
+from uhdm import uhdm
+from uhdm import util
+
+import argparse
+import os
+import sys
+
+
+def main(uhdm_filea, uhdm_fileb):
+    if not os.path.isfile(uhdm_filea):
+        print(f"{uhdm_filea}: File does not exist!", file=sys.stderr)
+        return 1
+    sa = uhdm.Serializer()
+    ha = sa.Restore(uhdm_filea)
+    if not ha:
+        print(f"{uhdm_filea}: Failed to load.")
+        return 1
+
+    if not os.path.isfile(uhdm_fileb):
+        print(f"{uhdm_fileb}: File does not exist!", file=sys.stderr)
+        return 1
+    sb = uhdm.Serializer()
+    hb = sb.Restore(uhdm_fileb)
+    if not hb:
+        print(f"{uhdm_fileb}: Failed to load.")
+        return 1
+
+    if len(ha) != len(hb):
+        print(f"Number of designs mismatch.")
+        return 1
+
+    for i in range(len(hb)):
+        context = uhdm.CompareContext()
+        ca = uhdm.UhdmBaseClassFromVpiHandle(ha[i])
+        cb = uhdm.UhdmBaseClassFromVpiHandle(hb[i])
+        if ca.Compare(cb, context):
+            if context.m_failedLhs:
+                print(f"LHS: {uhdm.decompile(context.m_failedLhs)}")
+            else:
+                print(f"LHS: <null>")
+            if context.m_failedRhs:
+                print(f"RHS: {uhdm.decompile(context.m_failedRhs)}")
+            else:
+                print(f"RHS: <null>")
+            return -1
+        return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=(
+            "Reads input UHDM binary representations of two files and "
+            "compares them topographically. "
+            f"(Version: {uhdm.UHDM_VERSION_MAJOR}.{uhdm.UHDM_VERSION_MINOR})\n\n"
+            "Exits with code:\n"
+            "  = 0, if input files are equal\n"
+            "  < 0, if input files are not equal\n"
+            "  > 0, for any failures"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("uhdm_filea", help="Path to the first UHDM file")
+    parser.add_argument("uhdm_fileb", help="Path to the second UHDM file")
+
+    args = parser.parse_args()
+    uhdm_filea = args.uhdm_filea
+    uhdm_fileb = args.uhdm_fileb
+
+    rc = main(uhdm_filea, uhdm_fileb)
+    sys.exit(rc)
+

--- a/util/uhdm-dump.cpp
+++ b/util/uhdm-dump.cpp
@@ -138,10 +138,6 @@ int32_t main(int32_t argc, char **argv) {
 
   if (dumpstats) {
     serializer.PrintStats(std::cout, uhdmFile);
-
-    if (!goldenFile.empty()) {
-      serializer.PrintStats(std::cout, goldenFile);
-    }
   }
 
   std::cout << uhdmFile << ": Restored design Pre-Elab: " << std::endl;

--- a/util/uhdm-dump.py
+++ b/util/uhdm-dump.py
@@ -1,0 +1,77 @@
+from uhdm import uhdm
+from uhdm import util
+
+import argparse
+import os
+import sys
+
+
+def main(uhdm_file, golden_file, stats, verbose):
+    if uhdm_file and not os.path.isfile(uhdm_file):
+        print(f"{uhdm_file}: File does not exist!", file=sys.stderr)
+        return 1
+
+    if golden_file and not os.path.isfile(golden_file):
+        print(f"{golden_file}: File does not exist!", file=sys.stderr)
+        return 1
+
+    s = uhdm.Serializer()
+    restoredDesigns = s.Restore(uhdm_file)
+
+    if not restoredDesigns:
+        print(f"{uhdm_file}: empty design!", file=sys.stderr)
+        return 1
+
+    if stats:
+        if uhdm_file:
+            print(f"{s.GetStats(uhdm_file)}")
+        if golden_file:
+            print(f"{s.GetStats(golden_file)}")
+
+    print(f"{uhdm_file}: Restored design Pre-Elab: \n{uhdm.visit_designs(restoredDesigns)}")
+
+    if golden_file:
+        content = uhdm.visit_designs(restoredDesigns)
+        with open(golden_file, "r") as golden_text:
+            expected = golden_text.read()
+
+        if expected != content:
+            print(f"Dump does not match content of '{golden_file}", file=sys.stderr)
+            return 2
+        elif verbose:
+            print(f"Dump matches '{golden_file}")
+
+    if elab:
+        elaboratorContext = uhdm.ElaboratorContext(s, False)
+        elaboratorContext.m_elaborator.listenDesigns(restoredDesigns)
+
+        print(f"{uhdm_file}: Restored design Post-Elab: \n{uhdm.visit_designs(restoredDesigns)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Reads UHDM binary representation and prints hierarchy tree.",
+    )
+    parser.add_argument("uhdm_file", help="Path to the UHDM file")
+    parser.add_argument("golden_file", nargs="?", help="Path to the UHDM file")
+    parser.add_argument("--elab", action="store_true", help="Print line info")
+    parser.add_argument("--stats", action="store_true", help="Print line info")
+    parser.add_argument("--verbose", action="store_true", help="Print line info")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"{uhdm.UHDM_VERSION_MAJOR}.{uhdm.UHDM_VERSION_MINOR}",
+    )
+
+    args = parser.parse_args()
+    uhdm_file = args.uhdm_file
+    golden_file = args.golden_file
+    elab = args.elab
+    stats = args.stats
+    verbose = args.verbose
+
+    rc = main(uhdm_file, golden_file, stats, verbose)
+    sys.exit(rc)
+

--- a/util/uhdm-hier.py
+++ b/util/uhdm-hier.py
@@ -13,7 +13,7 @@ def main(uhdm_file, line):
 
     if not data:
         print(f"{uhdm_file}: empty design!", file=sys.stderr)
-        sys.exit(1)
+        return 1
 
     result = ""
     for design in data:
@@ -54,6 +54,7 @@ def main(uhdm_file, line):
                 return res
 
             result += inst_visit(obj_h, "")
+    return 0
 
 
 if __name__ == "__main__":
@@ -76,5 +77,6 @@ if __name__ == "__main__":
         print(f"{uhdm_file}: File does not exist!", file=sys.stderr)
         sys.exit(1)
 
-    main(uhdm_file, line)
+    rc = main(uhdm_file, line)
+    sys.exit(rc)
 


### PR DESCRIPTION
This produces line-identical output with uhdm-cmp for the few test designs that I have.

This involved exposing CompareContext and BaseClass from the C++, but other than some SWIG strangeness there's nothing too wacky

depends on #1106 