### PR TITLE
clone_tree: resolve interface-port params via Param_assigns() in hier…

### DIFF
--- a/templates/clone_tree.cpp
+++ b/templates/clone_tree.cpp
@@ -1559,6 +1559,26 @@ hier_path* hier_path::DeepClone(BaseClass* parent,
                     }
                   }
                 }
+                // An interface reached only through a modport PORT exposes its
+                // resolved parameters/localparams on Param_assigns() (elaborated
+                // by NetlistElaboration::elab_interface_), not on Parameters().
+                // Bind `<port>.CFG` / `<port>.CFG_BUS_OFF` to the param on the
+                // Lhs so a terminal read gets its value and a nested struct-param
+                // chain (`sub.CFG.HSK.DLY`) continues into the uhdmparameter case
+                // below (rp32 SoC TCB lib: logsize2byteena / register_* / demux).
+                if (!found && interf->Param_assigns()) {
+                  for (param_assign* pa : *interf->Param_assigns()) {
+                    const any* lhs = pa->Lhs();
+                    if (lhs && lhs->VpiName() == name) {
+                      if (ref_obj* cro = any_cast<ref_obj*>(current)) {
+                        cro->Actual_group((any*)lhs);
+                      }
+                      previous = (any*)lhs;
+                      found = true;
+                      break;
+                    }
+                  }
+                }
                 if (!found && interf->Task_funcs()) {
                   for (auto tf : *interf->Task_funcs()) {
                     if (tf->VpiName() == name) {


### PR DESCRIPTION
…_path

hier_path::DeepClone resolved an interface-port member reference (`sub.CFG`, `sub.CFG_BUS_OFF`, `sub.CFG.HSK.DLY` where `sub` is a modport port) by searching only the interface_inst's Parameters() list.  An interface reached ONLY through a modport port has its resolved parameters/localparams elaborated onto Param_assigns() (by Surelog's NetlistElaboration::elab_interface_), not Parameters(), so the base element `CFG`/`CFG_BUS_OFF` was never found — the whole chain then reported UHDM_UNRESOLVED_HIER_PATH (and every trailing `.HSK`, `.DLY`, `.BUS`, `.DAT` element cascaded the same error).

Search Param_assigns() as well: bind the member to the parameter on the Lhs so a terminal read gets its value and a nested struct-parameter chain continues into the existing uhdmparameter typespec-navigation case.

Fixes ~50 UHDM_UNRESOLVED_HIER_PATH errors each on the rp32 mouse_soc / degu_soc SoCs (TCB lib: logsize2byteena, register_request/response, demultiplexer, lite_dev gpio/uart) with no netlist change.