### PR TITLE
ExprEval::evalFunc: mute the scope-setup param_assign clone

### DIFF
--- a/templates/ExprEval.cpp
+++ b/templates/ExprEval.cpp
@@ -5845,7 +5845,16 @@ expr *ExprEval::evalFunc(function *func, std::vector<any *> *args,
   if (param_assigns) {
     modinst->Param_assigns(s.MakeParam_assignVec());
     for (auto p : *param_assigns) {
-      ElaboratorContext elaboratorContext(&s, false, muteError);
+      // Scope setup only: this clone exists to populate the name->typespec
+      // map below (from p->Lhs()); the cloned Rhs is never read here.  Cloning
+      // a struct-typed param whose Rhs is a const-function call (e.g.
+      // `CVA6Cfg = build_config(cva6_cfg)`) can re-enter the function's result
+      // typespec whose members carry not-yet-evaluated struct-arg field refs
+      // (`CVA6Cfg.NrNonIdempotentRules`), which are unreachable in this
+      // detached clone.  Those are internal artifacts, not user errors, so
+      // always mute this scope-setup clone (real param errors are reported by
+      // the actual parameter elaboration).
+      ElaboratorContext elaboratorContext(&s, false, /*muteErrors=*/true);
       any *pp = clone_tree(p, &elaboratorContext);
       modinst->Param_assigns()->push_back((param_assign *)pp);
       const typespec *tps = nullptr;


### PR DESCRIPTION
evalFunc clones the enclosing instance's param_assigns only to build the local name->typespec map (from each param's Lhs); the cloned Rhs is never read.  When a struct-typed parameter's value is a constant-function call (e.g. CVA6 `CVA6Cfg = build_config_pkg::build_config(cva6_config_pkg::cva6_cfg)`), this clone re-enters the function-result struct typespec whose member value is a not-yet-evaluated expression over the function's struct ARGUMENT (`(CVA6Cfg.NrNonIdempotentRules > 0) && (CVA6Cfg.NonIdempotentLength > 0)`, build_config_pkg.sv:138).  Those argument-field hier_paths are unreachable in the detached clone and were reported as UHDM_UNRESOLVED_HIER_PATH (UH0725), even though the value is never consumed by the scope-setup and the referencing reduce (e.g. the `INTERRUPTS` localparam's `CVA6Cfg.XLEN`) succeeds.

Since this clone's Rhs is never read, mute its errors unconditionally; genuine parameter errors are still reported by the actual parameter elaboration, and statement-body evaluation errors inside evalFunc still honor the caller's muteError.

CVA6 (cv64a6_imafdc_sv39): UH0725 2 -> 0.