### PR TITLE
ExprEval: keep unsized fill literals intact in the ternary fold

### DIFF
--- a/templates/ExprEval.cpp
+++ b/templates/ExprEval.cpp
@@ -3776,7 +3776,18 @@ expr *ExprEval::reduceExpr(const any *result, bool &invalidValue,
                 the_val = reduceExpr(operands[2], localInvalidValue, inst,
                                      pexpr, muteError);
               }
-              if (localInvalidValue == false) {
+              // An UNBASED UNSIZED fill literal (`'1`, `'0`, `'x`, `'z` —
+              // VpiSize() == -1) must keep its fill identity: collapsing it
+              // through get_value() yields INT:1, so a context-determined
+              // `wide = cond ? … : '1` came out as the VALUE 1 instead of
+              // all-ones (CVA6 cva6_ptw `req_port_o.data_be = CVA6Cfg.
+              // IS_XLEN32 ? be_gen_32(…) : '1` → 8'h01 instead of 8'hff).
+              // Hand the literal back unchanged and let the consumer
+              // replicate it to the target width.
+              bool the_val_is_fill = false;
+              if (the_val && the_val->UhdmType() == uhdmconstant)
+                the_val_is_fill = (((constant *)the_val)->VpiSize() == -1);
+              if (localInvalidValue == false && !the_val_is_fill) {
                 val = get_value(localInvalidValue, the_val);
                 if (localInvalidValue == false) {
                   constant *c = s.MakeConstant();


### PR DESCRIPTION
## Problem

`ExprEval::reduceExpr`'s `vpiConditionOp` case collapses the selected branch
through `get_value()` and rebuilds it as a fresh `INT:<value>` constant. For an
**unbased unsized fill literal** (`'1`, `'0`, `'x`, `'z` — `VpiSize() == -1`)
that destroys the fill identity: `'1` becomes the integer `1`.

A context-determined `wide = cond ? f(x) : '1` has to fill every bit of the
target, so consumers replicate a `VpiSize() == -1` constant to the context
width. Once `reduceExpr` has rewritten it to `INT:1`, that information is gone
and the assignment yields `1` instead of all-ones.

Found in CVA6's `cva6_ptw`:

```systemverilog
assign req_port_o.data_be = CVA6Cfg.IS_XLEN32 ? be_gen_32(
    req_port_o.address_index[1:0], req_port_o.data_size
) : '1;
```

With `IS_XLEN32 = 0` the (constant) condition selects the fill branch, and
`data_be` came out `8'h01` instead of `8'hff`.

## Fix

If the selected branch is a fill constant, hand it back unchanged and let the
consumer size it. Non-fill branches keep the existing `INT:` collapse.

## Verification

- Downstream consumer (a Yosys SystemVerilog frontend) now produces `8'hff`;
  the behaviour was cross-checked against `iverilog` on the equivalent RTL.
- Surelog regression (`scripts/regression.py run`): **0 FAIL, 0 SEGFLT,
  0 TOOLFAIL**.
- Five large tests (`AzadiRTL`, `Rggen`, `Earlgrey_0_1`,
  `Earlgrey_Verilator_0_1`, `Earlgrey_Verilator_01_05_21`) report a **golden-log
  diff that is statistics-only** — the UHDM object-count table's `constant`
  entry moves by 2–4, because the fill constant is now reused instead of a new
  `INT` constant being allocated:

  ```
  4515c4515
  < constant                                          141757
  ---
  > constant                                          141755
  ```

  No message, error, or semantic differences. Those goldens live in the Surelog
  repo and want a `scripts/regression.py update` refresh when Surelog next bumps
  its UHDM pointer.

Isolated by bisection: with this change reverted the same five tests pass, and
with only the companion Surelog change applied they also pass, so the stat shift
is attributable solely to this commit.