### PR TITLE
ExprEval: walk the remaining path elements for a nested struct member

### DIFF
--- a/templates/ExprEval.cpp
+++ b/templates/ExprEval.cpp
@@ -2348,7 +2348,18 @@ any *ExprEval::hierarchicalSelector(std::vector<std::string> &select_path,
               } else if (returnType == ReturnType::MEMBER) {
                 return member;
               } else {
-                return member->Actual_value() ? member->Actual_value() : member->Default_value();
+                any *res = member->Actual_value() ? member->Actual_value()
+                                                  : member->Default_value();
+                // A member that is itself a struct must keep walking the
+                // remaining path elements (`CFG.u.sidWidth`): returning the
+                // intermediate member's value here drops the trailing
+                // selectors, and the caller then substitutes a whole-struct
+                // value where a scalar field was expected.  The
+                // struct_typespec branch below already does this.
+                if (lastElem || res == nullptr) return res;
+                return hierarchicalSelector(select_path, level + 1, res,
+                                            invalidValue, inst, pexpr,
+                                            returnType, muteError);
               }
             }
           }
@@ -2446,7 +2457,13 @@ any *ExprEval::hierarchicalSelector(std::vector<std::string> &select_path,
                     }
                   }
                 } else {
-                  return member->Actual_value() ? member->Actual_value() : member->Default_value();
+                  any *res = member->Actual_value() ? member->Actual_value()
+                                                    : member->Default_value();
+                  // Same nested-member walk as the struct_var branch above.
+                  if (lastElem || res == nullptr) return res;
+                  return hierarchicalSelector(select_path, level + 1, res,
+                                              invalidValue, inst, pexpr,
+                                              returnType, muteError);
                 }
               }
             }
@@ -2555,7 +2572,13 @@ any *ExprEval::hierarchicalSelector(std::vector<std::string> &select_path,
                   }
                 }
               } else {
-                return member->Actual_value() ? member->Actual_value() : member->Default_value();
+                any *res = member->Actual_value() ? member->Actual_value()
+                                                  : member->Default_value();
+                // Same nested-member walk as the struct_var branch above.
+                if (lastElem || res == nullptr) return res;
+                return hierarchicalSelector(select_path, level + 1, res,
+                                            invalidValue, inst, pexpr,
+                                            returnType, muteError);
               }
             }
           }


### PR DESCRIPTION
`hierarchicalSelector`'s `struct_var`, `io_decl` and `struct_net` branches returned the matched member's value **unconditionally** on a `ReturnType::VALUE` walk — ignoring `lastElem` and never recursing. A hierarchical read of a *nested* field therefore stopped at the first member and yielded the whole intermediate struct.

```systemverilog
typedef struct packed { int unsigned sidWidth; int unsigned dataWidth; } user_cfg_t;
typedef struct packed { user_cfg_t u; int unsigned derived; } cfg_t;

localparam cfg_t CFG = build(mku());

typedef logic [CFG.u.sidWidth-1:0] sid_t;   // two levels -> broken
typedef logic [CFG.derived-1:0]    data_t;  // one level  -> fine
```

`CFG.u.sidWidth` stopped at `u`, so the elaborated model ended up with an
`operation(vpiSubOp)` whose first operand is a `struct_var` — a whole
`user_cfg_t` substituted where the scalar `sidWidth` belonged.  Consumers
cannot evaluate that, so the range came out as `[-1:0]` and the port collapsed
to zero width.  One-level paths were unaffected because their only member is
already the last element — exactly the observed split above.

The `struct_typespec` branch in the same function already had the correct
`if (lastElem) return res; else recurse` shape; this gives the other three
branches the same walk.  **Single-level paths are unchanged by construction**
(`lastElem` is true, so the same value is returned as before).

Found via a per-module SystemVerilog frontend equivalence sweep over CVA6,
where it zero-widthed every port whose size comes from a nested field of the
hpdcache configuration struct.