### PR TITLE
Bump version to 1.87

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # -*- mode:cmake -*-
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
-project(UHDM VERSION 1.86)
+project(UHDM VERSION 1.87)
 
 # Detect build type, fallback to release and throw a warning if use didn't
 # specify any


### PR DESCRIPTION
Cuts the **v1.87** release.

`Version Tagging` tags the commit where `project(UHDM VERSION ...)` changes, so merging this automatically creates the `v1.87` tag.

Surelog and UHDM version numbers move in tandem — `Surelog.pc.in` pins `Requires: UHDM >= @PROJECT_VERSION@` — so Surelog goes to 1.87 alongside this, with its submodule pointer updated to the commit this tags.

### What's in 1.87 (24 commits since v1.86)

**Constant/struct evaluation in `ExprEval`**
- Assemble `struct_var` constants and member-select into packed constants
- Widen the struct_var assembler to enum, wide, cast and pattern members
- Walk the remaining path elements for a nested struct member
- Resolve struct-parameter typespecs via a dedicated functor (`setGetTypespecFunctor`)
- Keep unsized fill literals intact in the ternary fold
- Mute the scope-setup `param_assign` clone in `evalFunc`

**Hierarchical path and interface binding**
- `clone_tree`: resolve interface-port params via `Param_assigns()` in `hier_path`
- Interface member binding and generate-scope binding fixes
- No longer segfaults on a localparam initialiser

**Sizing and signedness**
- Preserve operand signedness in size cast `N'(expr)`
- Packed-array size, cast, and function-return size fixes
- `const_func` shadowing fixes

**Build**
- Python packaging: PIC when `UHDM_WITH_PYTHON` is on (fixes a shared-library relocation error against static Cap'n Proto), editable install from the build dir, separate `PyPackageDist` target, and the Python package version derived from CMake `PROJECT_VERSION`

🤖 Generated with [Claude Code](https://claude.com/claude-code)