### PR TITLE
ExprEval: element-select on multi-range packed arrays

### DIFF
--- a/templates/ExprEval.cpp
+++ b/templates/ExprEval.cpp
@@ -2544,6 +2544,21 @@ static constant *reducePackedElemSelect(constant *c, int64_t selectIndex,
       if (lt->Elem_typespec()) {
         ets = lt->Elem_typespec()->Actual_typespec();
         rgs = lt->Ranges();
+      } else if (lt->Ranges() && lt->Ranges()->size() >= 2) {
+        // MULTI-RANGE packed array (`logic [0:4][31:0]` — fpnew_pkg's
+        // fmt_unsigned_t): no Elem_typespec exists; the element type is the
+        // same logic type minus the outermost range.  Without this branch the
+        // select fell through to reduceBitSelect and `FmtPipeRegs[fmt]`
+        // returned BIT fmt of the 160-bit value — fpnew slices got
+        // NumPipeRegs 1,0,0,0,0 from a '{default:1} array, lost their
+        // pipeline registers at elaboration, and CVA6's fpu_wrap/ex_stage
+        // early_valid never asserted.
+        rgs = lt->Ranges();
+        ElaboratorContext elemCtx(&s, false, muteError);
+        logic_typespec *elt = (logic_typespec *)clone_tree(lt, &elemCtx);
+        if (elt->Ranges() && !elt->Ranges()->empty())
+          elt->Ranges()->erase(elt->Ranges()->begin());
+        ets = elt;
       }
     }
   }


### PR DESCRIPTION
`reducePackedElemSelect` resolves the element typespec for `packed_array_typespec` and for `logic_typespec` carrying an `Elem_typespec` — but a **multi-range** `logic_typespec` (`logic [0:4][31:0]`, e.g. fpnew_pkg's `fmt_unsigned_t`) has neither, so the element-select fell through to `reduceBitSelect` and returned a single **bit** of the packed value instead of a 32-bit **element**.

Consequence in Surelog elaboration: `parameter int unsigned NumPipeRegs = FmtPipeRegs[fmt]` on a `'{default: 1}`-filled `[0:4][31:0]` array stamped `1,0,0,0,0` instead of `1,1,1,1,1`, selecting the wrong generate arm (`early_out_valid_o = 1'b0`) in fpnew slices. Downstream, CVA6's `fpu_wrap`/`ex_stage` never asserted `early_valid` (26 and 32 co-sim divergences vs RTL over 300 cycles).

Fix: for a multi-range packed logic typespec, the element type is the same logic type minus the outermost range — clone the typespec and erase `Ranges()[0]`, keeping the existing range-based index arithmetic.

Validation:
- Minimal repro (20-instance generate reading distinct `[0:4][31:0]` parameter elements through a struct + typedef chain): 19/20 leaf parameter values wrong before (each equal to bit *f* of the full 160-bit value), 20/20 correct after.
- CVA6 per-module Verilator co-sim: `fpu_wrap` 26→0, `ex_stage` 32→0 mismatches vs RTL (slang frontend 0 on both) — the last two open UHDM-frontend divergences in the campaign.
- Surelog regression: 786 PASS, 5 large designs (Ariane2024, AzadiRTL, Earlgrey_0_1, Earlgrey_Verilator_0_1, IncompTitan) show only intended UHDM object-count stat changes (more constants/typespecs from newly-folding element-selects); golden updates will accompany the Surelog-side submodule bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)